### PR TITLE
add count

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import "./Transformation.css";
 import Error from "./Error";
 import { Filter } from "./transformation-components/Filter";
+import { Count } from "./transformation-components/Count";
 
 /**
  * Transformation represents an instance of the plugin, which applies a
@@ -16,9 +17,10 @@ function Transformation(): ReactElement {
    */
   enum TransformType {
     Filter = "Filter",
+    Count = "Count",
   }
 
-  const transformTypes = [TransformType.Filter];
+  const transformTypes = [TransformType.Filter, TransformType.Count];
 
   const [transformType, setTransformType] =
     useState<TransformType | null>(null);
@@ -26,6 +28,7 @@ function Transformation(): ReactElement {
 
   const transformComponents = {
     Filter: <Filter setErrMsg={setErrMsg} />,
+    Count: <Count setErrMsg={setErrMsg} />,
   };
 
   function typeChange(event: React.ChangeEvent<HTMLSelectElement>) {

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect, useCallback, ReactElement } from "react";
+import {
+  getDataFromContext,
+  setContextItems,
+  addContextUpdateListener,
+  removeContextUpdateListener,
+  createTableWithDataSet,
+  getDataContext,
+} from "../utils/codapPhone";
+import { useDataContexts, useInput } from "../utils/hooks";
+import { count } from "../transformations/count";
+
+interface CountProps {
+  setErrMsg: (s: string | null) => void;
+}
+
+export function Count({ setErrMsg }: CountProps): ReactElement {
+  const [inputDataCtxt, inputChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+  const [attributeName, attributeNameChange] = useInput<
+    string,
+    HTMLInputElement
+  >("", () => setErrMsg(null));
+  const dataContexts = useDataContexts();
+  const [lastContextName, setLastContextName] = useState<string | null>(null);
+
+  /**
+   * Applies the user-defined transformation to the indicated input data,
+   * and generates an output table into CODAP containing the transformed data.
+   */
+  const transform = useCallback(
+    async (doUpdate: boolean) => {
+      if (inputDataCtxt === null) {
+        setErrMsg("Please choose a valid data context to transform.");
+        return;
+      }
+
+      console.log(`Data context to count: ${inputDataCtxt}`);
+      console.log(`Attribute to count:\n${attributeName}`);
+
+      const dataset = {
+        collections: (await getDataContext(inputDataCtxt)).collections,
+        records: await getDataFromContext(inputDataCtxt),
+      };
+
+      try {
+        const counted = count(dataset, attributeName);
+
+        console.log(counted);
+
+        // if doUpdate is true then we should update a previously created table
+        // rather than creating a new one
+        if (doUpdate) {
+          if (!lastContextName) {
+            setErrMsg("Please apply transformation to a new table first.");
+            return;
+          }
+
+          // TODO: this won't work either.
+          setContextItems(lastContextName, counted.records);
+        } else {
+          const [newContext] = await createTableWithDataSet(counted);
+          setLastContextName(newContext.name);
+        }
+      } catch (e) {
+        setErrMsg(e.message);
+      }
+    },
+    [inputDataCtxt, attributeName, lastContextName, setErrMsg]
+  );
+
+  useEffect(() => {
+    if (inputDataCtxt !== null) {
+      addContextUpdateListener(inputDataCtxt, () => {
+        transform(true);
+      });
+      return () => removeContextUpdateListener(inputDataCtxt);
+    }
+  }, [transform, inputDataCtxt]);
+
+  return (
+    <>
+      <p>Table to Count</p>
+      <select
+        id="inputDataContext"
+        onChange={inputChange}
+        defaultValue="default"
+      >
+        <option disabled value="default">
+          Select a Data Context
+        </option>
+        {dataContexts.map((dataContext) => (
+          <option key={dataContext.name} value={dataContext.name}>
+            {dataContext.title} ({dataContext.name})
+          </option>
+        ))}
+      </select>
+
+      <p>Attribute to Count</p>
+      <input type="text" onChange={attributeNameChange}></input>
+
+      <br />
+      <button onClick={() => transform(false)}>Count attribute!</button>
+      <button onClick={() => transform(true)} disabled={!lastContextName}>
+        Update previous count
+      </button>
+    </>
+  );
+}

--- a/src/transformations/count.ts
+++ b/src/transformations/count.ts
@@ -1,0 +1,62 @@
+import { DataSet } from "./types";
+import { CodapAttribute, Collection } from "../utils/codapPhone/types";
+
+// TODO: allow for two modes:
+//  1) treat data like one table, values are counted across all cases
+//  2) treat hierarchy as subtables, values are counted *within subtable*
+
+/**
+ * Count consumes a dataset and attribute name and produces a new
+ * dataset that presents a summary of the frequency of difference
+ * values of that attribute in the input dataset.
+ *
+ * The output dataset has one collection with two attributes under
+ * the counted attribute name and `count`, which list all distinct values
+ * of the attribute, and the number of times each value occurred, respectively.
+ */
+export function count(dataset: DataSet, attribute: string): DataSet {
+  // find the attribute corresponding to given attribute name
+  let attr: undefined | CodapAttribute;
+  for (const coll of dataset.collections) {
+    attr = coll.attrs?.find((attr) => attr.name === attribute);
+    if (attr) {
+      break;
+    }
+  }
+
+  // ensure attribute exists
+  if (attr === undefined) {
+    throw new Error(`invalid attribute name: ${attribute}`);
+  }
+
+  // isolate values under this attribute
+  const values = dataset.records.map((record) => record[attribute]);
+  const distinctValues = Array.from(new Set(values));
+
+  // count occurrences of each distinct value under this attribute
+  const records: Record<string, unknown>[] = distinctValues.map((value) => {
+    const record: Record<string, unknown> = {};
+    record[attribute] = value;
+    record["count"] = values.filter((v) => v === value).length;
+    return record;
+  });
+
+  // construct collection with value/count attributes only
+  const collections: Collection[] = [
+    {
+      name: `Count (${attribute})`,
+      labels: {},
+      attrs: [
+        // first attribute is a copy of the original
+        { ...attr },
+        // second attribute is "count", containing all counts
+        { name: "count" },
+      ],
+    },
+  ];
+
+  return {
+    collections,
+    records,
+  };
+}


### PR DESCRIPTION
Adds a count transformation (as described [here](https://github.com/brownplt/B2T2/blob/main/TableAPI.md#count--t1table--ccolname---t2table)) which allows counting the frequency of distinct values under a given attribute.

This seems to work fine as an initial implementation, but I have a few thoughts: 

- It might be nice to have two "modes", one in which the counting is performed across the entire set of records (current implementation), and another in which it is performed locally for the records of each parent (ie, if the given attribute is part of a child collection, count within the records of the parents of that collection). I'm not sure what the output would look like for the latter.

- CODAP sometimes seems to use `""` to represent missing values, and count should probably take this into account. Right now, this shows up as a blank value in the values column, but we might consider displaying this with a better name ("N/A", or "Missing Value" maybe).

