### PR TITLE
abstract over transformations

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -1,41 +1,9 @@
 /* eslint use-isnan: 0 */
 import React, { ReactElement } from "react";
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
 import "./Transformation.css";
 import Error from "./Error";
-import {
-  getAllDataContexts,
-  getDataFromContext,
-  setContextItems,
-  addNewContextListener,
-  removeNewContextListener,
-  addContextUpdateListener,
-  removeContextUpdateListener,
-  createTableWithData,
-  getDataContext,
-} from "./utils/codapPhone";
-import { Value } from "./language/ast";
-import { Env } from "./language/interpret";
-import { evaluate } from "./language";
-import { CodapIdentifyingInfo } from "./utils/codapPhone/types";
-import { filter } from "./transformations/filter";
-
-function useDataContexts() {
-  const [dataContexts, setDataContexts] = useState<CodapIdentifyingInfo[]>([]);
-
-  async function refreshTables() {
-    setDataContexts(await getAllDataContexts());
-  }
-
-  // Initial refresh to set up connection, then start listening
-  useEffect(() => {
-    refreshTables();
-    addNewContextListener(refreshTables);
-    return () => removeNewContextListener(refreshTables);
-  }, []);
-
-  return dataContexts;
-}
+import { Filter } from "./transformation-components/Filter";
 
 /**
  * Transformation represents an instance of the plugin, which applies a
@@ -52,101 +20,21 @@ function Transformation(): ReactElement {
 
   const transformTypes = [TransformType.Filter];
 
-  const [inputDataCtxt, setInputDataCtxt] = useState<string | null>(null);
   const [transformType, setTransformType] =
     useState<TransformType | null>(null);
-  const [transformPgrm, setTransformPgrm] = useState("");
   const [errMsg, setErrMsg] = useState<string | null>(null);
-  const dataContexts = useDataContexts();
-  const [lastContextName, setLastContextName] = useState<string | null>(null);
 
-  function inputChange(event: React.ChangeEvent<HTMLSelectElement>) {
-    setInputDataCtxt(event.target.value);
-    setErrMsg(null);
-  }
+  const transformComponents = {
+    Filter: <Filter setErrMsg={setErrMsg} />,
+  };
 
   function typeChange(event: React.ChangeEvent<HTMLSelectElement>) {
     setTransformType(event.target.value as TransformType);
     setErrMsg(null);
   }
 
-  function pgrmChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
-    setTransformPgrm(event.target.value);
-    setErrMsg(null);
-  }
-
-  /**
-   * Applies the user-defined transformation to the indicated input data,
-   * and generates an output table into CODAP containing the transformed data.
-   */
-  const transform = useCallback(
-    async (doUpdate: boolean) => {
-      if (inputDataCtxt === null) {
-        setErrMsg("Please choose a valid data context to transform.");
-        return;
-      }
-      if (transformType === null) {
-        setErrMsg("Please choose a valid transformation type.");
-        return;
-      }
-
-      console.log(`Data context to transform: ${inputDataCtxt}`);
-      console.log(`Transformation type: ${transformType}`);
-      console.log(`Transformation to apply:\n${transformPgrm}`);
-
-      const dataset = {
-        context: await getDataContext(inputDataCtxt),
-        records: await getDataFromContext(inputDataCtxt),
-      };
-
-      try {
-        const filtered = filter(dataset, { predicate: transformPgrm });
-
-        // if doUpdate is true then we should update a previously created table
-        // rather than creating a new one
-        if (doUpdate) {
-          if (!lastContextName) {
-            setErrMsg("Please apply transformation to a new table first.");
-            return;
-          }
-          setContextItems(lastContextName, filtered.records);
-        } else {
-          const [newContext, _newTable] = await createTableWithData(
-            inputDataCtxt,
-            filtered.records
-          );
-          setLastContextName(newContext.name);
-        }
-      } catch (e) {
-        setErrMsg(e.message);
-      }
-    },
-    [inputDataCtxt, transformType, transformPgrm, lastContextName]
-  );
-
-  useEffect(() => {
-    if (inputDataCtxt !== null) {
-      addContextUpdateListener(inputDataCtxt, () => {
-        transform(true);
-      });
-      return () => removeContextUpdateListener(inputDataCtxt);
-    }
-  }, [transform, inputDataCtxt]);
-
   return (
     <div className="Transformation">
-      <p>Table to Transform</p>
-      <select id="inputDataContext" onChange={inputChange}>
-        <option selected disabled>
-          Select a Data Context
-        </option>
-        {dataContexts.map((dataContext) => (
-          <option key={dataContext.name} value={dataContext.name}>
-            {dataContext.title} ({dataContext.name})
-          </option>
-        ))}
-      </select>
-
       <p>Transformation Type</p>
       <select id="transformType" onChange={typeChange}>
         <option selected disabled>
@@ -156,17 +44,7 @@ function Transformation(): ReactElement {
           <option key={i}>{type}</option>
         ))}
       </select>
