### PR TITLE
Context update

### DIFF
--- a/src/transformation-components/util.ts
+++ b/src/transformation-components/util.ts
@@ -1,6 +1,9 @@
 import { DataSet } from "../transformations/types";
-import { createTableWithDataSet, setContextItems } from "../utils/codapPhone";
 import { DataContext } from "../utils/codapPhone/types";
+import {
+  createTableWithDataSet,
+  updateContextWithDataSet,
+} from "../utils/codapPhone";
 
 /**
  * This function takes a dataset as well as a `doUpdate` flag and either
@@ -22,7 +25,7 @@ export async function applyNewDataSet(
         setErrMsg("Please apply transformation to a new table first.");
         return;
       }
-      setContextItems(lastContextName, dataSet.records);
+      updateContextWithDataSet(lastContextName, dataSet);
     } else {
       const [newContext] = await createTableWithDataSet(dataSet, name);
       setLastContextName(newContext.name);

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -554,11 +554,19 @@ function fillAttrWithDefaults(attr: CodapAttribute): CodapAttribute {
     title: attr.title === undefined ? attr.name : attr.title,
     editable: attr.editable === undefined ? true : attr.editable,
     hidden: attr.hidden === undefined ? false : attr.hidden,
+    description: attr.description === undefined ? "" : attr.description,
   };
-  if (attr.type === undefined) {
+  if (withDefaults.type === undefined) {
     return {
       ...withDefaults,
       type: null,
+    };
+  }
+  if (withDefaults.type === "numeric") {
+    return {
+      ...withDefaults,
+      precision: 2,
+      unit: null,
     };
   }
   return withDefaults;

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -485,9 +485,30 @@ export async function updateContextWithDataSet(
   dataset: DataSet
 ): Promise<void> {
   const context = await getDataContext(contextName);
+  const concatNames = (nameAcc: string, collection: Collection) =>
+    nameAcc + collection.name;
+  const uniqueName =
+    context.collections.reduce(concatNames, "") +
+    dataset.collections.reduce(concatNames, "");
+
+  // Create placeholder empty collection, since data contexts must have at least
+  // one collection
+  await createCollections(contextName, [
+    {
+      name: uniqueName,
+      labels: {},
+    },
+  ]);
+
+  // Delete old collections
   for (const collection of context.collections) {
     await deleteAllCases(contextName, collection.name);
+    await deleteCollection(contextName, collection.name);
   }
+
+  // Insert new collections and delete placeholder
+  await createCollections(contextName, dataset.collections);
+  await deleteCollection(contextName, uniqueName);
 
   await insertDataItems(contextName, dataset.records);
 }
@@ -522,13 +543,14 @@ function deleteCollection(context: string, collection: string): Promise<void> {
         resource: collectionOfContext(context, collection),
       },
       (response) => {
-        if (response.success) {
-          resolve();
-        } else {
-          reject(
-            new Error(`Failed to delete collection ${collection} in ${context}`)
-          );
-        }
+        // if (response.success) {
+        //   resolve();
+        // } else {
+        //   reject(
+        //     new Error(`Failed to delete collection ${collection} in ${context}`)
+        //   );
+        // }
+        resolve();
       }
     )
   );

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -23,6 +23,7 @@ import {
   CaseTable,
   GetDataListResponse,
   CodapAttribute,
+  ExcludeNonObject,
 } from "./types";
 import { contextUpdateListeners, callAllContextListeners } from "./listeners";
 import { DataSet } from "../../transformations/types";
@@ -480,20 +481,43 @@ export function insertDataItems(
   );
 }
 
-function shallowEqual(a: any, b: any): boolean {
+/**
+ * Shallow equal
+ *
+ * Compares two objects for equality. This should not be used as a
+ * shallowEquals because of the way it treats `undefined` fields. A canonical
+ * shallowEquals will treat a field with a value of `undefined` and a missing
+ * field differently, but for our use case, we need to treat them the same. For
+ * example, if we send an attribute to CODAP with a missing field, the next
+ * time we query that object, it will be returned with the missing fields
+ * filled in with `undefined`. This will cause it to not be canonically equal
+ * to an identical objects with the undefined fields missing. This version of
+ * shallowEquals treats those objects as equal.
+ *
+ * @param a - The first object
+ * @param b - The second object
+ * @returns Whether the objects are equal
+ */
+function shallowEqual<T>(
+  a: ExcludeNonObject<T>,
+  b: ExcludeNonObject<T>
+): boolean {
+  // The type signature makes sure that the two arguments passed in have the
+  // same type, and that they are not a primitive value (they are objects). The
+  // casts allow us to use string keys. This is safe because the keys are
+  // obtained through `Object.keys`.
+  const aAsRecord = a as unknown as Record<string, unknown>;
+  const bAsRecord = b as unknown as Record<string, unknown>;
+
   if (a === b) {
     return true;
   }
 
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
+  const allKeys = new Set(Object.keys(a));
+  Object.keys(b).forEach((k) => allKeys.add(k));
 
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-
-  for (const key of keysA) {
-    if (!Object.prototype.hasOwnProperty.call(b, key) || a[key] !== b[key]) {
+  for (const key of allKeys) {
+    if (aAsRecord[key] !== bAsRecord[key]) {
       return false;
     }
   }
@@ -509,6 +533,45 @@ function attributesEqual(
     return attributes1 === attributes2;
   }
   return listEqual(attributes1, attributes2, shallowEqual);
+}
+
+/**
+ * Fill attribute with defaults
+ *
+ * These are the defaults that CODAP will automatically fill in.
+ * @param attr - Attribute to fill
+ * @returns Filled attribute
+ */
+function fillAttrWithDefaults(attr: CodapAttribute): CodapAttribute {
+  const withDefaults = {
+    ...attr,
+    title: attr.title === undefined ? attr.name : attr.title,
+    editable: attr.editable === undefined ? true : attr.editable,
+    hidden: attr.hidden === undefined ? false : attr.hidden,
+  };
+  if (attr.type === undefined) {
+    return {
+      ...withDefaults,
+      type: null,
+    };
+  }
+  return withDefaults;
+}
+
+/**
+ * Fill collection with defaults
+ *
+ * If the title is undefined, use the name as the title. Also fill the titles of
+ * the attrs.
+ * @param c - Collection to fill
+ * @returns Filled collection
+ */
+function fillCollectionWithDefaults(c: Collection): Collection {
+  return {
+    ...c,
+    attrs: c.attrs?.map(fillAttrWithDefaults),
+    title: c.title === undefined ? c.name : c.title,
+  };
 }
 
 function collectionEqual(c1: Collection, c2: Collection): boolean {
@@ -556,7 +619,15 @@ export async function updateContextWithDataSet(
     await deleteAllCases(contextName, collection.name);
   }
 
-  if (!collectionsEqual(context.collections, dataset.collections)) {
+  const normalizedCollections = dataset.collections.map(
+    fillCollectionWithDefaults
+  );
+
+  if (!collectionsEqual(context.collections, normalizedCollections)) {
+    console.group("Equality");
+    console.log(context.collections);
+    console.log(normalizedCollections);
+    console.groupEnd();
     const concatNames = (nameAcc: string, collection: Collection) =>
       nameAcc + collection.name;
     const uniqueName =

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -157,26 +157,32 @@ function codapRequestHandler(
     command.resource.startsWith(
       CodapInitiatedResource.DataContextChangeNotice
     ) &&
-    Array.isArray(command.values) &&
-    command.values.length > 0
+    Array.isArray(command.values)
   ) {
-    if (mutatingOperations.includes(command.values[0].operation)) {
-      const contextName = command.resource.slice(
-        command.resource.search("\\[") + 1,
-        command.resource.length - 1
-      );
-      if (contextUpdateListeners[contextName]) {
-        contextUpdateListeners[contextName]();
+    for (const value of command.values) {
+      if (mutatingOperations.includes(value.operation)) {
+        // Context name is between the first pair of brackets
+        const contextName = command.resource.slice(
+          command.resource.search("\\[") + 1,
+          command.resource.length - 1
+        );
+        if (contextUpdateListeners[contextName]) {
+          contextUpdateListeners[contextName]();
+        }
+        callback({ success: true });
+        return;
       }
-      callback({ success: true });
-      return;
-    }
-    if (command.values[0].operation === ContextChangeOperation.UpdateContext) {
-      callAllContextListeners();
-      callback({ success: true });
-      return;
+      if (
+        command.values[0].operation === ContextChangeOperation.UpdateContext
+      ) {
+        callAllContextListeners();
+        callback({ success: true });
+        return;
+      }
     }
   }
+
+  callback({ success: true });
 }
 
 export function getAllDataContexts(): Promise<CodapIdentifyingInfo[]> {

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -480,35 +480,107 @@ export function insertDataItems(
   );
 }
 
+function shallowEqual(a: any, b: any): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  for (const key of keysA) {
+    if (!Object.prototype.hasOwnProperty.call(b, key) || a[key] !== b[key]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function attributesEqual(
+  attributes1?: CodapAttribute[],
+  attributes2?: CodapAttribute[]
+): boolean {
+  if (attributes1 === undefined || attributes2 === undefined) {
+    return attributes1 === attributes2;
+  }
+  return listEqual(attributes1, attributes2, shallowEqual);
+}
+
+function collectionEqual(c1: Collection, c2: Collection): boolean {
+  return (
+    c1.name === c2.name &&
+    c1.title === c2.title &&
+    c1.description === c2.description &&
+    shallowEqual(c1.labels, c2.labels) &&
+    attributesEqual(c1.attrs, c2.attrs)
+  );
+}
+
+function listEqual<T>(
+  l1: T[],
+  l2: T[],
+  equalityFunc: (a: T, b: T) => boolean
+): boolean {
+  if (l1.length !== l2.length) {
+    return false;
+  }
+
+  for (let i = 0; i < l1.length; i++) {
+    if (!equalityFunc(l1[i], l2[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function collectionsEqual(
+  collections1: Collection[],
+  collections2: Collection[]
+) {
+  return listEqual(collections1, collections2, collectionEqual);
+}
+
 export async function updateContextWithDataSet(
   contextName: string,
   dataset: DataSet
 ): Promise<void> {
   const context = await getDataContext(contextName);
-  const concatNames = (nameAcc: string, collection: Collection) =>
-    nameAcc + collection.name;
-  const uniqueName =
-    context.collections.reduce(concatNames, "") +
-    dataset.collections.reduce(concatNames, "");
 
-  // Create placeholder empty collection, since data contexts must have at least
-  // one collection
-  await createCollections(contextName, [
-    {
-      name: uniqueName,
-      labels: {},
-    },
-  ]);
-
-  // Delete old collections
   for (const collection of context.collections) {
     await deleteAllCases(contextName, collection.name);
-    await deleteCollection(contextName, collection.name);
   }
 
-  // Insert new collections and delete placeholder
-  await createCollections(contextName, dataset.collections);
-  await deleteCollection(contextName, uniqueName);
+  if (!collectionsEqual(context.collections, dataset.collections)) {
+    const concatNames = (nameAcc: string, collection: Collection) =>
+      nameAcc + collection.name;
+    const uniqueName =
+      context.collections.reduce(concatNames, "") +
+      dataset.collections.reduce(concatNames, "");
+
+    // Create placeholder empty collection, since data contexts must have at least
+    // one collection
+    await createCollections(contextName, [
+      {
+        name: uniqueName,
+        labels: {},
+      },
+    ]);
+
+    // Delete old collections
+    for (const collection of context.collections) {
+      await deleteCollection(contextName, collection.name);
+    }
+
+    // Insert new collections and delete placeholder
+    await createCollections(contextName, dataset.collections);
+    await deleteCollection(contextName, uniqueName);
+  }
 
   await insertDataItems(contextName, dataset.records);
 }
@@ -543,14 +615,13 @@ function deleteCollection(context: string, collection: string): Promise<void> {
         resource: collectionOfContext(context, collection),
       },
       (response) => {
-        // if (response.success) {
-        //   resolve();
-        // } else {
-        //   reject(
-        //     new Error(`Failed to delete collection ${collection} in ${context}`)
-        //   );
-        // }
-        resolve();
+        if (response.success) {
+          resolve();
+        } else {
+          reject(
+            new Error(`Failed to delete collection ${collection} in ${context}`)
+          );
+        }
       }
     )
   );

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -271,7 +271,7 @@ export interface CategoricalAttribute extends RawAttribute {
 export interface NumericAttribute extends RawAttribute {
   type?: "numeric";
   precision?: number;
-  unit?: string;
+  unit?: string | null;
   colormap?: {
     "high-attribute-color": string;
     "low-attribute-color": string;

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -53,6 +53,12 @@ type CreateContextRequest = {
   };
 };
 
+type CreateCollectionsRequest = {
+  action: CodapActions.Create;
+  resource: string;
+  values: Collection[];
+};
+
 type CreateDataItemsRequest = {
   action: CodapActions.Create;
   resource: string;
@@ -78,7 +84,7 @@ interface CreateContextResponse extends CodapResponse {
   values: CodapIdentifyingInfo;
 }
 
-interface GetListResponse extends CodapResponse {
+interface ListResponse extends CodapResponse {
   values: CodapIdentifyingInfo[];
 }
 
@@ -112,8 +118,8 @@ interface TableResponse extends CodapResponse {
 
 export type CodapPhone = {
   call(r: UpdateInteractiveFrameRequest, cb: (r: CodapResponse) => void): void;
-  call(r: GetContextListRequest, cb: (r: GetListResponse) => void): void;
-  call(r: GetListRequest, cb: (r: GetListResponse) => void): void;
+  call(r: GetContextListRequest, cb: (r: ListResponse) => void): void;
+  call(r: GetListRequest, cb: (r: ListResponse) => void): void;
   call(r: GetRequest, cb: (r: GetDataResponse) => void): void;
   call(r: GetRequest, cb: (r: GetContextResponse) => void): void;
   call(r: GetRequest, cb: (r: GetDataListResponse) => void): void;
@@ -121,6 +127,7 @@ export type CodapPhone = {
   call(r: GetRequest, cb: (r: GetCaseResponse) => void): void;
   call(r: CreateContextRequest, cb: (r: CreateContextResponse) => void): void;
   call(r: CreateDataItemsRequest, cb: (r: CodapResponse) => void): void;
+  call(r: CreateCollectionsRequest, cb: (r: ListResponse) => void): void;
   call(r: DeleteRequest, cb: (r: CodapResponse) => void): void;
   call(r: CreateTableRequest, cb: (r: TableResponse) => void): void;
 };
@@ -132,18 +139,36 @@ export enum CodapInitiatedResource {
   DataContextChangeNotice = "dataContextChangeNotice",
 }
 
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#case-change-notifications
+// https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#example-collection-delete
 export enum ContextChangeOperation {
   UpdateCases = "updateCases",
   CreateCases = "createCases",
   DeleteCases = "deleteCases",
   SelectCases = "selectCases",
   UpdateContext = "updateDataContext",
+
+  // Despite the documentation, the first three of these are plural, while the
+  // last is singular
+  CreateAttribute = "createAttributes",
+  UpdateAttribute = "updateAttributes",
+  DeleteAttribute = "deleteAttributes",
+  MoveAttribute = "moveAttribute",
+
+  // Not sure where this is documented, but it is triggered when a collection
+  // is renamed, for example
+  UpdateCollection = "updateCollection",
 }
 
 export const mutatingOperations = [
   ContextChangeOperation.UpdateCases,
   ContextChangeOperation.CreateCases,
   ContextChangeOperation.DeleteCases,
+  ContextChangeOperation.CreateAttribute,
+  ContextChangeOperation.UpdateAttribute,
+  ContextChangeOperation.DeleteAttribute,
+  ContextChangeOperation.MoveAttribute,
+  ContextChangeOperation.UpdateCollection,
 ];
 
 export enum DocumentChangeOperations {

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -260,7 +260,7 @@ export interface RawAttribute {
 }
 
 export interface BaseAttribute extends RawAttribute {
-  type?: undefined;
+  type?: null;
 }
 
 export interface CategoricalAttribute extends RawAttribute {
@@ -428,3 +428,14 @@ type InteractiveFrame = {
   };
   savedState: Record<string, unknown>;
 };
+
+// Conditional type
+// https://www.typescriptlang.org/docs/handbook/2/conditional-types.html
+export type ExcludeNonObject<T> = T extends
+  | number
+  | boolean
+  | string
+  | null
+  | undefined
+  ? never
+  : T;


### PR DESCRIPTION
This is the finalized context update PR, with the recent merged changes folded in. Now there are reactive updates when things other than data change, such as when the user renames an attribute. These collection updates are done by first adding an empty collection, then deleting all old collections, then adding all the new collections. Since this is more expensive than the usual update (takes longer, more visual flicker), we will check if the collections have changed before performing this kind of update. If only the data has changed, we just delete and insert the data items as before.

A caveat is that when we delete all collections, the table gets shrunk, which feels finicky and is not great user experience. Not sure how to fix this yet.