### PR TITLE
Fill out IframePhone types and add return type annotations to API

### DIFF
--- a/src/Error.tsx
+++ b/src/Error.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactElement } from "react";
 import "./Error.css";
 
 type ErrorProps = {
@@ -9,7 +9,7 @@ type ErrorProps = {
  * Error represents an error message to be shown to the user
  * within the plugin.
  */
-function Error(props: ErrorProps) {
+function Error(props: ErrorProps): ReactElement {
   // render only if the error message is non-null
   return props.message === null ? (
     <></>

--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -1,5 +1,5 @@
 /* eslint use-isnan: 0 */
-import React from "react";
+import React, { ReactElement } from "react";
 import { useState, useEffect, useCallback } from "react";
 import "./Transformation.css";
 import Error from "./Error";
@@ -22,7 +22,7 @@ function useDataContexts() {
   const [dataContexts, setDataContexts] = useState<string[]>([]);
 
   async function refreshTables() {
-    setDataContexts(await getAllDataContexts());
+    setDataContexts(await (await getAllDataContexts()).map((x) => x.name));
   }
 
   // Initial refresh to set up connection, then start listening
@@ -39,7 +39,7 @@ function useDataContexts() {
  * Transformation represents an instance of the plugin, which applies a
  * user-defined transformation to input data from CODAP to yield output data.
  */
-function Transformation() {
+function Transformation(): ReactElement {
   /**
    * The broad categories of transformations that can be applied
    * to tables.

--- a/src/language/parselets.ts
+++ b/src/language/parselets.ts
@@ -96,7 +96,7 @@ export class IdentifierParselet implements PrefixParselet {
 export class ParenthesisParselet implements PrefixParselet {
   parse(tokens: Token[], current_token: Token): Ast {
     const expr = parseExpr(tokens, 0);
-    const next = expect_consume(
+    expect_consume(
       tokens,
       "RPAREN",
       "Expected right paren to close expression"
@@ -142,7 +142,7 @@ export class BuiltinParselet implements PrefixParselet {
       throw new Error("Tried to use BuiltinParselet on non-identifier");
     }
     const name = current_token.content as Builtin;
-    const lparen = expect_consume(
+    expect_consume(
       tokens,
       "LPAREN",
       `Expected parenthesis after built-in "${name}"`
@@ -172,7 +172,7 @@ export class BuiltinParselet implements PrefixParselet {
       }
       tokens.pop(); // consume the comma
     }
-    const rparen = expect_consume(
+    expect_consume(
       tokens,
       "RPAREN",
       `Expected closing parenthesis after arguments to built-in "${name}"`

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,6 +1,6 @@
 import { ReportHandler } from "web-vitals";
 
-const reportWebVitals = (onPerfEntry?: ReportHandler) => {
+const reportWebVitals = (onPerfEntry?: ReportHandler): void => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
       getCLS(onPerfEntry);

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -1,6 +1,6 @@
 import { IframePhoneRpcEndpoint } from "iframe-phone";
 import {
-  CodapComponent,
+  CodapComponentType,
   CodapResource,
   CodapActions,
   CodapRequest,
@@ -12,7 +12,7 @@ import {
   ContextChangeOperation,
   mutatingOperations,
   CodapInitiatedCommand,
-  DataSetDescription,
+  DataContext,
   CodapAttribute,
 } from "./types";
 import { newContextListeners, contextUpdateListeners } from "./listeners";
@@ -156,7 +156,7 @@ function createBareDataset(label: string, attrs: CodapAttribute[]) {
   const newName = getNewName();
   const newCollectionName = collectionNameFromContext(newName);
 
-  return new Promise<DataSetDescription>((resolve, reject) =>
+  return new Promise<DataContext>((resolve, reject) =>
     phone.call<CodapResponseValues>(
       {
         action: CodapActions.Create,
@@ -176,7 +176,7 @@ function createBareDataset(label: string, attrs: CodapAttribute[]) {
       },
       (response) => {
         if (response.success) {
-          resolve(response.values as DataSetDescription);
+          resolve(response.values as DataContext);
         } else {
           reject(new Error("Failed to create dataset"));
         }
@@ -210,7 +210,7 @@ export async function createDataset(
   const newDatasetDescription = await createBareDataset(label, attrs);
 
   // return itemIDs
-  return new Promise<DataSetDescription>((resolve, reject) =>
+  return new Promise<DataContext>((resolve, reject) =>
     phone.call<CodapResponseItemIDs>(
       {
         action: CodapActions.Create,
@@ -279,7 +279,7 @@ export async function createTable(context: string) {
         action: CodapActions.Create,
         resource: CodapResource.Component,
         values: {
-          type: CodapComponent.Table,
+          type: CodapComponentType.CaseTable,
           name: getNewName(),
           dimensions: {
             width: DEFAULT_TABLE_WIDTH,

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -3,13 +3,11 @@ import {
   CodapComponentType,
   CodapResource,
   CodapActions,
-  CodapRequest,
   CodapResponse,
   CodapResponseValues,
   CodapResponseItemIDs,
   CodapPhone,
   CodapInitiatedResource,
-  ContextChangeOperation,
   mutatingOperations,
   CodapInitiatedCommand,
   DataContext,
@@ -116,8 +114,8 @@ function codapRequestHandler(
   }
 }
 
-export function getAllDataContexts() {
-  return new Promise<string[]>((resolve, reject) =>
+export function getAllDataContexts(): Promise<DataContext[]> {
+  return new Promise<DataContext[]>((resolve, reject) =>
     phone.call<CodapResponseValues>(
       {
         action: CodapActions.Get,
@@ -125,7 +123,7 @@ export function getAllDataContexts() {
       },
       (response) => {
         if (Array.isArray(response.values)) {
-          resolve(response.values.map((v) => v.name));
+          resolve(response.values);
         } else {
           reject(new Error("Failed to get data contexts."));
         }
@@ -134,7 +132,9 @@ export function getAllDataContexts() {
   );
 }
 
-export function getDataFromContext(context: string) {
+export function getDataFromContext(
+  context: string
+): Promise<Record<string, unknown>[]> {
   return new Promise<Record<string, unknown>[]>((resolve, reject) =>
     phone.call<CodapResponseValues>(
       {
@@ -152,7 +152,10 @@ export function getDataFromContext(context: string) {
   );
 }
 
-function createBareDataset(label: string, attrs: CodapAttribute[]) {
+function createBareDataset(
+  label: string,
+  attrs: CodapAttribute[]
+): Promise<DataContext> {
   const newName = getNewName();
   const newCollectionName = collectionNameFromContext(newName);
 
@@ -200,7 +203,7 @@ function makeAttrsFromData(data: Record<string, unknown>[]): CodapAttribute[] {
 export async function createDataset(
   label: string,
   data: Record<string, unknown>[]
-) {
+): Promise<DataContext> {
   if (data.length === 0) {
     return await createBareDataset(label, []);
   }
@@ -231,7 +234,7 @@ export async function createDataset(
 export async function setContextItems(
   contextName: string,
   items: Record<string, unknown>[]
-) {
+): Promise<void> {
   await deleteAllCases(contextName);
 
   return new Promise<void>((resolve, reject) =>
@@ -252,7 +255,7 @@ export async function setContextItems(
   );
 }
 
-export async function deleteAllCases(context: string) {
+export async function deleteAllCases(context: string): Promise<void> {
   return new Promise<void>((resolve, reject) =>
     phone.call(
       {
@@ -272,7 +275,7 @@ export async function deleteAllCases(context: string) {
 
 const DEFAULT_TABLE_WIDTH = 300;
 const DEFAULT_TABLE_HEIGHT = 300;
-export async function createTable(context: string) {
+export async function createTable(context: string): Promise<void> {
   return new Promise<void>((resolve, reject) =>
     phone.call(
       {

--- a/src/utils/codapPhone/listeners.ts
+++ b/src/utils/codapPhone/listeners.ts
@@ -2,11 +2,11 @@
 
 export let newContextListeners: Array<() => void> = [];
 
-export function addNewContextListener(listener: () => void) {
+export function addNewContextListener(listener: () => void): void {
   newContextListeners.push(listener);
 }
 
-export function removeNewContextListener(listener: () => void) {
+export function removeNewContextListener(listener: () => void): void {
   newContextListeners = newContextListeners.filter((v) => v !== listener);
 }
 
@@ -18,10 +18,10 @@ export const contextUpdateListeners: Record<string, () => void | undefined> =
 export function addContextUpdateListener(
   context: string,
   listener: () => void
-) {
+): void {
   contextUpdateListeners[context] = listener;
 }
 
-export function removeContextUpdateListener(context: string) {
+export function removeContextUpdateListener(context: string): void {
   delete contextUpdateListeners[context];
 }

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -2,6 +2,8 @@ export enum CodapResource {
   DataContext = "dataContext",
   DataContextList = "dataContextList",
   Component = "component",
+  Collection = "collection",
+  CollectionList = "collectionList",
 }
 
 export enum CodapActions {
@@ -124,6 +126,15 @@ export interface AttributeLocation {
   collection: string;
   position: number;
 }
+
+export interface Case {
+  id: number;
+  parent?: string;
+  collection?: Collection;
+  values: Record<string, unknown>[];
+}
+
+export type SelectionList = number[];
 
 export enum CodapComponentType {
   Graph = "graph",

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -62,6 +62,7 @@ export type CodapInitiatedCommand = {
   values?: any;
 };
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#datacontexts
 export interface DataContext {
   name: string;
   title?: string;
@@ -69,6 +70,7 @@ export interface DataContext {
   collections?: Collection[];
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#collections
 export interface Collection {
   name: string;
   title?: string;
@@ -83,6 +85,12 @@ export interface Collection {
     setOfCasesWithArticle?: string;
   };
 }
+
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#attributes
+export type CodapAttribute =
+  | BaseAttribute
+  | CategoricalAttribute
+  | NumericAttribute;
 
 export interface BaseAttribute {
   name: string;
@@ -117,16 +125,13 @@ export interface NumericAttribute extends BaseAttribute {
   };
 }
 
-export type CodapAttribute =
-  | BaseAttribute
-  | CategoricalAttribute
-  | NumericAttribute;
-
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#attributelocations
 export interface AttributeLocation {
   collection: string;
   position: number;
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#cases
 export interface Case {
   id: number;
   parent?: string;
@@ -134,8 +139,10 @@ export interface Case {
   values: Record<string, unknown>[];
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#selectionlists
 export type SelectionList = number[];
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#components
 export enum CodapComponentType {
   Graph = "graph",
   CaseTable = "caseTable",
@@ -158,6 +165,7 @@ export interface CodapComponent {
   position: "top" | "bottom" | { left: number; top: number };
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#the-graph-object
 export interface Graph extends CodapComponent {
   type: CodapComponentType.Graph;
   cannotClose: boolean;
@@ -170,6 +178,7 @@ export interface Graph extends CodapComponent {
   numberToggleLastMode: boolean;
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#the-casetable-object
 export interface CaseTable extends CodapComponent {
   type: CodapComponentType.CaseTable;
   cannotClose: boolean;
@@ -178,6 +187,7 @@ export interface CaseTable extends CodapComponent {
   isIndexHidden: boolean;
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#the-map-object
 export interface Map extends CodapComponent {
   type: CodapComponentType.Map;
   cannotClose: boolean;
@@ -187,6 +197,7 @@ export interface Map extends CodapComponent {
   zoom: number;
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#the-slider-object
 export interface Slider extends CodapComponent {
   type: CodapComponentType.Slider;
   cannotClose: boolean;
@@ -197,23 +208,27 @@ export interface Slider extends CodapComponent {
   upperBound: number;
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#the-calculator-object
 export interface Calculator extends CodapComponent {
   type: CodapComponentType.Calculator;
   cannotClose: boolean;
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#the-text-object
 export interface Text extends CodapComponent {
   type: CodapComponentType.Text;
   cannotClose: boolean;
   text: string;
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#the-webview-object
 export interface WebView extends CodapComponent {
   type: CodapComponentType.WebView;
   cannotClose: boolean;
   URL: string;
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#the-guide-object
 export interface Guide extends CodapComponent {
   type: CodapComponentType.Guide;
   cannotClose: boolean;

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -17,7 +17,7 @@ export enum CodapActions {
 export type CodapRequest = {
   action: CodapActions;
   resource: string;
-  values?: any;
+  values?: unknown;
 };
 
 export interface CodapResponse {
@@ -25,7 +25,7 @@ export interface CodapResponse {
 }
 
 export interface CodapResponseValues extends CodapResponse {
-  values?: any;
+  values?: unknown;
 }
 
 export interface CodapResponseItemIDs extends CodapResponse {
@@ -33,7 +33,7 @@ export interface CodapResponseItemIDs extends CodapResponse {
 }
 
 export type CodapPhone = {
-  call<T extends CodapResponse>(r: CodapRequest, cb: (r: T) => any): void;
+  call<T extends CodapResponse>(r: CodapRequest, cb: (r: T) => unknown): void;
 };
 
 export enum CodapInitiatedResource {

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -66,7 +66,7 @@ export interface DataContext {
   name: string;
   title?: string;
   description?: string;
-  collections: Collection[];
+  collections?: Collection[];
 }
 
 export interface Collection {

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -60,36 +60,70 @@ export type CodapInitiatedCommand = {
   values?: any;
 };
 
-export type DataSetDescription = {
-  name: string;
-  id: number;
-  title: string;
-};
-
-interface BaseAttribute {
+export interface DataContext {
   name: string;
   title?: string;
-  colormap?: Record<string, string | undefined>;
+  description?: string;
+  collections: Collection[];
+}
+
+export interface Collection {
+  name: string;
+  title?: string;
+  description?: string;
+  parent: string;
+  attrs?: BaseAttribute[];
+  labels: {
+    singleCase?: string;
+    pluralCase?: string;
+    singleCaseWithArticle?: string;
+    setOfCases?: string;
+    setOfCasesWithArticle?: string;
+  };
+}
+
+export interface BaseAttribute {
+  name: string;
+  title?: string;
+  type?: "numeric" | "categorical";
+  colormap?:
+    | Record<string, string>
+    | {
+        "high-attribute-color": string;
+        "low-attribute-color": string;
+        "attribute-color": string;
+      };
   description?: string;
   editable?: boolean;
   formula?: string;
   hidden?: boolean;
 }
 
-interface CategoricalAttribute extends BaseAttribute {
+export interface CategoricalAttribute extends BaseAttribute {
   type: "categorical";
+  colormap?: Record<string, string>;
 }
 
-interface NumericAttribute extends BaseAttribute {
+export interface NumericAttribute extends BaseAttribute {
   type: "numeric";
   precision?: number;
   unit?: string;
+  colormap?: {
+    "high-attribute-color": string;
+    "low-attribute-color": string;
+    "attribute-color": string;
+  };
 }
 
 export type CodapAttribute =
   | BaseAttribute
   | CategoricalAttribute
   | NumericAttribute;
+
+export interface AttributeLocation {
+  collection: string;
+  position: number;
+}
 
 export enum CodapComponentType {
   Graph = "graph",

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -1,9 +1,3 @@
-export enum CodapComponent {
-  Graph = "graph",
-  Table = "caseTable",
-  Map = "map",
-}
-
 export enum CodapResource {
   DataContext = "dataContext",
   DataContextList = "dataContextList",
@@ -96,3 +90,92 @@ export type CodapAttribute =
   | BaseAttribute
   | CategoricalAttribute
   | NumericAttribute;
+
+export enum CodapComponentType {
+  Graph = "graph",
+  CaseTable = "caseTable",
+  Map = "map",
+  Slider = "slider",
+  Calculator = "calculator",
+  Text = "text",
+  WebView = "webView",
+  Guide = "guideView",
+}
+
+export interface CodapComponent {
+  type: CodapComponentType;
+  name: string;
+  title?: string;
+  dimensions: {
+    width: number;
+    height: number;
+  };
+  position: "top" | "bottom" | { left: number; top: number };
+}
+
+export interface Graph extends CodapComponent {
+  type: CodapComponentType.Graph;
+  cannotClose: boolean;
+  dataContext: string;
+  xAttributeName: string;
+  yAttributeName: string;
+  y2AttributeName: string;
+  legendAttributeName: string;
+  enableNumberToggle: boolean;
+  numberToggleLastMode: boolean;
+}
+
+export interface CaseTable extends CodapComponent {
+  type: CodapComponentType.CaseTable;
+  cannotClose: boolean;
+  dataContext: string;
+  horizontalScrollOffset: number;
+  isIndexHidden: boolean;
+}
+
+export interface Map extends CodapComponent {
+  type: CodapComponentType.Map;
+  cannotClose: boolean;
+  dataContext: string;
+  legendAttributeName: string;
+  center: [number, number];
+  zoom: number;
+}
+
+export interface Slider extends CodapComponent {
+  type: CodapComponentType.Slider;
+  cannotClose: boolean;
+  globalValueName: string;
+  animationDirection: number;
+  animationMode: number;
+  lowerBound: number;
+  upperBound: number;
+}
+
+export interface Calculator extends CodapComponent {
+  type: CodapComponentType.Calculator;
+  cannotClose: boolean;
+}
+
+export interface Text extends CodapComponent {
+  type: CodapComponentType.Text;
+  cannotClose: boolean;
+  text: string;
+}
+
+export interface WebView extends CodapComponent {
+  type: CodapComponentType.WebView;
+  cannotClose: boolean;
+  URL: string;
+}
+
+export interface Guide extends CodapComponent {
+  type: CodapComponentType.Guide;
+  cannotClose: boolean;
+  isVisible: boolean;
+  currentItemIndex: number;
+  items: {
+    itemTitle: string;
+    url: string;
+  }[];
+}


### PR DESCRIPTION
This PR includes a transcription of the types on [the IframePhone wiki](https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API) into Typescript interfaces so we have them for future use. It also adds return type annotations to some of the IframePhone API functions to help cut down on eslint warnings. 