### PR TITLE
add row() built-in for accessing tricky attribute names

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -19,6 +19,7 @@ import {
 import { Value } from "./language/ast";
 import { Env } from "./language/interpret";
 import { evaluate } from "./language";
+import { table } from "console";
 
 /**
  * Transformation represents an instance of the plugin, which applies a
@@ -89,8 +90,16 @@ function Transformation() {
       Object.entries(dataItem).map(([key, tableValue]) => {
         let value;
         // parse value from CODAP table data
-        if (tableValue === "true" || tableValue === "false") {
-          value = { kind: "Bool", content: tableValue === "true" };
+        if (
+          tableValue === "true" ||
+          tableValue === "false" ||
+          tableValue === true ||
+          tableValue === false
+        ) {
+          value = {
+            kind: "Bool",
+            content: tableValue === "true" || tableValue === true,
+          };
         } else if (!isNaN(Number(tableValue))) {
           value = { kind: "Num", content: Number(tableValue) };
         } else {

--- a/src/language/__tests__/interpret.test.ts
+++ b/src/language/__tests__/interpret.test.ts
@@ -115,3 +115,19 @@ test("interprets logic correctly", () => {
   };
   expect(interpret(ast)).toStrictEqual({ kind: "Bool", content: false });
 })
+
+test("uses row built-in to access non-identifier attribute names in env", () => {
+  const ast: Ast = {
+    kind: "Builtin",
+    name: "row",
+    args: [
+      { kind: "String", content: "Attribute name with spaces" }
+    ]
+  };
+
+  const env: Env = {
+    "Attribute name with spaces": { kind: "Num", content: 17 }
+  };
+
+  expect(interpret(ast, env)).toStrictEqual({ kind: "Num", content: 17 });
+});

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -1,4 +1,5 @@
 export type Ast =
+  | { kind: "Builtin"; name: Builtin; args: Ast[] }
   | { kind: "Binop"; op: Operator; op1: Ast; op2: Ast }
   | { kind: "Unop"; op: UnaryOperator; op1: Ast }
   | { kind: "Identifier"; content: string }
@@ -18,6 +19,8 @@ export type Operator =
   | "||";
 
 export type UnaryOperator = "not";
+
+export type Builtin = "row";
 
 export type Value =
   | { kind: "Num"; content: number }

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -1,7 +1,14 @@
 import { interpret, Env } from "./interpret";
+import { Value } from "./ast";
 import { lex } from "./lex";
 import { parse } from "./parse";
 
-export function evaluate(source: string, env?: Env) {
+/**
+ * Lex, parse, and interpret a source expression in a given environment.
+ * @param source text of expression to evaluate
+ * @param env environment in which to evaluate
+ * @returns value the expression evaluated to, or throws an error
+ */
+export function evaluate(source: string, env?: Env): Value {
   return interpret(parse(lex(source)), env);
 }

--- a/src/language/interpret.ts
+++ b/src/language/interpret.ts
@@ -1,4 +1,4 @@
-import { Ast, Operator, UnaryOperator, Value } from "./ast";
+import { Ast, Operator, UnaryOperator, Builtin, Value } from "./ast";
 
 /**
  * An environment is a map from strings to Values
@@ -26,6 +26,8 @@ export function interpret(expr: Ast, env?: Env): Value {
 
 function interpretExpr(expr: Ast, env: Env): Value {
   switch (expr.kind) {
+    case "Builtin":
+      return interpretBuiltin(expr.name, expr.args, env);
     case "Binop":
       return interpretBinop(expr.op, expr.op1, expr.op2, env);
     case "Unop":
@@ -96,5 +98,25 @@ function interpretUnop(op: UnaryOperator, op1: Ast, env: Env): Value {
         throw new Error("Tried logical not on non-boolean expression");
       }
       return { kind: "Bool", content: !operand.content };
+  }
+}
+
+function interpretBuiltin(name: Builtin, args: Ast[], env: Env): Value {
+  switch (name) {
+    case "row": {
+      if (args.length != 1) {
+        throw new Error("row() expects exactly 1 argument (a column name)");
+      }
+      const attr = args[0];
+      if (attr.kind !== "String") {
+        throw new Error(`Expected a column name given to row()`);
+      }
+      if (!env[attr.content]) {
+        throw new Error(`Unknown column name "${attr.content}" given to row()`);
+      }
+
+      // lookup column name in environment
+      return env[attr.content];
+    }
   }
 }

--- a/src/language/lex.ts
+++ b/src/language/lex.ts
@@ -4,6 +4,7 @@ export type Token =
   | { kind: "STRING"; content: string }
   | { kind: "LPAREN" }
   | { kind: "RPAREN" }
+  | { kind: "COMMA" }
   | { kind: "EQUAL" }
   | { kind: "NOT_EQUAL" }
   | { kind: "GREATER" }
@@ -24,6 +25,7 @@ const regexTable: Array<[RegExp, null | ((s: string) => Token)]> = [
   [/^-?[0-9]+/, (s) => ({ kind: "NUMBER", content: parseInt(s) })],
   [/^\(/, () => ({ kind: "LPAREN" })],
   [/^\)/, () => ({ kind: "RPAREN" })],
+  [/^,/, () => ({ kind: "COMMA" })],
   [/^=/, () => ({ kind: "EQUAL" })],
   [/^!=/, () => ({ kind: "NOT_EQUAL" })],
   [/^>=/, () => ({ kind: "GREATER_EQUAL" })],

--- a/src/language/parse.ts
+++ b/src/language/parse.ts
@@ -9,6 +9,7 @@ import {
   OperatorParselet,
   InfixParselet,
   ParenthesisParselet,
+  BuiltinParselet,
 } from "./parselets";
 
 /**
@@ -34,6 +35,14 @@ export function getBindingPower(op: Token): number {
 }
 
 /**
+ * Determine if a given name is the name of a built-in.
+ */
+function isBuiltin(name: string): boolean {
+  // ... add built-in names here as we extend
+  return ["row"].includes(name);
+}
+
+/**
  * Map tokens to prefix parselets
  */
 function prefixParseletMap(tok: Token): PrefixParselet | null {
@@ -42,7 +51,11 @@ function prefixParseletMap(tok: Token): PrefixParselet | null {
   } else if (tok.kind === "STRING") {
     return new StringParselet();
   } else if (tok.kind === "IDENTIFIER") {
-    return new IdentifierParselet();
+    if (isBuiltin(tok.content)) {
+      return new BuiltinParselet();
+    } else {
+      return new IdentifierParselet();
+    }
   } else if (tok.kind === "LPAREN") {
     return new ParenthesisParselet();
   } else if (tok.kind === "L_NOT") {


### PR DESCRIPTION
This adds some support for built-in functions, in particular, a `row()` function which takes a string name of an attribute. This allows us to access attributes that have spaces/other characters not valid in our language's identifier names.

For example: 
```
row("Long attribute name") > 100
```
as opposed to 
```
Long attribute name > 100
```
which will fail to parse.