### PR TITLE
switch from using `selected` on options to `defaultValue`

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -36,12 +36,14 @@ function Transformation(): ReactElement {
   return (
     <div className="Transformation">
       <p>Transformation Type</p>
-      <select id="transformType" onChange={typeChange}>
-        <option selected disabled>
+      <select id="transformType" onChange={typeChange} defaultValue="default">
+        <option disabled value="default">
           Select a Transformation
         </option>
         {transformTypes.map((type, i) => (
-          <option key={i}>{type}</option>
+          <option key={i} value={type}>
+            {type}
+          </option>
         ))}
       </select>
       {transformType && transformComponents[transformType]}

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -79,8 +79,12 @@ export function Filter({ setErrMsg }: FilterProps): ReactElement {
   return (
     <>
       <p>Table to Filter</p>
-      <select id="inputDataContext" onChange={inputChange}>
-        <option selected disabled>
+      <select
+        id="inputDataContext"
+        onChange={inputChange}
+        defaultValue="default"
+      >
+        <option disabled value="default">
           Select a Data Context
         </option>
         {dataContexts.map((dataContext) => (


### PR DESCRIPTION
This gets rid of the warning when running tests, by using the `defaultValue` property to indicate which `<option>` the selects should have selected by default ("Select a Transformation" and "Select a Data Context"). 

I think this is fine, let me know if there's a better way to remove this warning.