### PR TITLE
fix copying of attributes in flatten

### DIFF
--- a/src/transformations/flatten.ts
+++ b/src/transformations/flatten.ts
@@ -1,5 +1,4 @@
 import { DataSet } from "./types";
-import { copyAttrs } from "../utils/codapPhone";
 
 /**
  * Flatten produces an identical dataset with all hierarchical relationships
@@ -9,7 +8,7 @@ import { copyAttrs } from "../utils/codapPhone";
 export function flatten(dataset: DataSet): DataSet {
   // flatten attributes of all collections into single list of attributes
   const attrs = dataset.collections
-    .map((collection) => copyAttrs(collection.attrs) || [])
+    .map((collection) => collection.attrs?.slice() || [])
     .flat();
 
   // create combined name for collection

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -335,7 +335,7 @@ export function getDataContext(contextName: string): Promise<DataContext> {
 
 // Copies a list of attributes, only copying the fields relevant to our
 // representation of attributes and omitting any extra fields (cid, etc).
-export function copyAttrs(
+function copyAttrs(
   attrs: CodapAttribute[] | undefined
 ): CodapAttribute[] | undefined {
   return attrs?.map((attr) => {


### PR DESCRIPTION
Since every data context we get from CODAP passes through `normalizeDataContext`, its attributes are copied correctly and only include the fields we've defined in our `CodapAttribute` type.

Therefore, any further copying of attributes can simply do a normal copy, rather than having to use the `copyAttrs` functionality in `utils/codapPhone/index.ts`. I've updated flatten to no longer depend on this and removed the export of `copyAttrs`.