### PR TITLE
count with multiple attributes

### DIFF
--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -8,7 +8,7 @@ import { count } from "../transformations/count";
 import {
   TransformationSubmitButtons,
   ContextSelector,
-  AttributeSelector,
+  CodapFlowTextArea,
 } from "../ui-components";
 import { applyNewDataSet } from "./util";
 
@@ -21,10 +21,10 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
     string | null,
     HTMLSelectElement
   >(null, () => setErrMsg(null));
-  const [attributeName, attributeNameChange] = useInput<
-    string,
-    HTMLSelectElement
-  >("", () => setErrMsg(null));
+  const [attributes, attributesChange] = useInput<string, HTMLTextAreaElement>(
+    "",
+    () => setErrMsg(null)
+  );
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
@@ -40,9 +40,15 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
       }
 
       const dataset = await getDataSet(inputDataCtxt);
+      const attributeNames = attributes.split("\n").map((s) => s.trim());
+
+      if (attributeNames.length === 0) {
+        setErrMsg("Please choose at least one attribute to count");
+        return;
+      }
 
       try {
-        const counted = count(dataset, attributeName);
+        const counted = count(dataset, attributeNames);
         await applyNewDataSet(
           counted,
           doUpdate,
@@ -54,7 +60,7 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
         setErrMsg(e.message);
       }
     },
