### PR TITLE
change `row()` to `attr()`, improve some error messages

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -133,7 +133,9 @@ function Transformation() {
           const result = evaluate(transformPgrm, dataEnv);
 
           if (result.kind !== "Bool") {
-            setErrMsg(`Expected boolean output, instead got ${result.kind}.`);
+            setErrMsg(
+              `Expected filter condition to evaluate to true/false, instead got a ${result.kind}`
+            );
             return;
           }
           // include in filter if expression evaluated to true

--- a/src/language/__tests__/interpret.test.ts
+++ b/src/language/__tests__/interpret.test.ts
@@ -121,16 +121,19 @@ test("interprets logic correctly", () => {
   expect(interpret(ast)).toStrictEqual({ kind: "Bool", content: false });
 });
 
-test("uses attr() built-in to access non-identifier attribute names in env", () => {
+test("interprets built-ins", () => {
   const ast: Ast = {
     kind: "Builtin",
-    name: "attr",
-    args: [{ kind: "String", content: "Attribute name with spaces" }],
+    name: "isNegative",
+    args: [
+      {
+        kind: "Binop",
+        op: "+",
+        op1: { kind: "Number", content: 7 },
+        op2: { kind: "Number", content: -150 },
+      },
+    ],
   };
 
-  const env: Env = {
-    "Attribute name with spaces": { kind: "Num", content: 17 },
-  };
-
-  expect(interpret(ast, env)).toStrictEqual({ kind: "Num", content: 17 });
+  expect(interpret(ast, {})).toStrictEqual({ kind: "Bool", content: true });
 });

--- a/src/language/__tests__/interpret.test.ts
+++ b/src/language/__tests__/interpret.test.ts
@@ -121,10 +121,10 @@ test("interprets logic correctly", () => {
   expect(interpret(ast)).toStrictEqual({ kind: "Bool", content: false });
 });
 
-test("uses row built-in to access non-identifier attribute names in env", () => {
+test("uses attr() built-in to access non-identifier attribute names in env", () => {
   const ast: Ast = {
     kind: "Builtin",
-    name: "row",
+    name: "attr",
     args: [{ kind: "String", content: "Attribute name with spaces" }],
   };
 

--- a/src/language/__tests__/lex.test.ts
+++ b/src/language/__tests__/lex.test.ts
@@ -22,6 +22,12 @@ test("parses identifiers", () => {
   ]);
 });
 
+test("parses long/non-alphanumeric identifiers within backticks", () => {
+  expect(lex("`this is a long attribute name !@*#&$`")).toStrictEqual([
+    { kind: "IDENTIFIER", content: "this is a long attribute name !@*#&$" },
+  ]);
+});
+
 test("ignores whitespace", () => {
   expect(lex("1 +             2")).toStrictEqual([
     { kind: "NUMBER", content: 1 },

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -20,7 +20,7 @@ export type Operator =
 
 export type UnaryOperator = "not";
 
-export type Builtin = "row";
+export type Builtin = "attr";
 
 export type Value =
   | { kind: "Num"; content: number }

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -20,7 +20,7 @@ export type Operator =
 
 export type UnaryOperator = "not";
 
-export type Builtin = "attr";
+export type Builtin = "isNegative";
 
 export type Value =
   | { kind: "Num"; content: number }

--- a/src/language/interpret.ts
+++ b/src/language/interpret.ts
@@ -34,7 +34,7 @@ function interpretExpr(expr: Ast, env: Env): Value {
       return interpretUnop(expr.op, expr.op1, env);
     case "Identifier":
       if (!env[expr.content]) {
-        throw new Error(`Unknown column name: ${expr.content}`);
+        throw new Error(`Unknown attribute name: ${expr.content}`);
       }
       return env[expr.content];
     case "Number":
@@ -103,19 +103,23 @@ function interpretUnop(op: UnaryOperator, op1: Ast, env: Env): Value {
 
 function interpretBuiltin(name: Builtin, args: Ast[], env: Env): Value {
   switch (name) {
-    case "row": {
+    case "attr": {
       if (args.length != 1) {
-        throw new Error("row() expects exactly 1 argument (a column name)");
+        throw new Error(
+          "attr() expects exactly 1 argument (an attribute name)"
+        );
       }
       const attr = args[0];
       if (attr.kind !== "String") {
-        throw new Error(`Expected a column name given to row()`);
+        throw new Error(`Expected an attribute name given to attr()`);
       }
       if (!env[attr.content]) {
-        throw new Error(`Unknown column name "${attr.content}" given to row()`);
+        throw new Error(
+          `Unknown attribute name "${attr.content}" given to attr()`
+        );
       }
 
-      // lookup column name in environment
+      // lookup attribute name in environment
       return env[attr.content];
     }
   }

--- a/src/language/interpret.ts
+++ b/src/language/interpret.ts
@@ -115,25 +115,5 @@ function interpretBuiltin(name: Builtin, args: Ast[], env: Env): Value {
 
       return { kind: "Bool", content: argValue.content < 0 };
     }
-
-    // case "attr": {
-    //   if (args.length != 1) {
-    //     throw new Error(
-    //       "attr() expects exactly 1 argument (an attribute name)"
-    //     );
-    //   }
-    //   const attr = args[0];
-    //   if (attr.kind !== "String") {
-    //     throw new Error(`Expected an attribute name given to attr()`);
-    //   }
-    //   if (!env[attr.content]) {
-    //     throw new Error(
-    //       `Unknown attribute name "${attr.content}" given to attr()`
-    //     );
-    //   }
-
-    //   // lookup attribute name in environment
-    //   return env[attr.content];
-    // }
   }
 }

--- a/src/language/interpret.ts
+++ b/src/language/interpret.ts
@@ -103,24 +103,37 @@ function interpretUnop(op: UnaryOperator, op1: Ast, env: Env): Value {
 
 function interpretBuiltin(name: Builtin, args: Ast[], env: Env): Value {
   switch (name) {
-    case "attr": {
+    case "isNegative": {
       if (args.length != 1) {
-        throw new Error(
-          "attr() expects exactly 1 argument (an attribute name)"
-        );
-      }
-      const attr = args[0];
-      if (attr.kind !== "String") {
-        throw new Error(`Expected an attribute name given to attr()`);
-      }
-      if (!env[attr.content]) {
-        throw new Error(
-          `Unknown attribute name "${attr.content}" given to attr()`
-        );
+        throw new Error("isNegative expects exactly 1 argument");
       }
 
-      // lookup attribute name in environment
-      return env[attr.content];
+      const argValue = interpretExpr(args[0], env);
+      if (argValue.kind !== "Num") {
+        throw new Error(`isNegative expected a number, got a ${argValue.kind}`);
+      }
+
+      return { kind: "Bool", content: argValue.content < 0 };
     }
+
+    // case "attr": {
+    //   if (args.length != 1) {
+    //     throw new Error(
+    //       "attr() expects exactly 1 argument (an attribute name)"
+    //     );
+    //   }
+    //   const attr = args[0];
+    //   if (attr.kind !== "String") {
+    //     throw new Error(`Expected an attribute name given to attr()`);
+    //   }
+    //   if (!env[attr.content]) {
+    //     throw new Error(
+    //       `Unknown attribute name "${attr.content}" given to attr()`
+    //     );
+    //   }
+
+    //   // lookup attribute name in environment
+    //   return env[attr.content];
+    // }
   }
 }

--- a/src/language/lex.ts
+++ b/src/language/lex.ts
@@ -18,6 +18,13 @@ export type Token =
   | { kind: "L_NOT" };
 
 /**
+ * Get rid of the first and last character of a string.
+ */
+function trimEnds(s: string): string {
+  return s.substring(1, s.length - 1);
+}
+
+/**
  * A list of tuples representing a regex to use to search for a token
  * and a function to use to turn the resulting regex match string into a token
  */
@@ -38,10 +45,8 @@ const regexTable: Array<[RegExp, null | ((s: string) => Token)]> = [
   [/^(or|\|\|)/, () => ({ kind: "L_OR" })],
   [/^(not|!)/, () => ({ kind: "L_NOT" })],
   [/^[a-zA-Z][a-zA-Z0-9]*/, (s) => ({ kind: "IDENTIFIER", content: s })],
-  [
-    /^".*?"/,
-    (s) => ({ kind: "STRING", content: s.substring(1, s.length - 1) }),
-  ],
+  [/^`.*?`/, (s) => ({ kind: "IDENTIFIER", content: trimEnds(s) })],
+  [/^".*?"/, (s) => ({ kind: "STRING", content: trimEnds(s) })],
   [/^[ \n\t]+/, null],
 ];
 

--- a/src/language/parse.ts
+++ b/src/language/parse.ts
@@ -39,7 +39,7 @@ export function getBindingPower(op: Token): number {
  */
 function isBuiltin(name: string): boolean {
   // ... add built-in names here as we extend
-  return ["attr"].includes(name);
+  return ["isNegative"].includes(name);
 }
 
 /**

--- a/src/language/parse.ts
+++ b/src/language/parse.ts
@@ -39,7 +39,7 @@ export function getBindingPower(op: Token): number {
  */
 function isBuiltin(name: string): boolean {
   // ... add built-in names here as we extend
-  return ["row"].includes(name);
+  return ["attr"].includes(name);
 }
 
 /**
@@ -113,7 +113,7 @@ export function parseExpr(tokens: Token[], currentBindingPower: number): Ast {
   // Find the parselet that corresponds to the intial token
   const initialParselet = prefixParseletMap(initialToken);
   if (!initialParselet) {
-    throw new Error(`Unexpected token: ${initialToken}`);
+    throw new Error(`Unexpected token: ${initialToken.kind}`);
   }
 
   // Invoke the initial parselet


### PR DESCRIPTION
I realized `row()` should probably be called `attr()` and several other places where we refer to "columns" should be in terms of "attribute" instead, to keep better consistency with the CODAP lingo.

I also updated a few error messages.