### PR TITLE
add build column

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -5,6 +5,7 @@ import "./Transformation.css";
 import Error from "./Error";
 import { Filter } from "./transformation-components/Filter";
 import { TransformColumn } from "./transformation-components/TransformColumn";
+import { BuildColumn } from "./transformation-components/BuildColumn";
 
 /**
  * Transformation represents an instance of the plugin, which applies a
@@ -18,9 +19,14 @@ function Transformation(): ReactElement {
   enum TransformType {
     Filter = "Filter",
     TransformColumn = "TransformColumn",
+    BuildColumn = "BuildColumn",
   }
 
-  const transformTypes = [TransformType.Filter, TransformType.TransformColumn];
+  const transformTypes = [
+    TransformType.Filter,
+    TransformType.TransformColumn,
+    TransformType.BuildColumn,
+  ];
 
   const [transformType, setTransformType] =
     useState<TransformType | null>(null);
@@ -29,6 +35,7 @@ function Transformation(): ReactElement {
   const transformComponents = {
     Filter: <Filter setErrMsg={setErrMsg} />,
     TransformColumn: <TransformColumn setErrMsg={setErrMsg} />,
+    BuildColumn: <BuildColumn setErrMsg={setErrMsg} />,
   };
 
   function typeChange(event: React.ChangeEvent<HTMLSelectElement>) {

--- a/src/transformation-components/BuildColumn.tsx
+++ b/src/transformation-components/BuildColumn.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useCallback, ReactElement } from "react";
+import {
+  getDataFromContext,
+  addContextUpdateListener,
+  removeContextUpdateListener,
+  createTableWithDataSet,
+  getDataContext,
+} from "../utils/codapPhone";
+import { useDataContexts, useInput } from "../utils/hooks";
+import { buildColumn } from "../transformations/buildColumn";
+
+interface BuildColumnProps {
+  setErrMsg: (s: string | null) => void;
+}
+
+export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
+  const [inputDataCtxt, inputChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+  const [attributeName, attributeNameChange] = useInput<
+    string,
+    HTMLInputElement
+  >("", () => setErrMsg(null));
+  const [collectionName, collectionNameChange] = useInput<
+    string,
+    HTMLInputElement
+  >("", () => setErrMsg(null));
+  const [expression, expressionChange] = useInput<string, HTMLTextAreaElement>(
+    "",
+    () => setErrMsg(null)
+  );
+  const dataContexts = useDataContexts();
+
+  /**
+   * Applies the user-defined transformation to the indicated input data,
+   * and generates an output table into CODAP containing the transformed data.
+   */
+  const transform = useCallback(async () => {
+    if (inputDataCtxt === null) {
+      setErrMsg("Please choose a valid data context to transform.");
+      return;
+    }
+    if (attributeName === "") {
+      setErrMsg("Please enter a non-empty name for the new attribute");
+      return;
+    }
+    if (collectionName === "") {
+      setErrMsg("Please enter a non-empty collection name to add to");
+      return;
+    }
+    if (expression === "") {
+      setErrMsg("Please enter a non-empty expression");
+      return;
+    }
+
+    const dataset = {
+      collections: (await getDataContext(inputDataCtxt)).collections,
+      records: await getDataFromContext(inputDataCtxt),
+    };
+
+    try {
+      const built = buildColumn(
+        dataset,
+        attributeName,
+        collectionName,
+        expression
+      );
+      await createTableWithDataSet(built);
+    } catch (e) {
+      setErrMsg(e.message);
+    }
+  }, [inputDataCtxt, attributeName, collectionName, expression, setErrMsg]);
+
+  useEffect(() => {
+    if (inputDataCtxt !== null) {
+      addContextUpdateListener(inputDataCtxt, transform);
+      return () => removeContextUpdateListener(inputDataCtxt);
+    }
+  }, [transform, inputDataCtxt]);
+
+  return (
+    <>
+      <p>Table to Add Attribute To</p>
+      <select
+        id="inputDataContext"
+        onChange={inputChange}
+        defaultValue="default"
+      >
+        <option disabled value="default">
+          Select a Data Context
+        </option>
+        {dataContexts.map((dataContext) => (
+          <option key={dataContext.name} value={dataContext.name}>
+            {dataContext.title} ({dataContext.name})
+          </option>
+        ))}
+      </select>
+
+      <p>Name of New Attribute</p>
+      <input type="text" onChange={attributeNameChange} />
+
+      <p>Collection to Add To</p>
+      <input type="text" onChange={collectionNameChange} />
+
+      <p>Formula for Attribute Values</p>
+      <textarea onChange={expressionChange}></textarea>
+
+      <br />
+      <button onClick={transform}>Create table with attribute added</button>
+    </>
+  );
+}

