### PR TITLE
Fix prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "eject": "react-scripts eject",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --fix --ext .js,.jsx,.ts,.tsx",
-    "format": "prettier --write src/**/*.ts src/**/*.tsx",
-    "format:check": "prettier --check src/**/*.ts src/**/*.tsx"
+    "format": "prettier --write 'src/**/*.ts' 'src/**/*.tsx'",
+    "format:check": "prettier --check 'src/**/*.ts' 'src/**/*.tsx'"
   },
   "eslintConfig": {
     "extends": [

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,8 +1,8 @@
-import { ReportHandler } from 'web-vitals';
+import { ReportHandler } from "web-vitals";
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+    import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
       getCLS(onPerfEntry);
       getFID(onPerfEntry);
       getFCP(onPerfEntry);

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";


### PR DESCRIPTION
On my machine, `npm run format` wasn't targeting nested subdirectories, and adding single quotes around the file pattern globs in `package.json` following the suggestion from https://prettier.io/docs/en/cli.html fixed it.