### PR TITLE
add select attributes

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import "./Transformation.css";
 import Error from "./Error";
 import { Filter } from "./transformation-components/Filter";
+import { SelectAttributes } from "./transformation-components/SelectAttributes";
 
 /**
  * Transformation represents an instance of the plugin, which applies a
@@ -16,9 +17,10 @@ function Transformation(): ReactElement {
    */
   enum TransformType {
     Filter = "Filter",
+    SelectAttributes = "SelectAttributes",
   }
 
-  const transformTypes = [TransformType.Filter];
+  const transformTypes = [TransformType.Filter, TransformType.SelectAttributes];
 
   const [transformType, setTransformType] =
     useState<TransformType | null>(null);
@@ -26,6 +28,7 @@ function Transformation(): ReactElement {
 
   const transformComponents = {
     Filter: <Filter setErrMsg={setErrMsg} />,
+    SelectAttributes: <SelectAttributes setErrMsg={setErrMsg} />,
   };
 
   function typeChange(event: React.ChangeEvent<HTMLSelectElement>) {

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -1,0 +1,117 @@
+import React, { useState, useEffect, useCallback, ReactElement } from "react";
+import {
+  getDataFromContext,
+  setContextItems,
+  addContextUpdateListener,
+  removeContextUpdateListener,
+  createTableWithDataSet,
+  getDataContext,
+} from "../utils/codapPhone";
+import { useDataContexts, useInput } from "../utils/hooks";
+import { selectAttributes } from "../transformations/selectAttributes";
+
+interface SelectAttributesProps {
+  setErrMsg: (s: string | null) => void;
+}
+
+export function SelectAttributes({
+  setErrMsg,
+}: SelectAttributesProps): ReactElement {
+  const [inputDataCtxt, inputChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+  const [attributes, attributesChange] = useInput<string, HTMLTextAreaElement>(
+    "",
+    () => setErrMsg(null)
+  );
+  const dataContexts = useDataContexts();
+  const [lastContextName, setLastContextName] = useState<string | null>(null);
+
+  /**
+   * Applies the user-defined transformation to the indicated input data,
+   * and generates an output table into CODAP containing the transformed data.
+   */
+  const transform = useCallback(
+    async (doUpdate: boolean) => {
+      if (inputDataCtxt === null) {
+        setErrMsg("Please choose a valid data context to transform.");
+        return;
+      }
+
+      console.log(`Data context to select attributes from: ${inputDataCtxt}`);
+
+      const dataset = {
+        collections: (await getDataContext(inputDataCtxt)).collections,
+        records: await getDataFromContext(inputDataCtxt),
+      };
+
+      // extract attribute names from user's text
+      const attributeNames = attributes.split("\n").map((s) => s.trim());
+
+      try {
+        console.log("attributes to select:", attributeNames);
+
+        const selected = selectAttributes(dataset, attributeNames);
+
+        console.log("dataset with selected attrs:", selected);
+
+        // if doUpdate is true then we should update a previously created table
+        // rather than creating a new one
+        if (doUpdate) {
+          if (!lastContextName) {
+            setErrMsg("Please apply transformation to a new table first.");
+            return;
+          }
+
+          // TODO: this doesn't update the data context, only the records.
+          setContextItems(lastContextName, selected.records);
+        } else {
+          const [newContext] = await createTableWithDataSet(selected);
+          setLastContextName(newContext.name);
+        }
+      } catch (e) {
+        setErrMsg(e.message);
+      }
+    },
+    [inputDataCtxt, attributes, lastContextName, setErrMsg]
+  );
+
+  useEffect(() => {
+    if (inputDataCtxt !== null) {
+      addContextUpdateListener(inputDataCtxt, () => {
+        transform(true);
+      });
+      return () => removeContextUpdateListener(inputDataCtxt);
+    }
+  }, [transform, inputDataCtxt]);
+
+  return (
+    <>
+      <p>Table to Select Attributes From</p>
+      <select
+        id="inputDataContext"
+        onChange={inputChange}
+        defaultValue="default"
+      >
+        <option disabled value="default">
+          Select a Data Context
+        </option>
+        {dataContexts.map((dataContext) => (
+          <option key={dataContext.name} value={dataContext.name}>
+            {dataContext.title} ({dataContext.name})
+          </option>
+        ))}
+      </select>
+
+      <p>Attributes to Include in Output (1 per line)</p>
+      <textarea onChange={attributesChange}></textarea>
+
+      <br />
+      <button onClick={() => transform(false)}>Select attributes!</button>
+      <button onClick={() => transform(true)} disabled={!lastContextName}>
+        Update previous table
+      </button>
+    </>
+  );
+}

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, useCallback, ReactElement } from "react";
+import React, { useEffect, useCallback, ReactElement } from "react";
 import {
   getDataFromContext,
-  setContextItems,
   addContextUpdateListener,
   removeContextUpdateListener,
   createTableWithDataSet,
@@ -26,62 +25,36 @@ export function SelectAttributes({
     () => setErrMsg(null)
   );
   const dataContexts = useDataContexts();
-  const [lastContextName, setLastContextName] = useState<string | null>(null);
 
   /**
    * Applies the user-defined transformation to the indicated input data,
    * and generates an output table into CODAP containing the transformed data.
    */
-  const transform = useCallback(
-    async (doUpdate: boolean) => {
-      if (inputDataCtxt === null) {
-        setErrMsg("Please choose a valid data context to transform.");
-        return;
-      }
+  const transform = useCallback(async () => {
+    if (inputDataCtxt === null) {
+      setErrMsg("Please choose a valid data context to transform.");
+      return;
+    }
 
-      console.log(`Data context to select attributes from: ${inputDataCtxt}`);
+    const dataset = {
+      collections: (await getDataContext(inputDataCtxt)).collections,
+      records: await getDataFromContext(inputDataCtxt),
+    };
 
-      const dataset = {
-        collections: (await getDataContext(inputDataCtxt)).collections,
-        records: await getDataFromContext(inputDataCtxt),
-      };
+    // extract attribute names from user's text
+    const attributeNames = attributes.split("\n").map((s) => s.trim());
 
-      // extract attribute names from user's text
-      const attributeNames = attributes.split("\n").map((s) => s.trim());
-
-      try {
-        console.log("attributes to select:", attributeNames);
-
-        const selected = selectAttributes(dataset, attributeNames);
-
-        console.log("dataset with selected attrs:", selected);
-
-        // if doUpdate is true then we should update a previously created table
-        // rather than creating a new one
-        if (doUpdate) {
-          if (!lastContextName) {
-            setErrMsg("Please apply transformation to a new table first.");
-            return;
-          }
-
-          // TODO: this doesn't update the data context, only the records.
-          setContextItems(lastContextName, selected.records);
-        } else {
-          const [newContext] = await createTableWithDataSet(selected);
-          setLastContextName(newContext.name);
-        }
-      } catch (e) {
-        setErrMsg(e.message);
-      }
-    },
-    [inputDataCtxt, attributes, lastContextName, setErrMsg]
-  );
+    try {
+      const selected = selectAttributes(dataset, attributeNames);
+      await createTableWithDataSet(selected);
+    } catch (e) {
+      setErrMsg(e.message);
+    }
+  }, [inputDataCtxt, attributes, setErrMsg]);
 
   useEffect(() => {
     if (inputDataCtxt !== null) {
-      addContextUpdateListener(inputDataCtxt, () => {
-        transform(true);
-      });
+      addContextUpdateListener(inputDataCtxt, transform);
       return () => removeContextUpdateListener(inputDataCtxt);
     }
   }, [transform, inputDataCtxt]);
@@ -108,10 +81,7 @@ export function SelectAttributes({
       <textarea onChange={attributesChange}></textarea>
 
       <br />
-      <button onClick={() => transform(false)}>Select attributes!</button>
-      <button onClick={() => transform(true)} disabled={!lastContextName}>
-        Update previous table
-      </button>
+      <button onClick={() => transform()}>Select attributes!</button>
     </>
   );
 }

--- a/src/transformations/selectAttributes.ts
+++ b/src/transformations/selectAttributes.ts
@@ -1,0 +1,47 @@
+import { DataSet } from "./types";
+import { reparent } from "./util";
+
+/**
+ * Constructs a dataset with only the indicated attributes from the
+ * input dataset included, and all others removed.
+ */
+export function selectAttributes(
+  dataset: DataSet,
+  attributes: string[]
+): DataSet {
+  // copy records, but only the selected attributes
+  const records = [];
+  for (const record of dataset.records) {
+    const copy: Record<string, unknown> = {};
+    for (const attrName of attributes) {
+      // attribute does not appear on record, error
+      if (record[attrName] === undefined) {
+        throw new Error(`invalid attribute name: ${attrName}`);
+      }
+
+      copy[attrName] = record[attrName];
+    }
+    records.push(copy);
+  }
+
+  // copy collections
+  const allCollections = dataset.collections.slice();
+  const collections = [];
+
+  // filter out any attributes that aren't in the selected list
+  for (const coll of allCollections) {
+    coll.attrs = coll.attrs?.filter((attr) => attributes.includes(attr.name));
+
+    // keep only collections that have at least one attribute
+    if (coll.attrs === undefined || coll.attrs.length > 0) {
+      collections.push(coll);
+    } else {
+      reparent(allCollections, coll);
+    }
+  }
+
+  return {
+    collections,
+    records,
+  };
+}

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -1,5 +1,6 @@
 import { Env } from "../language/interpret";
 import { Value } from "../language/ast";
+import { Collection } from "../utils/codapPhone/types";
 
 /**
  * Converts a data item object into an environment for our language. Only
@@ -30,4 +31,19 @@ export function dataItemToEnv(dataItem: Record<string, unknown>): Env {
       return [key, value as Value];
     })
   );
+}
+
+/**
+ * Reparents any collections that have the given parent, to the
+ * parent's parent. This allows the parent to be eliminated.
+ *
+ * @param collections the collections to reparent
+ * @param parent the parent collection being removed
+ */
+export function reparent(collections: Collection[], parent: Collection): void {
+  for (const coll of collections) {
+    if (coll.parent === parent.name) {
+      coll.parent = parent.parent;
+    }
+  }
 }


### PR DESCRIPTION
This transformation (detailed [here](https://github.com/brownplt/B2T2/blob/main/TableAPI.md#overload-33-selectcolumns--t1table--selectorseqcolname---t2table)) allows you to create a new dataset and cherry pick which attributes to include from the original. 

If a collection consists entirely of attributes that were not included in the output, it is removed and its children re-parented.

Currently, the "update" functionality still doesn't work since we need a way of updating data contexts that accounts for structural changes like this.