--- a/src/transformation-components/TransformColumn.tsx
+++ b/src/transformation-components/TransformColumn.tsx
@@ -14,15 +14,17 @@ interface TransformColumnProps {
   setErrMsg: (s: string | null) => void;
 }
 
-export function TransformColumn({ setErrMsg }: TransformColumnProps): ReactElement {
+export function TransformColumn({
+  setErrMsg,
+}: TransformColumnProps): ReactElement {
   const [inputDataCtxt, inputChange] = useInput<
     string | null,
     HTMLSelectElement
   >(null, () => setErrMsg(null));
-  const [attributeName, attributeNameChange] = useInput<string, HTMLInputElement>(
-    "",
-    () => setErrMsg(null)
-  );
+  const [attributeName, attributeNameChange] = useInput<
+    string,
+    HTMLInputElement
+  >("", () => setErrMsg(null));
   const [expression, expressionChange] = useInput<string, HTMLTextAreaElement>(
     "",
     () => setErrMsg(null)
@@ -104,7 +106,7 @@ export function TransformColumn({ setErrMsg }: TransformColumnProps): ReactEleme
       </select>
 
       <p>Attribute to Transform</p>
-      <input type="text" onChange={attributeNameChange}/>
+      <input type="text" onChange={attributeNameChange} />
 
       <p>How to Transform Column</p>
       <textarea onChange={expressionChange}></textarea>

--- a/src/transformations/buildColumn.ts
+++ b/src/transformations/buildColumn.ts
@@ -1,0 +1,52 @@
+import { DataSet } from "./types";
+import { dataItemToEnv } from "./util";
+import { evaluate } from "../language";
+
+/**
+ * Builds a dataset with a new attribute added to one of the collections,
+ * whose case values are computed by evaluating the given expression.
+ */
+export function buildColumn(
+  dataset: DataSet,
+  newAttributeName: string,
+  collectionName: string,
+  expression: string
+): DataSet {
+  // find collection to add attribute to
+  const collections = dataset.collections.slice();
+  const toAdd = collections.find((coll) => coll.name === collectionName);
+
+  if (toAdd === undefined) {
+    throw new Error(`invalid collection name: ${collectionName}`);
+  }
+
+  // ensure no duplicate attr names
+  if (
+    collections.find((coll) =>
+      coll.attrs?.find((attr) => attr.name === newAttributeName)
+    )
+  ) {
+    throw new Error(`attribute name already in use: ${newAttributeName}`);
+  }
+
+  if (toAdd.attrs === undefined) {
+    toAdd.attrs = [];
+  }
+
+  // add new attribute
+  toAdd.attrs.push({
+    name: newAttributeName,
+  });
+
+  // add new values for this attribute to each record
+  const records = dataset.records.slice();
+  for (const record of records) {
+    const env = dataItemToEnv(record);
+    record[newAttributeName] = evaluate(expression, env).content;
+  }
+
+  return {
+    collections,
+    records,
+  };
+}

--- a/src/transformations/transformColumn.ts
+++ b/src/transformations/transformColumn.ts
@@ -7,7 +7,11 @@ import { evaluate } from "../language";
  * to be the result of evaluating the given expression in the context
  * of each case.
  */
-export function transformColumn(dataset: DataSet, attributeName: string, expression: string): DataSet {
+export function transformColumn(
+  dataset: DataSet,
+  attributeName: string,
+  expression: string
+): DataSet {
   const records = dataset.records.slice();
   for (const record of records) {
     if (record[attributeName] === undefined) {


### PR DESCRIPTION
Adds a build column transformation that allows you to construct new columns by evaluating an expression at every record and putting the result under a new attribute. The user gets to select which collection to put the new column under. 

If a child attribute is referenced when building on a parent collection, the parent cases will just change their grouping based on how the child attribute differentiates between cases that previously had no differentiation at the parent level. 