-
-      <p>How to Transform</p>
-      <textarea onChange={pgrmChange}></textarea>
-
-      <br />
-      <button onClick={() => transform(false)}>
-        Create table with transformation
-      </button>
-      <button onClick={() => transform(true)} disabled={!lastContextName}>
-        Update previous table with transformation
-      </button>
+      {transformType && transformComponents[transformType]}
 
       <Error message={errMsg} />
     </div>

--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -12,11 +12,13 @@ import {
   addContextUpdateListener,
   removeContextUpdateListener,
   createTableWithData,
+  getDataContext,
 } from "./utils/codapPhone";
 import { Value } from "./language/ast";
 import { Env } from "./language/interpret";
 import { evaluate } from "./language";
 import { CodapIdentifyingInfo } from "./utils/codapPhone/types";
+import { filter } from "./transformations/filter";
 
 function useDataContexts() {
   const [dataContexts, setDataContexts] = useState<CodapIdentifyingInfo[]>([]);
@@ -74,37 +76,6 @@ function Transformation(): ReactElement {
   }
 
   /**
-   * Converts a data item object into an environment for our language. Only
-   * includes numeric values.
-   *
-   * @returns An environment from the fields of the data item.
-   */
-  function dataItemToEnv(dataItem: Record<string, unknown>): Env {
-    return Object.fromEntries(
-      Object.entries(dataItem).map(([key, tableValue]) => {
-        let value;
-        // parse value from CODAP table data
-        if (
-          tableValue === "true" ||
-          tableValue === "false" ||
-          tableValue === true ||
-          tableValue === false
-        ) {
-          value = {
-            kind: "Bool",
-            content: tableValue === "true" || tableValue === true,
-          };
-        } else if (!isNaN(Number(tableValue))) {
-          value = { kind: "Num", content: Number(tableValue) };
-        } else {
-          value = { kind: "String", content: tableValue };
-        }
-        return [key, value as Value];
-      })
-    );
-  }
-
-  /**
    * Applies the user-defined transformation to the indicated input data,
    * and generates an output table into CODAP containing the transformed data.
    */
@@ -123,26 +94,13 @@ function Transformation(): ReactElement {
       console.log(`Transformation type: ${transformType}`);
       console.log(`Transformation to apply:\n${transformPgrm}`);
 
-      const data = await getDataFromContext(inputDataCtxt);
+      const dataset = {
+        context: await getDataContext(inputDataCtxt),
+        records: await getDataFromContext(inputDataCtxt),
+      };
 
       try {
-        const newData = [];
-
-        for (const dataItem of data) {
-          const dataEnv = dataItemToEnv(dataItem);
-          const result = evaluate(transformPgrm, dataEnv);
-
-          if (result.kind !== "Bool") {
-            setErrMsg(
-              `Expected filter condition to evaluate to true/false, instead got a ${result.kind}`
-            );
-            return;
-          }
-          // include in filter if expression evaluated to true
-          if (result.content) {
-            newData.push(dataItem);
-          }
-        }
+        const filtered = filter(dataset, { predicate: transformPgrm });
 
         // if doUpdate is true then we should update a previously created table
         // rather than creating a new one
@@ -151,11 +109,11 @@ function Transformation(): ReactElement {
             setErrMsg("Please apply transformation to a new table first.");
             return;
           }
-          setContextItems(lastContextName, newData);
+          setContextItems(lastContextName, filtered.records);
         } else {
           const [newContext, _newTable] = await createTableWithData(
             inputDataCtxt,
-            newData
+            filtered.records
           );
           setLastContextName(newContext.name);
         }

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -1,0 +1,106 @@
+import React, { useState, useEffect, useCallback, ReactElement } from "react";
+import {
+  getDataFromContext,
+  setContextItems,
+  addContextUpdateListener,
+  removeContextUpdateListener,
+  createTableWithData,
+  getDataContext,
+} from "../utils/codapPhone";
+import { useDataContexts, useInput } from "../utils/hooks";
+import { filter } from "../transformations/filter";
+
+interface FilterProps {
+  setErrMsg: (s: string | null) => void;
+}
+
+export function Filter({ setErrMsg }: FilterProps): ReactElement {
+  const [inputDataCtxt, inputChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+  const [transformPgrm, pgrmChange] = useInput<string, HTMLTextAreaElement>(
+    "",
+    () => setErrMsg(null)
+  );
+  const dataContexts = useDataContexts();
+  const [lastContextName, setLastContextName] = useState<string | null>(null);
+
+  /**
+   * Applies the user-defined transformation to the indicated input data,
+   * and generates an output table into CODAP containing the transformed data.
+   */
+  const transform = useCallback(
+    async (doUpdate: boolean) => {
+      if (inputDataCtxt === null) {
+        setErrMsg("Please choose a valid data context to transform.");
+        return;
+      }
+
+      console.log(`Data context to filter: ${inputDataCtxt}`);
+      console.log(`Filter predicate to apply:\n${transformPgrm}`);
+
+      const dataset = {
+        collections: (await getDataContext(inputDataCtxt)).collections,
+        records: await getDataFromContext(inputDataCtxt),
+      };
+
+      try {
+        const filtered = filter(dataset, transformPgrm);
+
+        // if doUpdate is true then we should update a previously created table
+        // rather than creating a new one
+        if (doUpdate) {
+          if (!lastContextName) {
+            setErrMsg("Please apply transformation to a new table first.");
+            return;
+          }
+          setContextItems(lastContextName, filtered.records);
+        } else {
+          const [newContext] = await createTableWithData(
+            inputDataCtxt,
+            filtered.records
+          );
+          setLastContextName(newContext.name);
+        }
+      } catch (e) {
+        setErrMsg(e.message);
+      }
+    },
+    [inputDataCtxt, transformPgrm, lastContextName, setErrMsg]
+  );
+
+  useEffect(() => {
+    if (inputDataCtxt !== null) {
+      addContextUpdateListener(inputDataCtxt, () => {
+        transform(true);
+      });
+      return () => removeContextUpdateListener(inputDataCtxt);
+    }
+  }, [transform, inputDataCtxt]);
+
+  return (
+    <>
+      <p>Table to Filter</p>
+      <select id="inputDataContext" onChange={inputChange}>
+        <option selected disabled>
+          Select a Data Context
+        </option>
+        {dataContexts.map((dataContext) => (
+          <option key={dataContext.name} value={dataContext.name}>
+            {dataContext.title} ({dataContext.name})
+          </option>
+        ))}
+      </select>
+
+      <p>How to Filter</p>
+      <textarea onChange={pgrmChange}></textarea>
+
+      <br />
+      <button onClick={() => transform(false)}>Create filtered table</button>
+      <button onClick={() => transform(true)} disabled={!lastContextName}>
+        Update previous filtered table
+      </button>
+    </>
+  );
+}

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -4,7 +4,7 @@ import {
   setContextItems,
   addContextUpdateListener,
   removeContextUpdateListener,
-  createTableWithData,
+  createTableWithDataSet,
   getDataContext,
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
@@ -57,10 +57,7 @@ export function Filter({ setErrMsg }: FilterProps): ReactElement {
           }
           setContextItems(lastContextName, filtered.records);
         } else {
-          const [newContext] = await createTableWithData(
-            inputDataCtxt,
-            filtered.records
-          );
+          const [newContext] = await createTableWithDataSet(filtered);
           setLastContextName(newContext.name);
         }
       } catch (e) {

--- a/src/transformations/filter.ts
+++ b/src/transformations/filter.ts
@@ -3,18 +3,10 @@ import { dataItemToEnv } from "./util";
 import { evaluate } from "../language";
 
 /**
- * Filter requires a predicate string from our expression language.
- */
-type FilterExtra = {
-  predicate: string;
-};
-
-/**
  * Filter produces a dataset with certain records excluded
  * depending on a given predicate.
  */
-export function filter(dataset: DataSet, extra: unknown): DataSet {
-  const { predicate } = extra as FilterExtra;
+export function filter(dataset: DataSet, predicate: string): DataSet {
   const filteredRecords = [];
 
   for (const dataItem of dataset.records) {
@@ -37,7 +29,7 @@ export function filter(dataset: DataSet, extra: unknown): DataSet {
 
   // dataset with same context but filtered records
   return {
-    context: { ...dataset.context },
+    collections: dataset.collections.slice(),
     records: filteredRecords,
   };
 }

--- a/src/transformations/filter.ts
+++ b/src/transformations/filter.ts
@@ -1,0 +1,43 @@
+import { DataSet } from "./types";
+import { dataItemToEnv } from "./util";
+import { evaluate } from "../language";
+
+/**
+ * Filter requires a predicate string from our expression language.
+ */
+type FilterExtra = {
+  predicate: string;
+};
+
+/**
+ * Filter produces a dataset with certain records excluded
+ * depending on a given predicate.
+ */
+export function filter(dataset: DataSet, extra: unknown): DataSet {
+  const { predicate } = extra as FilterExtra;
+  const filteredRecords = [];
+
+  for (const dataItem of dataset.records) {
+    // bind attribute names to values from this record,
+    // evaluate the predicate in this environment
+    const dataEnv = dataItemToEnv(dataItem);
+    const result = evaluate(predicate, dataEnv);
+
+    // type error if predicate does not evaluate to a boolean
+    if (result.kind !== "Bool") {
+      throw new Error(
+        `Expected filter condition to evaluate to true/false, instead got a ${result.kind}`
+      );
+    }
+    // include in filter if expression evaluated to true
+    if (result.content) {
+      filteredRecords.push(dataItem);
+    }
+  }
+
+  // dataset with same context but filtered records
+  return {
+    context: { ...dataset.context },
+    records: filteredRecords,
+  };
+}

--- a/src/transformations/types.ts
+++ b/src/transformations/types.ts
@@ -1,0 +1,18 @@
+import { DataContext } from "../utils/codapPhone/types";
+
+/**
+ * DataSet represents a data context and all of the actual data
+ * contained within it.
+ */
+export type DataSet = {
+  context: DataContext;
+  records: Record<string, unknown>[];
+};
+
+/**
+ * A transformation operates on a dataset to produce a new,
+ * transformed dataset.
+ */
+export interface Transformation {
+  (dataset: DataSet, extra?: unknown): DataSet;
+}

--- a/src/transformations/types.ts
+++ b/src/transformations/types.ts
@@ -1,11 +1,11 @@
-import { DataContext } from "../utils/codapPhone/types";
+import { Collection } from "../utils/codapPhone/types";
 
 /**
  * DataSet represents a data context and all of the actual data
  * contained within it.
  */
 export type DataSet = {
-  context: DataContext;
+  collections: Pick<Collection, "attrs" | "labels">[];
   records: Record<string, unknown>[];
 };
 

--- a/src/transformations/types.ts
+++ b/src/transformations/types.ts
@@ -5,7 +5,7 @@ import { Collection } from "../utils/codapPhone/types";
  * contained within it.
  */
 export type DataSet = {
-  collections: Pick<Collection, "attrs" | "labels">[];
+  collections: Collection[];
   records: Record<string, unknown>[];
 };
 

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -1,0 +1,33 @@
+import { Env } from "../language/interpret";
+import { Value } from "../language/ast";
+
+/**
+ * Converts a data item object into an environment for our language. Only
+ * includes numeric values.
+ *
+ * @returns An environment from the fields of the data item.
+ */
+export function dataItemToEnv(dataItem: Record<string, unknown>): Env {
+  return Object.fromEntries(
+    Object.entries(dataItem).map(([key, tableValue]) => {
+      let value;
+      // parse value from CODAP table data
+      if (
+        tableValue === "true" ||
+        tableValue === "false" ||
+        tableValue === true ||
+        tableValue === false
+      ) {
+        value = {
+          kind: "Bool",
+          content: tableValue === "true" || tableValue === true,
+        };
+      } else if (!isNaN(Number(tableValue))) {
+        value = { kind: "Num", content: Number(tableValue) };
+      } else {
+        value = { kind: "String", content: tableValue };
+      }
+      return [key, value as Value];
+    })
+  );
+}

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -164,7 +164,7 @@ export function getDataFromContext(
 //   return new Promise<unknown>((resolve, reject) => phone.call);
 // }
 
-function getDataContext(contextName: string): Promise<DataContext> {
+export function getDataContext(contextName: string): Promise<DataContext> {
   return new Promise<DataContext>((resolve, reject) =>
     phone.call(
       {

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -66,7 +66,7 @@ export interface CodapResponse {
 }
 
 interface CreateContextResponse extends CodapResponse {
-  values: DataContext;
+  values: CodapIdentifyingInfo;
 }
 
 interface GetListResponse extends CodapResponse {
@@ -84,7 +84,7 @@ export interface GetCasesResponse extends CodapResponse {
 }
 
 export interface GetContextResponse extends CodapResponse {
-  values: DataContext;
+  values: ReturnedDataContext;
 }
 
 interface TableResponse extends CodapResponse {
@@ -162,6 +162,10 @@ export interface DataContext {
   name: string;
   title?: string;
   description?: string;
+  collections: Collection[];
+}
+
+export interface ReturnedDataContext extends Omit<DataContext, "collections"> {
   collections: ReturnedCollection[];
 }
 

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,0 +1,47 @@
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  getAllDataContexts,
+  addNewContextListener,
+  removeNewContextListener,
+} from "./codapPhone";
+import { CodapIdentifyingInfo } from "./codapPhone/types";
+
+export function useDataContexts(): CodapIdentifyingInfo[] {
+  const [dataContexts, setDataContexts] = useState<CodapIdentifyingInfo[]>([]);
+
+  async function refreshTables() {
+    setDataContexts(await getAllDataContexts());
+  }
+
+  // Initial refresh to set up connection, then start listening
+  useEffect(() => {
+    refreshTables();
+    addNewContextListener(refreshTables);
+    return () => removeNewContextListener(refreshTables);
+  }, []);
+
+  return dataContexts;
+}
+
+interface ElementWithValue {
+  value: string;
+}
+
+export function useInput<T, E extends ElementWithValue>(
+  initialValue: T | string,
+  extraAction: (newValue: T | string) => void
+): [
+  T | string,
+  (e: React.ChangeEvent<E>) => void,
+  React.Dispatch<React.SetStateAction<T | string>>
+] {
+  const [inputValue, setInputValue] = useState<T | string>(initialValue);
+  const onChange = useCallback(
+    (event: React.ChangeEvent<E>) => {
+      setInputValue(event.target.value);
+      extraAction(event.target.value);
+    },
+    [setInputValue, extraAction]
+  );
+  return [inputValue, onChange, setInputValue];
+}


### PR DESCRIPTION
This adds very preliminary support for multiple transformations, by extracting the functionality of filter out of the UI code. This is meant as a jumping off point and is WIP. 

This defines the notion of a "dataset" as:
```ts
export type DataSet = {
  context: DataContext;
  records: Record<string, unknown>[];
};
```
and a transformation as something which fulfills the following contract: 
```ts
export interface Transformation {
  (dataset: DataSet, extra?: unknown): DataSet;
}
```
That is, a transformation produces a whole new dataset as its output. This allows for transformations that may change not just records but the structure of the collections themselves (adding/deleting attributes, etc). The `extra` is intended to allow for extra information a transformation might need (e.g. in the case of filter, the predicate to filter by).

I've ported filter to this format (in `src/transformations/filter.ts`) and connected it to the UI to get an idea of how this might work.