### PR TITLE
Standardize component UI and functionality

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -21,6 +21,47 @@ import {
   runningMax,
   difference,
 } from "./transformations/fold";
+import { getAllAttributes, getAllDataContexts } from "./utils/codapPhone";
+import { CodapAttribute, CodapIdentifyingInfo } from "./utils/codapPhone/types";
+
+type CompareState = {
+  dataContexts: string[];
+  selectedDataContext: string | null;
+  attributes: string[];
+  selectedAttribute: string | null;
+};
+const CompareData = {
+  state: [
+    {
+      name: "dataContexts",
+      dependsOn: [],
+      refresh: async (_state: CompareState) => await getAllDataContexts(),
+    },
+    {
+      name: "selectedDataContext",
+      dependsOn: ["DataContexts"],
+      refresh: (_state: CompareState): string => "",
+    },
+    {
+      name: "attributes",
+      dependsOn: ["dataContexts", "selectedDataContext"],
+      refresh: async (state: CompareState): Promise<CodapIdentifyingInfo[]> =>
+        !state.selectedDataContext
+          ? []
+          : await getAllAttributes(state.selectedDataContext),
+    },
+    {
+      name: "selectedAttribute",
+      dependsOn: ["dataContexts", "selectedDataContext", "attributes"],
+      refresh: async (
+        state: CompareState
+      ): Promise<CodapIdentifyingInfo[] | null> =>
+        !state.dataContexts || !state.selectedDataContext || !state.attributes
+          ? null
+          : await getAllAttributes(state.selectedDataContext),
+    },
+  ],
+};
 
 /**
  * Transformation represents an instance of the plugin, which applies a

--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -21,6 +21,7 @@ import {
   runningMax,
   difference,
 } from "./transformations/fold";
+import { CodapFlowSelect } from "./ui-components";
 
 /**
  * Transformation represents an instance of the plugin, which applies a
@@ -74,14 +75,16 @@ function Transformation(): ReactElement {
   return (
     <div className="Transformation">
       <p>Transformation Type</p>
-      <select id="transformType" onChange={typeChange} defaultValue="default">
-        <option disabled value="default">
-          Select a Transformation
-        </option>
-        {Object.keys(transformComponents).map((type, i) => (
-          <option key={i}>{type}</option>
-        ))}
-      </select>
+      <CodapFlowSelect
+        onChange={typeChange}
+        options={Object.keys(transformComponents).map((type) => ({
+          value: type,
+          title: type,
+        }))}
+        value={transformType}
+        defaultValue="Select a transformation"
+      />
+
       {transformType && transformComponents[transformType]}
 
       <Error message={errMsg} />

--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -36,29 +36,29 @@ function Transformation(): ReactElement {
    */
   const transformComponents = {
     Filter: <Filter setErrMsg={setErrMsg} />,
-    TransformColumn: <TransformColumn setErrMsg={setErrMsg} />,
-    BuildColumn: <BuildColumn setErrMsg={setErrMsg} />,
-    GroupBy: <GroupBy setErrMsg={setErrMsg} />,
-    SelectAttributes: <SelectAttributes setErrMsg={setErrMsg} />,
+    "Transform Column": <TransformColumn setErrMsg={setErrMsg} />,
+    "Build Column": <BuildColumn setErrMsg={setErrMsg} />,
+    "Group By": <GroupBy setErrMsg={setErrMsg} />,
+    "Select Attributes": <SelectAttributes setErrMsg={setErrMsg} />,
     Count: <Count setErrMsg={setErrMsg} />,
     Flatten: <Flatten setErrMsg={setErrMsg} />,
     Compare: <Compare setErrMsg={setErrMsg} />,
-    RunningSum: (
+    "Running Sum": (
       <Fold setErrMsg={setErrMsg} label="running sum" foldFunc={runningSum} />
     ),
-    RunningMean: (
+    "Running Mean": (
       <Fold setErrMsg={setErrMsg} label="running mean" foldFunc={runningMean} />
     ),
-    RunningMin: (
+    "Running Min": (
       <Fold setErrMsg={setErrMsg} label="running min" foldFunc={runningMin} />
     ),
-    RunningMax: (
+    "Running Max": (
       <Fold setErrMsg={setErrMsg} label="running max" foldFunc={runningMax} />
     ),
-    RunningDifference: (
+    "Running Difference": (
       <Fold setErrMsg={setErrMsg} label="difference" foldFunc={difference} />
     ),
-    DifferenceFrom: <DifferenceFrom setErrMsg={setErrMsg} />,
+    "Difference From": <DifferenceFrom setErrMsg={setErrMsg} />,
     Sort: <Sort setErrMsg={setErrMsg} />,
   };
 

--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -21,47 +21,6 @@ import {
   runningMax,
   difference,
 } from "./transformations/fold";
-import { getAllAttributes, getAllDataContexts } from "./utils/codapPhone";
-import { CodapAttribute, CodapIdentifyingInfo } from "./utils/codapPhone/types";
-
-type CompareState = {
-  dataContexts: string[];
-  selectedDataContext: string | null;
-  attributes: string[];
-  selectedAttribute: string | null;
-};
-const CompareData = {
-  state: [
-    {
-      name: "dataContexts",
-      dependsOn: [],
-      refresh: async (_state: CompareState) => await getAllDataContexts(),
-    },
-    {
-      name: "selectedDataContext",
-      dependsOn: ["DataContexts"],
-      refresh: (_state: CompareState): string => "",
-    },
-    {
-      name: "attributes",
-      dependsOn: ["dataContexts", "selectedDataContext"],
-      refresh: async (state: CompareState): Promise<CodapIdentifyingInfo[]> =>
-        !state.selectedDataContext
-          ? []
-          : await getAllAttributes(state.selectedDataContext),
-    },
-    {
-      name: "selectedAttribute",
-      dependsOn: ["dataContexts", "selectedDataContext", "attributes"],
-      refresh: async (
-        state: CompareState
-      ): Promise<CodapIdentifyingInfo[] | null> =>
-        !state.dataContexts || !state.selectedDataContext || !state.attributes
-          ? null
-          : await getAllAttributes(state.selectedDataContext),
-    },
-  ],
-};
 
 /**
  * Transformation represents an instance of the plugin, which applies a

--- a/src/transformation-components/BuildColumn.tsx
+++ b/src/transformation-components/BuildColumn.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback, ReactElement } from "react";
 import { getDataSet } from "../utils/codapPhone";
 import {
-  useDataContexts,
   useInput,
   useContextUpdateListenerWithFlowEffect,
 } from "../utils/hooks";
@@ -10,8 +9,8 @@ import { applyNewDataSet } from "./util";
 import {
   CodapFlowTextArea,
   CodapFlowTextInput,
-  CodapFlowSelect,
   TransformationSubmitButtons,
+  ContextSelector,
 } from "../ui-components";
 
 interface BuildColumnProps {
@@ -35,7 +34,6 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
     "",
     () => setErrMsg(null)
   );
-  const dataContexts = useDataContexts();
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
@@ -104,15 +102,7 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
   return (
     <>
       <p>Table to Add Attribute To</p>
-      <CodapFlowSelect
-        onChange={inputChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
-        value={inputDataCtxt}
-        defaultValue="Select a Data Context"
-      />
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
       <p>Name of New Attribute</p>
       <CodapFlowTextInput
         value={attributeName}

--- a/src/transformation-components/BuildColumn.tsx
+++ b/src/transformation-components/BuildColumn.tsx
@@ -108,7 +108,7 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
         onChange={inputChange}
         options={dataContexts.map((dataContext) => ({
           value: dataContext.name,
-          title: `${dataContext.title} (${dataContext.name})`,
+          title: dataContext.title,
         }))}
         value={inputDataCtxt}
         defaultValue="Select a Data Context"

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -1,16 +1,7 @@
-import React, { useState, useCallback, ReactElement, useEffect } from "react";
-import {
-  getDataFromContext,
-  setContextItems,
-  createTableWithDataSet,
-  getDataContext,
-  addContextUpdateListener,
-  removeContextUpdateListener,
-  getDataSet,
-} from "../utils/codapPhone";
+import React, { useState, useCallback, ReactElement } from "react";
+import { getDataSet } from "../utils/codapPhone";
 import {
   useAttributes,
-  useContextUpdateListener,
   useContextUpdateListenerWithFlowEffect,
   useDataContexts,
   useInput,

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -1,13 +1,16 @@
 import React, { useState, useCallback, ReactElement } from "react";
 import { getDataSet } from "../utils/codapPhone";
 import {
-  useAttributes,
   useContextUpdateListenerWithFlowEffect,
-  useDataContexts,
   useInput,
 } from "../utils/hooks";
 import { compare } from "../transformations/compare";
-import { CodapFlowSelect, TransformationSubmitButtons } from "../ui-components";
+import {
+  CodapFlowSelect,
+  AttributeSelector,
+  ContextSelector,
+  TransformationSubmitButtons,
+} from "../ui-components";
 import { applyNewDataSet } from "./util";
 
 interface CompareProps {
@@ -31,10 +34,6 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
     string | null,
     HTMLSelectElement
   >(null, () => setErrMsg(null));
-
-  const dataContexts = useDataContexts();
-  const attributes1 = useAttributes(inputDataContext1);
-  const attributes2 = useAttributes(inputDataContext2);
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
@@ -106,46 +105,28 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
   return (
     <>
       <p>Table to Compare 1</p>
-      <CodapFlowSelect
-        onChange={inputDataContext1OnChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
+      <ContextSelector
         value={inputDataContext1}
-        defaultValue="Select a Data Context"
+        onChange={inputDataContext1OnChange}
       />
       <p>Table to Compare 2</p>
-      <CodapFlowSelect
-        onChange={inputDataContext2OnChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
+      <ContextSelector
         value={inputDataContext2}
-        defaultValue="Select a Data Context"
+        onChange={inputDataContext2OnChange}
       />
 
       <p>First attribute to Compare</p>
-      <CodapFlowSelect
+      <AttributeSelector
         onChange={inputAttribute1OnChange}
-        options={attributes1.map((attribute) => ({
-          value: attribute.name,
-          title: `${attribute.title} (${attribute.name})`,
-        }))}
         value={inputAttribute1}
-        defaultValue="Select an attribute"
+        context={inputDataContext1}
       />
 
       <p>Second attribute to Compare</p>
-      <CodapFlowSelect
+      <AttributeSelector
         onChange={inputAttribute2OnChange}
-        options={attributes2.map((attribute) => ({
-          value: attribute.name,
-          title: `${attribute.title} (${attribute.name})`,
-        }))}
         value={inputAttribute2}
-        defaultValue="Select an attribute"
+        context={inputDataContext2}
       />
 
       <p>What kind of Comparison?</p>

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -6,6 +6,7 @@ import {
   getDataContext,
   addContextUpdateListener,
   removeContextUpdateListener,
+  getDataSet,
 } from "../utils/codapPhone";
 import { useAttributes, useDataContexts, useInput } from "../utils/hooks";
 import { compare } from "../transformations/compare";
@@ -53,15 +54,8 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
         return;
       }
 
-      // FIXME: perhaps a wrapper function for making a dataset from a context name?
-      const dataset1 = {
-        collections: (await getDataContext(inputDataContext1)).collections,
-        records: await getDataFromContext(inputDataContext1),
-      };
-      const dataset2 = {
-        collections: (await getDataContext(inputDataContext2)).collections,
-        records: await getDataFromContext(inputDataContext2),
-      };
+      const dataset1 = await getDataSet(inputDataContext1);
+      const dataset2 = await getDataSet(inputDataContext2);
 
       const compared = compare(
         dataset1,

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -8,7 +8,13 @@ import {
   removeContextUpdateListener,
   getDataSet,
 } from "../utils/codapPhone";
-import { useAttributes, useDataContexts, useInput } from "../utils/hooks";
+import {
+  useAttributes,
+  useContextUpdateListener,
+  useContextUpdateListenerWithFlowEffect,
+  useDataContexts,
+  useInput,
+} from "../utils/hooks";
 import { compare } from "../transformations/compare";
 import { CodapFlowSelect, TransformationSubmitButtons } from "../ui-components";
 
@@ -18,21 +24,21 @@ interface CompareProps {
 
 export function Compare({ setErrMsg }: CompareProps): ReactElement {
   const [inputDataContext1, inputDataContext1OnChange] = useInput<
-    string,
+    string | null,
     HTMLSelectElement
-  >("", () => setErrMsg(null));
+  >(null, () => setErrMsg(null));
   const [inputDataContext2, inputDataContext2OnChange] = useInput<
-    string,
+    string | null,
     HTMLSelectElement
-  >("", () => setErrMsg(null));
+  >(null, () => setErrMsg(null));
   const [inputAttribute1, inputAttribute1OnChange] = useInput<
-    string,
+    string | null,
     HTMLSelectElement
-  >("", () => setErrMsg(null));
+  >(null, () => setErrMsg(null));
   const [inputAttribute2, inputAttribute2OnChange] = useInput<
-    string,
+    string | null,
     HTMLSelectElement
-  >("", () => setErrMsg(null));
+  >(null, () => setErrMsg(null));
 
   const dataContexts = useDataContexts();
   const attributes1 = useAttributes(inputDataContext1);
@@ -93,26 +99,23 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
     ]
   );
 
-  // FIXME: can we find a way to make these update listeners more automatic?
-  // Listen for updates to first data context
-  useEffect(() => {
-    if (inputDataContext1 !== null) {
-      addContextUpdateListener(inputDataContext1, () => {
-        transform(true);
-      });
-      return () => removeContextUpdateListener(inputDataContext1);
-    }
-  }, [transform, inputDataContext1]);
+  useContextUpdateListenerWithFlowEffect(
+    inputDataContext1,
+    lastContextName,
+    () => {
+      transform(true);
+    },
+    [transform]
+  );
 
-  // Listen for updates to second data context
-  useEffect(() => {
-    if (inputDataContext2 !== null) {
-      addContextUpdateListener(inputDataContext2, () => {
-        transform(true);
-      });
-      return () => removeContextUpdateListener(inputDataContext2);
-    }
-  }, [transform, inputDataContext2]);
+  useContextUpdateListenerWithFlowEffect(
+    inputDataContext2,
+    lastContextName,
+    () => {
+      transform(true);
+    },
+    [transform]
+  );
 
   return (
     <>

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -110,7 +110,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
         onChange={inputDataContext1OnChange}
         options={dataContexts.map((dataContext) => ({
           value: dataContext.name,
-          title: `${dataContext.title} (${dataContext.name})`,
+          title: dataContext.title,
         }))}
         value={inputDataContext1}
         defaultValue="Select a Data Context"
@@ -120,7 +120,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
         onChange={inputDataContext2OnChange}
         options={dataContexts.map((dataContext) => ({
           value: dataContext.name,
-          title: `${dataContext.title} (${dataContext.name})`,
+          title: dataContext.title,
         }))}
         value={inputDataContext2}
         defaultValue="Select a Data Context"

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -55,20 +55,24 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
       const dataset1 = await getDataSet(inputDataContext1);
       const dataset2 = await getDataSet(inputDataContext2);
 
-      const compared = compare(
-        dataset1,
-        dataset2,
-        inputAttribute1,
-        inputAttribute2,
-        isCategorical
-      );
-      await applyNewDataSet(
-        compared,
-        doUpdate,
-        lastContextName,
-        setLastContextName,
-        setErrMsg
-      );
+      try {
+        const compared = compare(
+          dataset1,
+          dataset2,
+          inputAttribute1,
+          inputAttribute2,
+          isCategorical
+        );
+        await applyNewDataSet(
+          compared,
+          doUpdate,
+          lastContextName,
+          setLastContextName,
+          setErrMsg
+        );
+      } catch (e) {
+        setErrMsg(e.message);
+      }
     },
     [
       inputDataContext1,

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -9,8 +9,7 @@ import {
 } from "../utils/codapPhone";
 import { useAttributes, useDataContexts, useInput } from "../utils/hooks";
 import { compare } from "../transformations/compare";
-import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
-import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
+import { CodapFlowSelect, TransformationSubmitButtons } from "../ui-components";
 
 interface CompareProps {
   setErrMsg: (s: string | null) => void;

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -17,6 +17,7 @@ import {
 } from "../utils/hooks";
 import { compare } from "../transformations/compare";
 import { CodapFlowSelect, TransformationSubmitButtons } from "../ui-components";
+import { applyNewDataSet } from "./util";
 
 interface CompareProps {
   setErrMsg: (s: string | null) => void;
@@ -70,23 +71,13 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
         inputAttribute2,
         isCategorical
       );
-      try {
-        // FIXME: wrap up this update vs. create logic in a function
-        // if doUpdate is true then we should update a previously created table
-        // rather than creating a new one
-        if (doUpdate) {
-          if (!lastContextName) {
-            setErrMsg("Please apply transformation to a new table first.");
-            return;
-          }
-          setContextItems(lastContextName, compared.records);
-        } else {
-          const [newContext] = await createTableWithDataSet(compared);
-          setLastContextName(newContext.name);
-        }
-      } catch (e) {
-        setErrMsg(e.message);
-      }
+      await applyNewDataSet(
+        compared,
+        doUpdate,
+        lastContextName,
+        setLastContextName,
+        setErrMsg
+      );
     },
     [
       inputDataContext1,

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -141,7 +141,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
           { value: "numeric", title: "Numeric" },
         ]}
         value={inputAttribute2}
-        defaultValue="numeric"
+        defaultValue="Select a type"
       />
 
       <br />

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -9,6 +9,8 @@ import {
 } from "../utils/codapPhone";
 import { useAttributes, useDataContexts, useInput } from "../utils/hooks";
 import { compare } from "../transformations/compare";
+import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
+import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
 
 interface CompareProps {
   setErrMsg: (s: string | null) => void;
@@ -52,6 +54,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
         return;
       }
 
+      // FIXME: perhaps a wrapper function for making a dataset from a context name?
       const dataset1 = {
         collections: (await getDataContext(inputDataContext1)).collections,
         records: await getDataFromContext(inputDataContext1),
@@ -61,15 +64,15 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
         records: await getDataFromContext(inputDataContext2),
       };
 
+      const compared = compare(
+        dataset1,
+        dataset2,
+        inputAttribute1,
+        inputAttribute2,
+        isCategorical
+      );
       try {
-        const compared = compare(
-          dataset1,
-          dataset2,
-          inputAttribute1,
-          inputAttribute2,
-          isCategorical
-        );
-
+        // FIXME: wrap up this update vs. create logic in a function
         // if doUpdate is true then we should update a previously created table
         // rather than creating a new one
         if (doUpdate) {
@@ -97,6 +100,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
     ]
   );
 
+  // FIXME: can we find a way to make these update listeners more automatic?
   // Listen for updates to first data context
   useEffect(() => {
     if (inputDataContext1 !== null) {
@@ -120,89 +124,69 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
   return (
     <>
       <p>Table to Compare 1</p>
-      <select
-        id="inputDataContext1"
+      <CodapFlowSelect
         onChange={inputDataContext1OnChange}
-        defaultValue="default"
-      >
-        <option disabled value="default">
-          Select a Data Context
-        </option>
-        {dataContexts.map((dataContext) => (
-          <option key={dataContext.name} value={dataContext.name}>
-            {dataContext.title} ({dataContext.name})
-          </option>
-        ))}
-      </select>
+        options={dataContexts.map((dataContext) => ({
+          value: dataContext.name,
+          title: `${dataContext.title} (${dataContext.name})`,
+        }))}
+        value={inputDataContext1}
+        defaultValue="Select a Data Context"
+      />
       <p>Table to Compare 2</p>
-      <select
-        id="inputDataContext2"
+      <CodapFlowSelect
         onChange={inputDataContext2OnChange}
-        defaultValue="default"
-      >
-        <option disabled value="default">
-          Select a Data Context
-        </option>
-        {dataContexts.map((dataContext) => (
-          <option key={dataContext.name} value={dataContext.name}>
-            {dataContext.title} ({dataContext.name})
-          </option>
-        ))}
-      </select>
+        options={dataContexts.map((dataContext) => ({
+          value: dataContext.name,
+          title: `${dataContext.title} (${dataContext.name})`,
+        }))}
+        value={inputDataContext2}
+        defaultValue="Select a Data Context"
+      />
 
       <p>First attribute to Compare</p>
-      <select
-        id="inputAttribute1"
+      <CodapFlowSelect
         onChange={inputAttribute1OnChange}
-        defaultValue="default"
-      >
-        <option disabled value="default">
-          Select a attribute
-        </option>
-        {attributes1.map((attribute) => (
-          <option key={attribute.name} value={attribute.name}>
-            {attribute.title} ({attribute.name})
-          </option>
-        ))}
-      </select>
+        options={attributes1.map((attribute) => ({
+          value: attribute.name,
+          title: `${attribute.title} (${attribute.name})`,
+        }))}
+        value={inputAttribute1}
+        defaultValue="Select an attribute"
+      />
 
       <p>Second attribute to Compare</p>
-      <select
-        id="inputAttribute2"
+      <CodapFlowSelect
         onChange={inputAttribute2OnChange}
-        defaultValue="default"
-      >
-        <option disabled value="default">
-          Select a attribute
-        </option>
-        {attributes2.map((attribute) => (
-          <option key={attribute.name} value={attribute.name}>
-            {attribute.title} ({attribute.name})
-          </option>
-        ))}
-      </select>
+        options={attributes2.map((attribute) => ({
+          value: attribute.name,
+          title: `${attribute.title} (${attribute.name})`,
+        }))}
+        value={inputAttribute2}
+        defaultValue="Select an attribute"
+      />
+
       <p>What kind of Comparison?</p>
-      <select
-        id="isCategorical"
+      <CodapFlowSelect
         onChange={(e) =>
           e.target.value === "categorical"
             ? setIsCategorical(true)
             : setIsCategorical(false)
         }
+        options={[
+          { value: "categorical", title: "Categorical" },
+          { value: "numeric", title: "Numeric" },
+        ]}
+        value={inputAttribute2}
         defaultValue="numeric"
-      >
-        <option value="categorical">Categorical</option>
-        <option value="numeric">Numeric</option>
-      </select>
+      />
 
       <br />
-      <button onClick={() => transform(false)}>
-        Create Table with Comparison
-      </button>
-      <br />
-      <button onClick={() => transform(true)}>
-        Update Previous Table With Comparison
-      </button>
+      <TransformationSubmitButtons
+        onCreate={() => transform(false)}
+        onUpdate={() => transform(true)}
+        updateDisabled={!lastContextName}
+      />
     </>
   );
 }

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -5,6 +5,7 @@ import {
   removeContextUpdateListener,
   createTableWithDataSet,
   getDataContext,
+  getDataSet,
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { count } from "../transformations/count";
@@ -39,10 +40,7 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
       return;
     }
 
-    const dataset = {
-      collections: (await getDataContext(inputDataCtxt)).collections,
-      records: await getDataFromContext(inputDataCtxt),
-    };
+    const dataset = await getDataSet(inputDataCtxt);
 
     try {
       const counted = count(dataset, attributeName);

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -8,9 +8,11 @@ import {
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { count } from "../transformations/count";
-import { CodapFlowTextInput } from "../ui-components/CodapFlowTextInput";
-import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
-import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
+import {
+  CodapFlowTextInput,
+  CodapFlowSelect,
+  TransformationSubmitButtons,
+} from "../ui-components";
 
 interface CountProps {
   setErrMsg: (s: string | null) => void;

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -2,14 +2,13 @@ import React, { useCallback, ReactElement, useState } from "react";
 import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
-  useDataContexts,
   useInput,
 } from "../utils/hooks";
 import { count } from "../transformations/count";
 import {
-  CodapFlowTextInput,
-  CodapFlowSelect,
   TransformationSubmitButtons,
+  ContextSelector,
+  AttributeSelector,
 } from "../ui-components";
 import { applyNewDataSet } from "./util";
 
@@ -24,9 +23,8 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
   >(null, () => setErrMsg(null));
   const [attributeName, attributeNameChange] = useInput<
     string,
-    HTMLInputElement
+    HTMLSelectElement
   >("", () => setErrMsg(null));
-  const dataContexts = useDataContexts();
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
@@ -71,18 +69,11 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
   return (
     <>
       <p>Table to Count</p>
-      <CodapFlowSelect
-        onChange={inputChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
-        value={inputDataCtxt}
-        defaultValue="Select a Data Context"
-      />
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
 
       <p>Attribute to Count</p>
-      <CodapFlowTextInput
+      <AttributeSelector
+        context={inputDataCtxt}
         value={attributeName}
         onChange={attributeNameChange}
       />

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -56,7 +56,7 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
         setErrMsg(e.message);
       }
     },
-    [inputDataCtxt, attributeName, setErrMsg]
+    [inputDataCtxt, attributeName, setErrMsg, lastContextName]
   );
 
   useContextUpdateListenerWithFlowEffect(

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -8,6 +8,9 @@ import {
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { count } from "../transformations/count";
+import { CodapFlowTextInput } from "../ui-components/CodapFlowTextInput";
+import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
+import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
 
 interface CountProps {
   setErrMsg: (s: string | null) => void;
@@ -57,26 +60,28 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
   return (
     <>
       <p>Table to Count</p>
-      <select
-        id="inputDataContext"
+      <CodapFlowSelect
         onChange={inputChange}
-        defaultValue="default"
-      >
-        <option disabled value="default">
-          Select a Data Context
-        </option>
-        {dataContexts.map((dataContext) => (
-          <option key={dataContext.name} value={dataContext.name}>
-            {dataContext.title} ({dataContext.name})
-          </option>
-        ))}
-      </select>
+        options={dataContexts.map((dataContext) => ({
+          value: dataContext.name,
+          title: `${dataContext.title} (${dataContext.name})`,
+        }))}
+        value={inputDataCtxt}
+        defaultValue="Select a Data Context"
+      />
 
       <p>Attribute to Count</p>
-      <input type="text" onChange={attributeNameChange}></input>
+      <CodapFlowTextInput
+        value={attributeName}
+        onChange={attributeNameChange}
+      />
 
       <br />
-      <button onClick={() => transform()}>Count attribute!</button>
+      <TransformationSubmitButtons
+        onCreate={() => transform()}
+        onUpdate={() => transform()}
+        updateDisabled={true}
+      />
     </>
   );
 }

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -1,12 +1,5 @@
-import React, { useEffect, useCallback, ReactElement, useState } from "react";
-import {
-  getDataFromContext,
-  addContextUpdateListener,
-  removeContextUpdateListener,
-  createTableWithDataSet,
-  getDataContext,
-  getDataSet,
-} from "../utils/codapPhone";
+import React, { useCallback, ReactElement, useState } from "react";
+import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useDataContexts,

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -75,7 +75,7 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
         onChange={inputChange}
         options={dataContexts.map((dataContext) => ({
           value: dataContext.name,
-          title: `${dataContext.title} (${dataContext.name})`,
+          title: dataContext.title,
         }))}
         value={inputDataCtxt}
         defaultValue="Select a Data Context"

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, ReactElement } from "react";
+import React, { useEffect, useCallback, ReactElement, useState } from "react";
 import {
   getDataFromContext,
   addContextUpdateListener,
@@ -7,7 +7,11 @@ import {
   getDataContext,
   getDataSet,
 } from "../utils/codapPhone";
-import { useDataContexts, useInput } from "../utils/hooks";
+import {
+  useContextUpdateListenerWithFlowEffect,
+  useDataContexts,
+  useInput,
+} from "../utils/hooks";
 import { count } from "../transformations/count";
 import {
   CodapFlowTextInput,
@@ -29,6 +33,8 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
     HTMLInputElement
   >("", () => setErrMsg(null));
   const dataContexts = useDataContexts();
+
+  const [lastContextName, setLastContextName] = useState<null | string>(null);
 
   /**
    * Applies the user-defined transformation to the indicated input data,
@@ -56,6 +62,15 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
       return () => removeContextUpdateListener(inputDataCtxt);
     }
   }, [transform, inputDataCtxt]);
+
+  useContextUpdateListenerWithFlowEffect(
+    inputDataCtxt,
+    lastContextName,
+    () => {
+      transform();
+    },
+    [transform]
+  );
 
   return (
     <>

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -7,6 +7,9 @@ import {
 import { useDataContexts, useInput } from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { differenceFrom } from "../transformations/fold";
+import { CodapFlowTextInput } from "../ui-components/CodapFlowTextInput";
+import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
+import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
 
 export function DifferenceFrom({
   setErrMsg,
@@ -78,32 +81,36 @@ export function DifferenceFrom({
   return (
     <>
       <p>Table to calculate difference on</p>
-      <select id="inputDataContext" onChange={inputChange}>
-        <option selected disabled>
-          Select a Data Context
-        </option>
-        {dataContexts.map((dataContext) => (
-          <option key={dataContext.name} value={dataContext.name}>
-            {dataContext.title} ({dataContext.name})
-          </option>
-        ))}
-      </select>
+      <CodapFlowSelect
+        onChange={inputChange}
+        options={dataContexts.map((dataContext) => ({
+          value: dataContext.name,
+          title: `${dataContext.title} (${dataContext.name})`,
+        }))}
+        value={inputDataCtxt}
+        defaultValue="Select a Data Context"
+      />
       <p>Input Column Name:</p>
-      <input
-        type="text"
+      <CodapFlowTextInput
         value={inputColumnName}
         onChange={inputColumnNameChange}
       />
       <p>Result Column Name:</p>
-      <input
-        type="text"
+      <CodapFlowTextInput
         value={resultColumnName}
         onChange={resultColumnNameChange}
       />
       <p>Starting value for difference</p>
-      <input type="text" value={startingValue} onChange={startingValueChange} />
+      <CodapFlowTextInput
+        value={startingValue}
+        onChange={startingValueChange}
+      />
       <br />
-      <button onClick={transform}>Create table with difference</button>
+      <TransformationSubmitButtons
+        onCreate={() => transform()}
+        onUpdate={() => transform()}
+        updateDisabled={true}
+      />
     </>
   );
 }

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -7,9 +7,11 @@ import {
 import { useDataContexts, useInput } from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { differenceFrom } from "../transformations/fold";
-import { CodapFlowTextInput } from "../ui-components/CodapFlowTextInput";
-import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
-import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
+import {
+  CodapFlowTextInput,
+  CodapFlowSelect,
+  TransformationSubmitButtons,
+} from "../ui-components";
 
 export function DifferenceFrom({
   setErrMsg,

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -1,10 +1,5 @@
 import React, { useCallback, ReactElement, useState } from "react";
-import {
-  getDataFromContext,
-  createTableWithDataSet,
-  getDataContext,
-  getDataSet,
-} from "../utils/codapPhone";
+import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useDataContexts,
@@ -85,7 +80,14 @@ export function DifferenceFrom({
         setErrMsg(e.message);
       }
     },
-    [inputDataCtxt, inputColumnName, resultColumnName, setErrMsg, startingValue]
+    [
+      inputDataCtxt,
+      inputColumnName,
+      resultColumnName,
+      setErrMsg,
+      startingValue,
+      lastContextName,
+    ]
   );
 
   useContextUpdateListenerWithFlowEffect(

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -3,6 +3,7 @@ import {
   getDataFromContext,
   createTableWithDataSet,
   getDataContext,
+  getDataSet,
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { TransformationProps } from "./types";
@@ -56,10 +57,7 @@ export function DifferenceFrom({
       );
     }
 
-    const dataset = {
-      collections: (await getDataContext(inputDataCtxt)).collections,
-      records: await getDataFromContext(inputDataCtxt),
-    };
+    const dataset = await getDataSet(inputDataCtxt);
 
     try {
       const result = differenceFrom(

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -2,15 +2,14 @@ import React, { useCallback, ReactElement, useState } from "react";
 import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
-  useDataContexts,
   useInput,
 } from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { differenceFrom } from "../transformations/fold";
 import {
   CodapFlowTextInput,
-  CodapFlowSelect,
   TransformationSubmitButtons,
+  ContextSelector,
 } from "../ui-components";
 import { applyNewDataSet } from "./util";
 
@@ -36,8 +35,6 @@ export function DifferenceFrom({
     string,
     HTMLInputElement
   >("0", () => setErrMsg(null));
-
-  const dataContexts = useDataContexts();
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
@@ -102,15 +99,7 @@ export function DifferenceFrom({
   return (
     <>
       <p>Table to calculate difference on</p>
-      <CodapFlowSelect
-        onChange={inputChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
-        value={inputDataCtxt}
-        defaultValue="Select a Data Context"
-      />
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
       <p>Input Column Name:</p>
       <CodapFlowTextInput
         value={inputColumnName}

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -1,11 +1,15 @@
-import React, { useCallback, ReactElement } from "react";
+import React, { useCallback, ReactElement, useState } from "react";
 import {
   getDataFromContext,
   createTableWithDataSet,
   getDataContext,
   getDataSet,
 } from "../utils/codapPhone";
-import { useDataContexts, useInput } from "../utils/hooks";
+import {
+  useContextUpdateListenerWithFlowEffect,
+  useDataContexts,
+  useInput,
+} from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { differenceFrom } from "../transformations/fold";
 import {
@@ -38,6 +42,8 @@ export function DifferenceFrom({
   >("0", () => setErrMsg(null));
 
   const dataContexts = useDataContexts();
+
+  const [lastContextName, setLastContextName] = useState<null | string>(null);
 
   const transform = useCallback(async () => {
     if (inputDataCtxt === null) {
@@ -77,6 +83,15 @@ export function DifferenceFrom({
     setErrMsg,
     startingValue,
   ]);
+
+  useContextUpdateListenerWithFlowEffect(
+    inputDataCtxt,
+    lastContextName,
+    () => {
+      transform();
+    },
+    [transform]
+  );
 
   return (
     <>

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -106,7 +106,7 @@ export function DifferenceFrom({
         onChange={inputChange}
         options={dataContexts.map((dataContext) => ({
           value: dataContext.name,
-          title: `${dataContext.title} (${dataContext.name})`,
+          title: dataContext.title,
         }))}
         value={inputDataCtxt}
         defaultValue="Select a Data Context"

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -9,6 +9,9 @@ import {
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { filter } from "../transformations/filter";
+import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
+import { CodapFlowTextArea } from "../ui-components/CodapFlowTextArea";
+import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
 
 interface FilterProps {
   setErrMsg: (s: string | null) => void;
@@ -79,29 +82,25 @@ export function Filter({ setErrMsg }: FilterProps): ReactElement {
   return (
     <>
       <p>Table to Filter</p>
-      <select
-        id="inputDataContext"
+      <CodapFlowSelect
         onChange={inputChange}
-        defaultValue="default"
-      >
-        <option disabled value="default">
-          Select a Data Context
-        </option>
-        {dataContexts.map((dataContext) => (
-          <option key={dataContext.name} value={dataContext.name}>
-            {dataContext.title} ({dataContext.name})
-          </option>
-        ))}
-      </select>
+        options={dataContexts.map((dataContext) => ({
+          value: dataContext.name,
+          title: dataContext.title,
+        }))}
+        value={inputDataCtxt}
+        defaultValue="Select a Data Context"
+      />
 
       <p>How to Filter</p>
-      <textarea onChange={pgrmChange}></textarea>
+      <CodapFlowTextArea onChange={pgrmChange} value={transformPgrm} />
 
       <br />
-      <button onClick={() => transform(false)}>Create filtered table</button>
-      <button onClick={() => transform(true)} disabled={!lastContextName}>
-        Update previous filtered table
-      </button>
+      <TransformationSubmitButtons
+        onCreate={() => transform(false)}
+        onUpdate={() => transform(true)}
+        updateDisabled={!lastContextName}
+      />
     </>
   );
 }

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -9,9 +9,11 @@ import {
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { filter } from "../transformations/filter";
-import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
-import { CodapFlowTextArea } from "../ui-components/CodapFlowTextArea";
-import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
+import {
+  CodapFlowSelect,
+  TransformationSubmitButtons,
+  CodapFlowTextArea,
+} from "../ui-components";
 
 interface FilterProps {
   setErrMsg: (s: string | null) => void;

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -6,14 +6,13 @@ import {
 } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
-  useDataContexts,
   useInput,
 } from "../utils/hooks";
 import { filter } from "../transformations/filter";
 import {
-  CodapFlowSelect,
   TransformationSubmitButtons,
   CodapFlowTextArea,
+  ContextSelector,
 } from "../ui-components";
 import { applyNewDataSet } from "./util";
 
@@ -30,7 +29,6 @@ export function Filter({ setErrMsg }: FilterProps): ReactElement {
     "",
     () => setErrMsg(null)
   );
-  const dataContexts = useDataContexts();
   const [lastContextName, setLastContextName] = useState<string | null>(null);
 
   /**
@@ -86,15 +84,7 @@ export function Filter({ setErrMsg }: FilterProps): ReactElement {
   return (
     <>
       <p>Table to Filter</p>
-      <CodapFlowSelect
-        onChange={inputChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
-        value={inputDataCtxt}
-        defaultValue="Select a Data Context"
-      />
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
 
       <p>How to Filter</p>
       <CodapFlowTextArea onChange={pgrmChange} value={transformPgrm} />

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -19,6 +19,7 @@ import {
   TransformationSubmitButtons,
   CodapFlowTextArea,
 } from "../ui-components";
+import { applyNewDataSet } from "./util";
 
 interface FilterProps {
   setErrMsg: (s: string | null) => void;
@@ -54,19 +55,13 @@ export function Filter({ setErrMsg }: FilterProps): ReactElement {
 
       try {
         const filtered = filter(dataset, transformPgrm);
-
-        // if doUpdate is true then we should update a previously created table
-        // rather than creating a new one
-        if (doUpdate) {
-          if (!lastContextName) {
-            setErrMsg("Please apply transformation to a new table first.");
-            return;
-          }
-          setContextItems(lastContextName, filtered.records);
-        } else {
-          const [newContext] = await createTableWithDataSet(filtered);
-          setLastContextName(newContext.name);
-        }
+        await applyNewDataSet(
+          filtered,
+          doUpdate,
+          lastContextName,
+          setLastContextName,
+          setErrMsg
+        );
       } catch (e) {
         setErrMsg(e.message);
       }

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, ReactElement } from "react";
+import React, { useEffect, useCallback, ReactElement, useState } from "react";
 import {
   getDataFromContext,
   setContextItems,
@@ -8,7 +8,11 @@ import {
   getDataContext,
   getDataSet,
 } from "../utils/codapPhone";
-import { useDataContexts, useInput } from "../utils/hooks";
+import {
+  useContextUpdateListenerWithFlowEffect,
+  useDataContexts,
+  useInput,
+} from "../utils/hooks";
 import { filter } from "../transformations/filter";
 import {
   CodapFlowSelect,
@@ -68,6 +72,15 @@ export function Filter({ setErrMsg }: FilterProps): ReactElement {
       }
     },
     [inputDataCtxt, transformPgrm, lastContextName, setErrMsg]
+  );
+
+  useContextUpdateListenerWithFlowEffect(
+    inputDataCtxt,
+    lastContextName,
+    () => {
+      transform(true);
+    },
+    [transform]
   );
 
   useEffect(() => {

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -6,6 +6,7 @@ import {
   removeContextUpdateListener,
   createTableWithDataSet,
   getDataContext,
+  getDataSet,
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { filter } from "../transformations/filter";
@@ -45,10 +46,7 @@ export function Filter({ setErrMsg }: FilterProps): ReactElement {
       console.log(`Data context to filter: ${inputDataCtxt}`);
       console.log(`Filter predicate to apply:\n${transformPgrm}`);
 
-      const dataset = {
-        collections: (await getDataContext(inputDataCtxt)).collections,
-        records: await getDataFromContext(inputDataCtxt),
-      };
+      const dataset = await getDataSet(inputDataCtxt);
 
       try {
         const filtered = filter(dataset, transformPgrm);

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect, useCallback, ReactElement, useState } from "react";
 import {
-  getDataFromContext,
-  setContextItems,
   addContextUpdateListener,
   removeContextUpdateListener,
-  createTableWithDataSet,
-  getDataContext,
   getDataSet,
 } from "../utils/codapPhone";
 import {

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -2,11 +2,10 @@ import React, { useCallback, ReactElement, useState } from "react";
 import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
-  useDataContexts,
   useInput,
 } from "../utils/hooks";
 import { flatten } from "../transformations/flatten";
-import { CodapFlowSelect, TransformationSubmitButtons } from "../ui-components";
+import { TransformationSubmitButtons, ContextSelector } from "../ui-components";
 import { applyNewDataSet } from "./util";
 
 interface FlattenProps {
@@ -18,7 +17,6 @@ export function Flatten({ setErrMsg }: FlattenProps): ReactElement {
     string | null,
     HTMLSelectElement
   >(null, () => setErrMsg(null));
-  const dataContexts = useDataContexts();
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
@@ -63,15 +61,7 @@ export function Flatten({ setErrMsg }: FlattenProps): ReactElement {
   return (
     <>
       <p>Table to Flatten</p>
-      <CodapFlowSelect
-        onChange={inputChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
-        value={inputDataCtxt}
-        defaultValue="Select a Data Context"
-      />
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
 
       <br />
       <TransformationSubmitButtons

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -8,6 +8,8 @@ import {
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { flatten } from "../transformations/flatten";
+import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
+import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
 
 interface FlattenProps {
   setErrMsg: (s: string | null) => void;
@@ -55,19 +57,22 @@ export function Flatten({ setErrMsg }: FlattenProps): ReactElement {
   return (
     <>
       <p>Table to Flatten</p>
-      <select id="inputDataContext" onChange={inputChange}>
-        <option selected disabled>
-          Select a Data Context
-        </option>
-        {dataContexts.map((dataContext) => (
-          <option key={dataContext.name} value={dataContext.name}>
-            {dataContext.title} ({dataContext.name})
-          </option>
-        ))}
-      </select>
+      <CodapFlowSelect
+        onChange={inputChange}
+        options={dataContexts.map((dataContext) => ({
+          value: dataContext.name,
+          title: dataContext.title,
+        }))}
+        value={inputDataCtxt}
+        defaultValue="Select a Data Context"
+      />
 
       <br />
-      <button onClick={transform}>Create flattened table</button>
+      <TransformationSubmitButtons
+        onCreate={() => transform()}
+        onUpdate={() => transform()}
+        updateDisabled={true}
+      />
     </>
   );
 }

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -48,7 +48,7 @@ export function Flatten({ setErrMsg }: FlattenProps): ReactElement {
         setErrMsg(e.message);
       }
     },
-    [inputDataCtxt, setErrMsg]
+    [inputDataCtxt, setErrMsg, lastContextName]
   );
 
   useContextUpdateListenerWithFlowEffect(

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -5,6 +5,7 @@ import {
   removeContextUpdateListener,
   createTableWithDataSet,
   getDataContext,
+  getDataSet,
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { flatten } from "../transformations/flatten";
@@ -31,10 +32,7 @@ export function Flatten({ setErrMsg }: FlattenProps): ReactElement {
       return;
     }
 
-    const dataset = {
-      collections: (await getDataContext(inputDataCtxt)).collections,
-      records: await getDataFromContext(inputDataCtxt),
-    };
+    const dataset = await getDataSet(inputDataCtxt);
 
     try {
       const flat = flatten(dataset);

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -8,8 +8,7 @@ import {
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { flatten } from "../transformations/flatten";
-import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
-import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
+import { CodapFlowSelect, TransformationSubmitButtons } from "../ui-components";
 
 interface FlattenProps {
   setErrMsg: (s: string | null) => void;

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, ReactElement } from "react";
+import React, { useEffect, useCallback, ReactElement, useState } from "react";
 import {
   getDataFromContext,
   addContextUpdateListener,
@@ -7,7 +7,11 @@ import {
   getDataContext,
   getDataSet,
 } from "../utils/codapPhone";
-import { useDataContexts, useInput } from "../utils/hooks";
+import {
+  useContextUpdateListenerWithFlowEffect,
+  useDataContexts,
+  useInput,
+} from "../utils/hooks";
 import { flatten } from "../transformations/flatten";
 import { CodapFlowSelect, TransformationSubmitButtons } from "../ui-components";
 
@@ -21,6 +25,8 @@ export function Flatten({ setErrMsg }: FlattenProps): ReactElement {
     HTMLSelectElement
   >(null, () => setErrMsg(null));
   const dataContexts = useDataContexts();
+
+  const [lastContextName, setLastContextName] = useState<null | string>(null);
 
   /**
    * Applies the flatten transformation to the input data context,
@@ -42,14 +48,14 @@ export function Flatten({ setErrMsg }: FlattenProps): ReactElement {
     }
   }, [inputDataCtxt, setErrMsg]);
 
-  useEffect(() => {
-    if (inputDataCtxt !== null) {
-      addContextUpdateListener(inputDataCtxt, () => {
-        transform();
-      });
-      return () => removeContextUpdateListener(inputDataCtxt);
-    }
-  }, [transform, inputDataCtxt]);
+  useContextUpdateListenerWithFlowEffect(
+    inputDataCtxt,
+    lastContextName,
+    () => {
+      transform();
+    },
+    [transform]
+  );
 
   return (
     <>

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -1,12 +1,5 @@
-import React, { useEffect, useCallback, ReactElement, useState } from "react";
-import {
-  getDataFromContext,
-  addContextUpdateListener,
-  removeContextUpdateListener,
-  createTableWithDataSet,
-  getDataContext,
-  getDataSet,
-} from "../utils/codapPhone";
+import React, { useCallback, ReactElement, useState } from "react";
+import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useDataContexts,

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -1,10 +1,5 @@
 import React, { useCallback, ReactElement, useState } from "react";
-import {
-  getDataFromContext,
-  createTableWithDataSet,
-  getDataContext,
-  getDataSet,
-} from "../utils/codapPhone";
+import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useDataContexts,

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -70,7 +70,14 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
         setErrMsg(e.message);
       }
     },
-    [inputDataCtxt, inputColumnName, resultColumnName, setErrMsg, foldFunc]
+    [
+      inputDataCtxt,
+      inputColumnName,
+      resultColumnName,
+      setErrMsg,
+      foldFunc,
+      lastContextName,
+    ]
   );
 
   useContextUpdateListenerWithFlowEffect(

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -7,6 +7,9 @@ import {
 import { useDataContexts, useInput } from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { DataSet } from "../transformations/types";
+import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
+import { CodapFlowTextInput } from "../ui-components/CodapFlowTextInput";
+import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
 
 interface FoldProps extends TransformationProps {
   label: string;
@@ -62,30 +65,31 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
   return (
     <>
       <p>Table to calculate {label} on</p>
-      <select id="inputDataContext" onChange={inputChange}>
-        <option selected disabled>
-          Select a Data Context
-        </option>
-        {dataContexts.map((dataContext) => (
-          <option key={dataContext.name} value={dataContext.name}>
-            {dataContext.title} ({dataContext.name})
-          </option>
-        ))}
-      </select>
+      <CodapFlowSelect
+        onChange={inputChange}
+        options={dataContexts.map((dataContext) => ({
+          value: dataContext.name,
+          title: dataContext.title,
+        }))}
+        value={inputDataCtxt}
+        defaultValue="Select a Data Context"
+      />
       <p>Input Column Name:</p>
-      <input
-        type="text"
+      <CodapFlowTextInput
         value={inputColumnName}
         onChange={inputColumnNameChange}
       />
       <p>Result Column Name:</p>
-      <input
-        type="text"
+      <CodapFlowTextInput
         value={resultColumnName}
         onChange={resultColumnNameChange}
       />
       <br />
-      <button onClick={transform}>Create table with {label}</button>
+      <TransformationSubmitButtons
+        onCreate={() => transform()}
+        onUpdate={() => transform()}
+        updateDisabled={true}
+      />
     </>
   );
 }

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -3,6 +3,7 @@ import {
   getDataFromContext,
   createTableWithDataSet,
   getDataContext,
+  getDataSet,
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { TransformationProps } from "./types";
@@ -51,10 +52,7 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
       return;
     }
 
-    const dataset = {
-      collections: (await getDataContext(inputDataCtxt)).collections,
-      records: await getDataFromContext(inputDataCtxt),
-    };
+    const dataset = await getDataSet(inputDataCtxt);
 
     try {
       const result = foldFunc(dataset, inputColumnName, resultColumnName);

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -7,9 +7,11 @@ import {
 import { useDataContexts, useInput } from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { DataSet } from "../transformations/types";
-import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
-import { CodapFlowTextInput } from "../ui-components/CodapFlowTextInput";
-import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
+import {
+  CodapFlowTextInput,
+  CodapFlowSelect,
+  TransformationSubmitButtons,
+} from "../ui-components";
 
 interface FoldProps extends TransformationProps {
   label: string;

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -1,11 +1,15 @@
-import React, { useCallback, ReactElement } from "react";
+import React, { useCallback, ReactElement, useState } from "react";
 import {
   getDataFromContext,
   createTableWithDataSet,
   getDataContext,
   getDataSet,
 } from "../utils/codapPhone";
-import { useDataContexts, useInput } from "../utils/hooks";
+import {
+  useContextUpdateListenerWithFlowEffect,
+  useDataContexts,
+  useInput,
+} from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { DataSet } from "../transformations/types";
 import {
@@ -41,6 +45,8 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
 
   const dataContexts = useDataContexts();
 
+  const [lastContextName, setLastContextName] = useState<null | string>(null);
+
   const transform = useCallback(async () => {
     if (inputDataCtxt === null) {
       setErrMsg("Please choose a valid data context to transform.");
@@ -61,6 +67,15 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
       setErrMsg(e.message);
     }
   }, [inputDataCtxt, inputColumnName, resultColumnName, setErrMsg, foldFunc]);
+
+  useContextUpdateListenerWithFlowEffect(
+    inputDataCtxt,
+    lastContextName,
+    () => {
+      transform();
+    },
+    [transform]
+  );
 
   return (
     <>

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -2,15 +2,14 @@ import React, { useCallback, ReactElement, useState } from "react";
 import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
-  useDataContexts,
   useInput,
 } from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { DataSet } from "../transformations/types";
 import {
   CodapFlowTextInput,
-  CodapFlowSelect,
   TransformationSubmitButtons,
+  ContextSelector,
 } from "../ui-components";
 import { applyNewDataSet } from "./util";
 
@@ -38,8 +37,6 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
     string,
     HTMLInputElement
   >("", () => setErrMsg(null));
-
-  const dataContexts = useDataContexts();
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
@@ -92,15 +89,7 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
   return (
     <>
       <p>Table to calculate {label} on</p>
-      <CodapFlowSelect
-        onChange={inputChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
-        value={inputDataCtxt}
-        defaultValue="Select a Data Context"
-      />
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
       <p>Input Column Name:</p>
       <CodapFlowTextInput
         value={inputColumnName}

--- a/src/transformation-components/GroupBy.tsx
+++ b/src/transformation-components/GroupBy.tsx
@@ -83,7 +83,7 @@ export function GroupBy({ setErrMsg }: GroupByProps): ReactElement {
         onChange={inputChange}
         options={dataContexts.map((dataContext) => ({
           value: dataContext.name,
-          title: `${dataContext.title} (${dataContext.name})`,
+          title: dataContext.title,
         }))}
         value={inputDataCtxt}
         defaultValue="Select a Data Context"

--- a/src/transformation-components/GroupBy.tsx
+++ b/src/transformation-components/GroupBy.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback, ReactElement } from "react";
 import { getDataSet } from "../utils/codapPhone";
 import {
-  useDataContexts,
   useInput,
   useContextUpdateListenerWithFlowEffect,
 } from "../utils/hooks";
@@ -9,8 +8,8 @@ import { groupBy } from "../transformations/groupBy";
 import { applyNewDataSet } from "./util";
 import {
   CodapFlowTextArea,
-  CodapFlowSelect,
   TransformationSubmitButtons,
+  ContextSelector,
 } from "../ui-components";
 
 interface GroupByProps {
@@ -26,7 +25,6 @@ export function GroupBy({ setErrMsg }: GroupByProps): ReactElement {
     "",
     () => setErrMsg(null)
   );
-  const dataContexts = useDataContexts();
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
@@ -79,15 +77,7 @@ export function GroupBy({ setErrMsg }: GroupByProps): ReactElement {
   return (
     <>
       <p>Table to Group</p>
-      <CodapFlowSelect
-        onChange={inputChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
-        value={inputDataCtxt}
-        defaultValue="Select a Data Context"
-      />
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
       <p>Attributes to Group By (1 per line)</p>
       <CodapFlowTextArea value={attributes} onChange={attributesChange} />
 

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -5,6 +5,7 @@ import {
   removeContextUpdateListener,
   createTableWithDataSet,
   getDataContext,
+  getDataSet,
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { selectAttributes } from "../transformations/selectAttributes";
@@ -41,10 +42,7 @@ export function SelectAttributes({
       return;
     }
 
-    const dataset = {
-      collections: (await getDataContext(inputDataCtxt)).collections,
-      records: await getDataFromContext(inputDataCtxt),
-    };
+    const dataset = await getDataSet(inputDataCtxt);
 
     // extract attribute names from user's text
     const attributeNames = attributes.split("\n").map((s) => s.trim());

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -8,9 +8,11 @@ import {
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { selectAttributes } from "../transformations/selectAttributes";
-import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
-import { CodapFlowTextArea } from "../ui-components/CodapFlowTextArea";
-import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
+import {
+  CodapFlowSelect,
+  TransformationSubmitButtons,
+  CodapFlowTextArea,
+} from "../ui-components";
 
 interface SelectAttributesProps {
   setErrMsg: (s: string | null) => void;

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -2,14 +2,13 @@ import React, { useCallback, ReactElement, useState } from "react";
 import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
-  useDataContexts,
   useInput,
 } from "../utils/hooks";
 import { selectAttributes } from "../transformations/selectAttributes";
 import {
-  CodapFlowSelect,
   TransformationSubmitButtons,
   CodapFlowTextArea,
+  ContextSelector,
 } from "../ui-components";
 import { applyNewDataSet } from "./util";
 
@@ -28,7 +27,6 @@ export function SelectAttributes({
     "",
     () => setErrMsg(null)
   );
-  const dataContexts = useDataContexts();
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
@@ -76,15 +74,7 @@ export function SelectAttributes({
   return (
     <>
       <p>Table to Select Attributes From</p>
-      <CodapFlowSelect
-        onChange={inputChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
-        value={inputDataCtxt}
-        defaultValue="Select a Data Context"
-      />
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
 
       <p>Attributes to Include in Output (1 per line)</p>
       <CodapFlowTextArea onChange={attributesChange} value={attributes} />

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -8,6 +8,9 @@ import {
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { selectAttributes } from "../transformations/selectAttributes";
+import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
+import { CodapFlowTextArea } from "../ui-components/CodapFlowTextArea";
+import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
 
 interface SelectAttributesProps {
   setErrMsg: (s: string | null) => void;
@@ -62,26 +65,25 @@ export function SelectAttributes({
   return (
     <>
       <p>Table to Select Attributes From</p>
-      <select
-        id="inputDataContext"
+      <CodapFlowSelect
         onChange={inputChange}
-        defaultValue="default"
-      >
-        <option disabled value="default">
-          Select a Data Context
-        </option>
-        {dataContexts.map((dataContext) => (
-          <option key={dataContext.name} value={dataContext.name}>
-            {dataContext.title} ({dataContext.name})
-          </option>
-        ))}
-      </select>
+        options={dataContexts.map((dataContext) => ({
+          value: dataContext.name,
+          title: dataContext.title,
+        }))}
+        value={inputDataCtxt}
+        defaultValue="Select a Data Context"
+      />
 
       <p>Attributes to Include in Output (1 per line)</p>
-      <textarea onChange={attributesChange}></textarea>
+      <CodapFlowTextArea onChange={attributesChange} value={attributes} />
 
       <br />
-      <button onClick={() => transform()}>Select attributes!</button>
+      <TransformationSubmitButtons
+        onCreate={() => transform()}
+        onUpdate={() => transform()}
+        updateDisabled={true}
+      />
     </>
   );
 }

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -1,12 +1,5 @@
 import React, { useEffect, useCallback, ReactElement, useState } from "react";
-import {
-  getDataFromContext,
-  addContextUpdateListener,
-  removeContextUpdateListener,
-  createTableWithDataSet,
-  getDataContext,
-  getDataSet,
-} from "../utils/codapPhone";
+import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useDataContexts,

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, ReactElement, useState } from "react";
+import React, { useCallback, ReactElement, useState } from "react";
 import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
@@ -61,7 +61,7 @@ export function SelectAttributes({
         setErrMsg(e.message);
       }
     },
-    [inputDataCtxt, attributes, setErrMsg]
+    [inputDataCtxt, attributes, setErrMsg, lastContextName]
   );
 
   useContextUpdateListenerWithFlowEffect(

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, ReactElement } from "react";
+import React, { useEffect, useCallback, ReactElement, useState } from "react";
 import {
   getDataFromContext,
   addContextUpdateListener,
@@ -7,7 +7,11 @@ import {
   getDataContext,
   getDataSet,
 } from "../utils/codapPhone";
-import { useDataContexts, useInput } from "../utils/hooks";
+import {
+  useContextUpdateListenerWithFlowEffect,
+  useDataContexts,
+  useInput,
+} from "../utils/hooks";
 import { selectAttributes } from "../transformations/selectAttributes";
 import {
   CodapFlowSelect,
@@ -32,6 +36,8 @@ export function SelectAttributes({
   );
   const dataContexts = useDataContexts();
 
+  const [lastContextName, setLastContextName] = useState<null | string>(null);
+
   /**
    * Applies the user-defined transformation to the indicated input data,
    * and generates an output table into CODAP containing the transformed data.
@@ -55,12 +61,14 @@ export function SelectAttributes({
     }
   }, [inputDataCtxt, attributes, setErrMsg]);
 
-  useEffect(() => {
-    if (inputDataCtxt !== null) {
-      addContextUpdateListener(inputDataCtxt, transform);
-      return () => removeContextUpdateListener(inputDataCtxt);
-    }
-  }, [transform, inputDataCtxt]);
+  useContextUpdateListenerWithFlowEffect(
+    inputDataCtxt,
+    lastContextName,
+    () => {
+      transform();
+    },
+    [transform]
+  );
 
   return (
     <>

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -1,10 +1,5 @@
 import React, { useCallback, ReactElement, useState } from "react";
-import {
-  getDataFromContext,
-  createTableWithDataSet,
-  getDataContext,
-  getDataSet,
-} from "../utils/codapPhone";
+import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useDataContexts,

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -7,6 +7,9 @@ import {
 import { useDataContexts, useInput } from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { sort } from "../transformations/sort";
+import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
+import { CodapFlowTextArea } from "../ui-components/CodapFlowTextArea";
+import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
 
 export function Sort({ setErrMsg }: TransformationProps): ReactElement {
   const [inputDataCtxt, inputChange] = useInput<
@@ -48,20 +51,24 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
   return (
     <>
       <p>Table to sort</p>
-      <select id="inputDataContext" onChange={inputChange}>
-        <option selected disabled>
-          Select a Data Context
-        </option>
-        {dataContexts.map((dataContext) => (
-          <option key={dataContext.name} value={dataContext.name}>
-            {dataContext.title} ({dataContext.name})
-          </option>
-        ))}
-      </select>
+      <CodapFlowSelect
+        onChange={inputChange}
+        options={dataContexts.map((dataContext) => ({
+          value: dataContext.name,
+          title: dataContext.title,
+        }))}
+        value={inputDataCtxt}
+        defaultValue="Select a Data Context"
+      />
+
       <p>Key expression</p>
-      <textarea value={keyExpression} onChange={keyExpressionChange} />
+      <CodapFlowTextArea value={keyExpression} onChange={keyExpressionChange} />
       <br />
-      <button onClick={transform}>Create sorted table</button>
+      <TransformationSubmitButtons
+        onCreate={() => transform()}
+        onUpdate={() => transform()}
+        updateDisabled={true}
+      />
     </>
   );
 }

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -2,15 +2,14 @@ import React, { useCallback, ReactElement, useState } from "react";
 import { getDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
-  useDataContexts,
   useInput,
 } from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { sort } from "../transformations/sort";
 import {
-  CodapFlowSelect,
   TransformationSubmitButtons,
   CodapFlowTextArea,
+  ContextSelector,
 } from "../ui-components";
 import { applyNewDataSet } from "./util";
 
@@ -24,8 +23,6 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
     string,
     HTMLTextAreaElement
   >("", () => setErrMsg(null));
-
-  const dataContexts = useDataContexts();
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
@@ -71,15 +68,7 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
   return (
     <>
       <p>Table to sort</p>
-      <CodapFlowSelect
-        onChange={inputChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
-        value={inputDataCtxt}
-        defaultValue="Select a Data Context"
-      />
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
 
       <p>Key expression</p>
       <CodapFlowTextArea value={keyExpression} onChange={keyExpressionChange} />

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -3,6 +3,7 @@ import {
   getDataFromContext,
   createTableWithDataSet,
   getDataContext,
+  getDataSet,
 } from "../utils/codapPhone";
 import { useDataContexts, useInput } from "../utils/hooks";
 import { TransformationProps } from "./types";
@@ -37,10 +38,7 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
       return;
     }
 
-    const dataset = {
-      collections: (await getDataContext(inputDataCtxt)).collections,
-      records: await getDataFromContext(inputDataCtxt),
-    };
+    const dataset = await getDataSet(inputDataCtxt);
 
     try {
       const result = sort(dataset, keyExpression);

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -1,11 +1,15 @@
-import React, { useCallback, ReactElement } from "react";
+import React, { useCallback, ReactElement, useState } from "react";
 import {
   getDataFromContext,
   createTableWithDataSet,
   getDataContext,
   getDataSet,
 } from "../utils/codapPhone";
-import { useDataContexts, useInput } from "../utils/hooks";
+import {
+  useContextUpdateListenerWithFlowEffect,
+  useDataContexts,
+  useInput,
+} from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { sort } from "../transformations/sort";
 import {
@@ -27,6 +31,8 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
 
   const dataContexts = useDataContexts();
 
+  const [lastContextName, setLastContextName] = useState<null | string>(null);
+
   const transform = useCallback(async () => {
     if (inputDataCtxt === null) {
       setErrMsg("Please choose a valid data context to transform.");
@@ -47,6 +53,15 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
       setErrMsg(e.message);
     }
   }, [inputDataCtxt, setErrMsg, keyExpression]);
+
+  useContextUpdateListenerWithFlowEffect(
+    inputDataCtxt,
+    lastContextName,
+    () => {
+      transform();
+    },
+    [transform]
+  );
 
   return (
     <>

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -7,9 +7,11 @@ import {
 import { useDataContexts, useInput } from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { sort } from "../transformations/sort";
-import { TransformationSubmitButtons } from "../ui-components/TransformationSubmitButtons";
-import { CodapFlowTextArea } from "../ui-components/CodapFlowTextArea";
-import { CodapFlowSelect } from "../ui-components/CodapFlowSelect";
+import {
+  CodapFlowSelect,
+  TransformationSubmitButtons,
+  CodapFlowTextArea,
+} from "../ui-components";
 
 export function Sort({ setErrMsg }: TransformationProps): ReactElement {
   const [inputDataCtxt, inputChange] = useInput<

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -56,7 +56,7 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
         setErrMsg(e.message);
       }
     },
-    [inputDataCtxt, setErrMsg, keyExpression]
+    [inputDataCtxt, setErrMsg, keyExpression, lastContextName]
   );
 
   useContextUpdateListenerWithFlowEffect(

--- a/src/transformation-components/TransformColumn.tsx
+++ b/src/transformation-components/TransformColumn.tsx
@@ -86,7 +86,7 @@ export function TransformColumn({
         onChange={inputChange}
         options={dataContexts.map((dataContext) => ({
           value: dataContext.name,
-          title: `${dataContext.title} (${dataContext.name})`,
+          title: dataContext.title,
         }))}
         value={inputDataCtxt}
         defaultValue="Select a Data Context"

--- a/src/transformation-components/TransformColumn.tsx
+++ b/src/transformation-components/TransformColumn.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useCallback, ReactElement } from "react";
-import { useDataContexts, useInput } from "../utils/hooks";
+import { useInput } from "../utils/hooks";
 import { transformColumn } from "../transformations/transformColumn";
 import { applyNewDataSet } from "./util";
 import {
   CodapFlowTextArea,
   CodapFlowTextInput,
-  CodapFlowSelect,
   TransformationSubmitButtons,
+  ContextSelector,
 } from "../ui-components";
 import { useContextUpdateListenerWithFlowEffect } from "../utils/hooks";
 import { getDataSet } from "../utils/codapPhone";
@@ -30,7 +30,6 @@ export function TransformColumn({
     "",
     () => setErrMsg(null)
   );
-  const dataContexts = useDataContexts();
   const [lastContextName, setLastContextName] = useState<string | null>(null);
 
   /**
@@ -82,15 +81,7 @@ export function TransformColumn({
   return (
     <>
       <p>Table to TransformColumn</p>
-      <CodapFlowSelect
-        onChange={inputChange}
-        options={dataContexts.map((dataContext) => ({
-          value: dataContext.name,
-          title: dataContext.title,
-        }))}
-        value={inputDataCtxt}
-        defaultValue="Select a Data Context"
-      />
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
 
       <p>Attribute to Transform</p>
       <CodapFlowTextInput

--- a/src/transformation-components/util.ts
+++ b/src/transformation-components/util.ts
@@ -1,6 +1,10 @@
 import { DataSet } from "../transformations/types";
 import { createTableWithDataSet, setContextItems } from "../utils/codapPhone";
 
+/**
+ * This function takes a dataset as well as a `doUpdate` flag and either
+ * creates a new table for the dataset or updates an existing one accordingly.
+ */
 export async function applyNewDataSet(
   dataSet: DataSet,
   doUpdate: boolean,

--- a/src/transformation-components/util.ts
+++ b/src/transformation-components/util.ts
@@ -1,0 +1,27 @@
+import { DataSet } from "../transformations/types";
+import { createTableWithDataSet, setContextItems } from "../utils/codapPhone";
+
+export async function applyNewDataSet(
+  dataSet: DataSet,
+  doUpdate: boolean,
+  lastContextName: string | null,
+  setLastContextName: (s: string) => void,
+  setErrMsg: (s: string | null) => void
+): Promise<void> {
+  try {
+    // if doUpdate is true then we should update a previously created table
+    // rather than creating a new one
+    if (doUpdate) {
+      if (!lastContextName) {
+        setErrMsg("Please apply transformation to a new table first.");
+        return;
+      }
+      setContextItems(lastContextName, dataSet.records);
+    } else {
+      const [newContext] = await createTableWithDataSet(dataSet);
+      setLastContextName(newContext.name);
+    }
+  } catch (e) {
+    setErrMsg(e.message);
+  }
+}

--- a/src/ui-components/AttributeSelector.tsx
+++ b/src/ui-components/AttributeSelector.tsx
@@ -24,6 +24,7 @@ export default function AttributeSelector({
       }))}
       value={value}
       defaultValue="Select an attribute"
+      showValue={true}
     />
   );
 }

--- a/src/ui-components/AttributeSelector.tsx
+++ b/src/ui-components/AttributeSelector.tsx
@@ -1,0 +1,29 @@
+import React, { ReactElement, ChangeEvent } from "react";
+import CodapFlowSelect from "./CodapFlowSelect";
+import { useAttributes } from "../utils/hooks";
+
+interface ContextSelectorProps {
+  context: string | null;
+  value: string | null;
+  onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
+}
+
+export default function AttributeSelector({
+  context,
+  value,
+  onChange,
+}: ContextSelectorProps): ReactElement {
+  const attributes = useAttributes(context);
+
+  return (
+    <CodapFlowSelect
+      onChange={onChange}
+      options={attributes.map((attribute) => ({
+        value: attribute.name,
+        title: attribute.title,
+      }))}
+      value={value}
+      defaultValue="Select an attribute"
+    />
+  );
+}

--- a/src/ui-components/CodapFlowSelect.tsx
+++ b/src/ui-components/CodapFlowSelect.tsx
@@ -10,7 +10,7 @@ interface CodapFlowSelectProps<T extends string | number> {
   }[];
 }
 
-export function CodapFlowSelect<T extends string | number>({
+export default function CodapFlowSelect<T extends string | number>({
   onChange,
   value,
   defaultValue,

--- a/src/ui-components/CodapFlowSelect.tsx
+++ b/src/ui-components/CodapFlowSelect.tsx
@@ -1,0 +1,35 @@
+import React, { ReactElement } from "react";
+
+interface CodapFlowSelectProps<T extends string | number> {
+  onChange: React.ChangeEventHandler<HTMLSelectElement>;
+  defaultValue: T;
+  value: T | null;
+  options: {
+    value: T;
+    title: string;
+  }[];
+}
+
+export function CodapFlowSelect<T extends string | number>({
+  onChange,
+  value,
+  defaultValue,
+  options,
+}: CodapFlowSelectProps<T>): ReactElement {
+  return (
+    <select
+      onChange={onChange}
+      defaultValue={defaultValue}
+      value={value || defaultValue}
+    >
+      <option disabled value={defaultValue}>
+        {defaultValue}
+      </option>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.title} ({option.value})
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/ui-components/CodapFlowSelect.tsx
+++ b/src/ui-components/CodapFlowSelect.tsx
@@ -8,6 +8,7 @@ interface CodapFlowSelectProps<T extends string | number> {
     value: T;
     title: string;
   }[];
+  showValue?: boolean;
 }
 
 export default function CodapFlowSelect<T extends string | number>({
@@ -15,7 +16,13 @@ export default function CodapFlowSelect<T extends string | number>({
   value,
   defaultValue,
   options,
+  showValue,
 }: CodapFlowSelectProps<T>): ReactElement {
+  // showValue is false by default
+  if (showValue === undefined || showValue === null) {
+    showValue = false;
+  }
+
   return (
     <select
       onChange={onChange}
@@ -27,7 +34,7 @@ export default function CodapFlowSelect<T extends string | number>({
       </option>
       {options.map((option) => (
         <option key={option.value} value={option.value}>
-          {option.title} ({option.value})
+          {showValue ? `${option.title} (${option.value})` : option.title}
         </option>
       ))}
     </select>

--- a/src/ui-components/CodapFlowSelect.tsx
+++ b/src/ui-components/CodapFlowSelect.tsx
@@ -24,11 +24,7 @@ export default function CodapFlowSelect<T extends string | number>({
   }
 
   return (
-    <select
-      onChange={onChange}
-      defaultValue={defaultValue}
-      value={value || defaultValue}
-    >
+    <select onChange={onChange} value={value || defaultValue}>
       <option disabled value={defaultValue}>
         {defaultValue}
       </option>

--- a/src/ui-components/CodapFlowTextArea.tsx
+++ b/src/ui-components/CodapFlowTextArea.tsx
@@ -5,7 +5,7 @@ interface CodapFlowTextAreaProps {
   value: string;
 }
 
-export function CodapFlowTextArea({
+export default function CodapFlowTextArea({
   onChange,
   value,
 }: CodapFlowTextAreaProps): ReactElement {

--- a/src/ui-components/CodapFlowTextArea.tsx
+++ b/src/ui-components/CodapFlowTextArea.tsx
@@ -1,0 +1,13 @@
+import React, { ReactElement } from "react";
+
+interface CodapFlowTextAreaProps {
+  onChange: React.ChangeEventHandler<HTMLTextAreaElement>;
+  value: string;
+}
+
+export function CodapFlowTextArea({
+  onChange,
+  value,
+}: CodapFlowTextAreaProps): ReactElement {
+  return <textarea onChange={onChange} value={value} />;
+}

--- a/src/ui-components/CodapFlowTextInput.tsx
+++ b/src/ui-components/CodapFlowTextInput.tsx
@@ -1,0 +1,13 @@
+import React, { ReactElement } from "react";
+
+interface CodapFlowTextInputProps {
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  value: string;
+}
+
+export function CodapFlowTextInput({
+  onChange,
+  value,
+}: CodapFlowTextInputProps): ReactElement {
+  return <input type="text" onChange={onChange} value={value} />;
+}

--- a/src/ui-components/CodapFlowTextInput.tsx
+++ b/src/ui-components/CodapFlowTextInput.tsx
@@ -5,7 +5,7 @@ interface CodapFlowTextInputProps {
   value: string;
 }
 
-export function CodapFlowTextInput({
+export default function CodapFlowTextInput({
   onChange,
   value,
 }: CodapFlowTextInputProps): ReactElement {

--- a/src/ui-components/ContextSelector.tsx
+++ b/src/ui-components/ContextSelector.tsx
@@ -22,6 +22,7 @@ export default function ContextSelector({
       }))}
       value={value}
       defaultValue="Select a Data Context"
+      showValue={true}
     />
   );
 }

--- a/src/ui-components/ContextSelector.tsx
+++ b/src/ui-components/ContextSelector.tsx
@@ -1,0 +1,27 @@
+import React, { ReactElement, ChangeEvent } from "react";
+import CodapFlowSelect from "./CodapFlowSelect";
+import { useDataContexts } from "../utils/hooks";
+
+interface ContextSelectorProps {
+  value: string | null;
+  onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
+}
+
+export default function ContextSelector({
+  value,
+  onChange,
+}: ContextSelectorProps): ReactElement {
+  const dataContexts = useDataContexts();
+
+  return (
+    <CodapFlowSelect
+      onChange={onChange}
+      options={dataContexts.map((dataContext) => ({
+        value: dataContext.name,
+        title: dataContext.title,
+      }))}
+      value={value}
+      defaultValue="Select a Data Context"
+    />
+  );
+}

--- a/src/ui-components/TransformationSubmitButtons.tsx
+++ b/src/ui-components/TransformationSubmitButtons.tsx
@@ -1,0 +1,22 @@
+import React, { ReactElement } from "react";
+
+interface TransformationSubmitButtonsProps {
+  onCreate: () => void;
+  onUpdate: () => void;
+  updateDisabled: boolean;
+}
+
+export function TransformationSubmitButtons({
+  onCreate,
+  onUpdate,
+  updateDisabled,
+}: TransformationSubmitButtonsProps): ReactElement {
+  return (
+    <>
+      <button onClick={onCreate}>Create table with transformation</button>
+      <button onClick={onUpdate} disabled={updateDisabled}>
+        Update previous table with transformation
+      </button>
+    </>
+  );
+}

--- a/src/ui-components/TransformationSubmitButtons.tsx
+++ b/src/ui-components/TransformationSubmitButtons.tsx
@@ -6,7 +6,7 @@ interface TransformationSubmitButtonsProps {
   updateDisabled: boolean;
 }
 
-export function TransformationSubmitButtons({
+export default function TransformationSubmitButtons({
   onCreate,
   onUpdate,
   updateDisabled,

--- a/src/ui-components/index.ts
+++ b/src/ui-components/index.ts
@@ -1,9 +1,6 @@
-import a from "./CodapFlowTextInput";
-import b from "./TransformationSubmitButtons";
-import c from "./CodapFlowSelect";
-import d from "./CodapFlowTextArea";
-
-export const CodapFlowTextInput = a;
-export const TransformationSubmitButtons = b;
-export const CodapFlowSelect = c;
-export const CodapFlowTextArea = d;
+export { default as CodapFlowTextInput } from "./CodapFlowTextInput";
+export { default as CodapFlowSelect } from "./CodapFlowSelect";
+export { default as CodapFlowTextArea } from "./CodapFlowTextArea";
+export { default as TransformationSubmitButtons } from "./TransformationSubmitButtons";
+export { default as ContextSelector } from "./ContextSelector";
+export { default as AttributeSelector } from "./AttributeSelector";

--- a/src/ui-components/index.ts
+++ b/src/ui-components/index.ts
@@ -1,0 +1,9 @@
+import a from "./CodapFlowTextInput";
+import b from "./TransformationSubmitButtons";
+import c from "./CodapFlowSelect";
+import d from "./CodapFlowTextArea";
+
+export const CodapFlowTextInput = a;
+export const TransformationSubmitButtons = b;
+export const CodapFlowSelect = c;
+export const CodapFlowTextArea = d;

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -315,6 +315,13 @@ export async function getDataFromContext(
   );
 }
 
+export async function getDataSet(contextName: string): Promise<DataSet> {
+  return {
+    collections: (await getDataContext(contextName)).collections,
+    records: await getDataFromContext(contextName),
+  };
+}
+
 export function getDataContext(contextName: string): Promise<DataContext> {
   return new Promise<DataContext>((resolve, reject) =>
     phone.call(


### PR DESCRIPTION
## Changelog
* Create a set of UI components for common UI elements (dropdown, text input, text area, transformation buttons) and switch over existing `transformation-components` to use the new UI components.
* Factor out repeated behavior from `transformation-components`. Affected behavior is as follows:
  * Listening for updates in source context and performing corresponding transformations: `useContextUpdateListenerWithFlowEffect`. This function takes a two context names and calls a callback when the first one updates. See the docstring for more info.
  * Deciding whether to update or create a new table and handling errors: `applyNewDataSet`. This function takes a dataset and some other callbacks/state and either makes a new table or updates an existing one, handling errors accordingly.
  * Turning a context name into a dataset: `getDataSet`. This function is just a small wrapper that uses CodapPhone requests to turn a context name string into a dataset.

## Notes:
The main point of this PR is to take functionality that's copy+pasted in different components and factor it out to a single function. Hopefully this will make it easier for us to change the corresponding functionality in the future, since there's only one place to tweak and all components get updated.

Because of this, there's some pretty verbose function argument lists/names. I erred on the side of taking more arguments rather than fewer, so if we need to add more functionality that requires the extra state we have it.

Finally, it's worth noting the UI components don't actually look any different, they're just in one place now. I suppose we should also do a styling PR at some point.