-    [inputDataCtxt, attributeName, setErrMsg, lastContextName]
+    [inputDataCtxt, attributes, setErrMsg, lastContextName]
   );
 
   useContextUpdateListenerWithFlowEffect(
@@ -71,12 +77,8 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
       <p>Table to Count</p>
       <ContextSelector onChange={inputChange} value={inputDataCtxt} />
 
-      <p>Attribute to Count</p>
-      <AttributeSelector
-        context={inputDataCtxt}
-        value={attributeName}
-        onChange={attributeNameChange}
-      />
+      <p>Attributes to Count (1 per line)</p>
+      <CodapFlowTextArea value={attributes} onChange={attributesChange} />
 
       <br />
       <TransformationSubmitButtons

--- a/src/transformations/count.ts
+++ b/src/transformations/count.ts
@@ -1,96 +1,90 @@
 import { DataSet } from "./types";
 import { CodapAttribute, Collection } from "../utils/codapPhone/types";
+import { eraseFormulas, uniqueAttrName } from "./util";
 
 // TODO: allow for two modes:
 //  1) treat data like one table, values are counted across all cases
 //  2) treat hierarchy as subtables, values are counted *within subtable*
 
 /**
- * Count consumes a dataset and attribute name and produces a new
- * dataset that presents a summary of the frequency of difference
- * values of that attribute in the input dataset.
+ * Count consumes a dataset and list of attribute names and produces a new
+ * dataset that presents a summary of the frequency of all tuples of values
+ * from those attributes that are present in the input.
  *
- * The output dataset has one collection with two attributes under
- * the counted attribute name and `count`, which list all distinct values
- * of the attribute, and the number of times each value occurred, respectively.
+ * The output dataset has one collection containing all the counted attributes
+ * (with their distinct tuples), as well as a `count` attribute, which lists
+ * the frequency of a given tuple.
  */
-export function count(dataset: DataSet, attribute: string): DataSet {
-  // find the attribute corresponding to given attribute name
-  let attr: undefined | CodapAttribute;
-  for (const coll of dataset.collections) {
-    attr = coll.attrs?.find((attr) => attr.name === attribute);
-    if (attr) {
-      break;
+export function count(dataset: DataSet, attributes: string[]): DataSet {
+  // validate attribute names
+  for (const attrName of attributes) {
+    if (
+      dataset.collections.find((coll) =>
+        coll.attrs?.find((attr) => attr.name === attrName)
+      ) === undefined
+    ) {
+      throw new Error(`invalid attribute name: ${attrName}`);
     }
   }
 
-  // ensure attribute exists
-  if (attr === undefined) {
-    throw new Error(`invalid attribute name: ${attribute}`);
+  let countedAttrs: CodapAttribute[] = [];
+  for (const coll of dataset.collections) {
+    countedAttrs = countedAttrs.concat(
+      coll.attrs?.filter((attr) => attributes.includes(attr.name)).slice() || []
+    );
   }
+  eraseFormulas(countedAttrs);
 
-  // isolate values under this attribute
-  const values = dataset.records.map((record) => record[attribute]);
-  const uniqueValues = unique(values);
+  // generate a unique attribute name for the `count` column
+  const countAttrName = uniqueAttrName("count", countedAttrs);
 
-  // count occurrences of each distinct value under this attribute
-  const records: Record<string, unknown>[] = uniqueValues.map((value) => {
-    const record: Record<string, unknown> = {};
-    record[attribute] = value;
-    record["count"] = values.filter((v) => valueEquals(v, value)).length;
-    return record;
-  });
-
-  // construct collection with value/count attributes only
+  // single collection with copy of counted attributes, plus
+  // a new "count" attribute for the frequencies
   const collections: Collection[] = [
     {
-      name: `Count (${attribute})`,
+      name: `Count (${attributes.join(", ")})`,
       labels: {},
-      attrs: [
-        // first attribute is a copy of the original
-        // NOTE: formulas are not copied: a formula-based attribute being
-        // counted will be removed from its dependencies in the output
-        // which makes the formula invalid.
-        { ...attr, formula: undefined },
-        // second attribute is "count", containing all counts
-        { name: "count" },
-      ],
+      attrs: [...countedAttrs, { name: countAttrName }],
     },
   ];
+
+  // make copy of records containing only the attributes to count
+  const tuples = dataset.records.map((record) => {
+    const copy: Record<string, unknown> = {};
+    for (const attrName of attributes) {
+      if (record[attrName] === undefined) {
+        throw new Error(`invalid attribute name: ${attrName}`);
+      }
+
+      copy[attrName] = record[attrName];
+    }
+    return copy;
+  });
+
+  // map from stringified tuples to the tuple itself and its frequency
+  const tupleToCount: Record<string, Record<string, unknown>> = {};
+
+  // count frequency of tuples in dataset
+  tuples.forEach((tuple) => {
+    const key = JSON.stringify(tuple);
+
+    if (tupleToCount[key] === undefined) {
+      const withCount = { ...tuple };
+      withCount[countAttrName] = 1;
+      tupleToCount[key] = withCount;
+    } else {
+      // the count field is guaranteed to exist because
+      // we initialized it with a count of 1
+      // eslint-disable-next-line
+      (tupleToCount[key] as any)[countAttrName]++;
+    }
+  });
+
+  // the distinct, counted tuples become the records of the new dataset
+  const records = Object.values(tupleToCount);
 
   return {
     collections,
     records,
   };
-}
-
-/**
- * Determines whether or not two values from the same attribute are
- * equivalent for the purposes of counting. Attributes may consist
- * of objects so this can't just be == or ===.
- */
-function valueEquals(left: unknown, right: unknown): boolean {
-  // FIXME: this is SUPER slow for boundary objects
-  return JSON.stringify(left) === JSON.stringify(right);
-}
-
-/**
- * Produces a version of the input list without duplicate elements.
- * @param values list to de-duplicate
- * @returns list without duplicates
- */
-function unique(values: unknown[]): unknown[] {
-  const soFar: unknown[] = [];
-
-  outer: for (const v of values) {
-    for (const already of soFar) {
-      if (valueEquals(v, already)) {
-        continue outer;
-      }
-    }
-
-    soFar.push(v);
-  }
-
-  return soFar;
 }

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -108,3 +108,36 @@ export function insertInRow(
   newRow[newProp] = newValue;
   return newRow;
 }
+
+/**
+ * Sets `formula` field of all attributes in the given list
+ * to undefined. Useful in several transformations where
+ * preserving formulas will result in broken formulas.
+ */
+export function eraseFormulas(attrs: CodapAttribute[]): void {
+  attrs.forEach((attr) => (attr.formula = undefined));
+}
+
+/**
+ * Finds an attribute name with the given base that is unique relative
+ * to the given list of attributes.
+ */
+export function uniqueAttrName(base: string, attrs: CodapAttribute[]): string {
+  let name = base;
+  let counter = 0;
+  let conflicts = true;
+  while (conflicts) {
+    conflicts = false;
+    for (const attr of attrs) {
+      if (attr.name === name) {
+        conflicts = true;
+        break;
+      }
+    }
+    if (conflicts) {
+      counter++;
+      name = `${base} (${counter})`;
+    }
+  }
+  return name;
+}


### PR DESCRIPTION
This is a new version of count that allows the user to select multiple attributes to count by. It counts the frequency of every tuple of those attributes that is present in the input dataset. For instance, if you want to count the frequency of Sex/Age pairs, you could get the following output:

![multi-count](https://user-images.githubusercontent.com/13399527/119689121-96977b80-be16-11eb-8a16-3a9c070268f7.png)
