### PR TITLE
copy values instead of formulas in some transformations

### DIFF
--- a/src/transformations/compare.ts
+++ b/src/transformations/compare.ts
@@ -53,7 +53,13 @@ export function compare(
     {
       name: `Comparison of ${attributeName1} and ${attributeName2}`,
       labels: {},
-      attrs: [attributeData1, { ...attributeData2, name: safeAttributeName2 }],
+      // copy attributes to compare
+      // NOTE: do not copy formulas: formulas may be separated from their
+      // dependencies and would be invalid.
+      attrs: [
+        { ...attributeData1, formula: undefined },
+        { ...attributeData2, name: safeAttributeName2, formula: undefined },
+      ],
     },
   ];
   // Only add this attribute if this is a categorical diff

--- a/src/transformations/selectAttributes.ts
+++ b/src/transformations/selectAttributes.ts
@@ -32,6 +32,10 @@ export function selectAttributes(
   for (const coll of allCollections) {
     coll.attrs = coll.attrs?.filter((attr) => attributes.includes(attr.name));
 
+    // do not copy formulas: selected attributes may be separated from
+    // their formula's dependencies, rendering the formula invalid.
+    coll.attrs?.forEach((attr) => (attr.formula = undefined));
+
     // keep only collections that have at least one attribute
     if (coll.attrs === undefined || coll.attrs.length > 0) {
       collections.push(coll);


### PR DESCRIPTION
This implements the fixes noted [here](https://www.notion.so/Copying-values-vs-formulas-08f1a00664034e989e0487dcca63b1ff). 

For count, I also noticed that it wasn't ever counting objects correctly (for instance, Boundaries were always seen as distinct). I updated count to use `JSON.stringify` for now for deep equality but I really do not like this solution. LMK if you all have any ideas. 