### PR TITLE
name tables relative to transformations

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -56,7 +56,11 @@ function Transformation(): ReactElement {
       <Fold setErrMsg={setErrMsg} label="Running Max" foldFunc={runningMax} />
     ),
     "Running Difference": (
-      <Fold setErrMsg={setErrMsg} label="Running Difference" foldFunc={difference} />
+      <Fold
+        setErrMsg={setErrMsg}
+        label="Running Difference"
+        foldFunc={difference}
+      />
     ),
     "Difference From": <DifferenceFrom setErrMsg={setErrMsg} />,
     Sort: <Sort setErrMsg={setErrMsg} />,

--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -44,19 +44,19 @@ function Transformation(): ReactElement {
     Flatten: <Flatten setErrMsg={setErrMsg} />,
     Compare: <Compare setErrMsg={setErrMsg} />,
     "Running Sum": (
-      <Fold setErrMsg={setErrMsg} label="running sum" foldFunc={runningSum} />
+      <Fold setErrMsg={setErrMsg} label="Running Sum" foldFunc={runningSum} />
     ),
     "Running Mean": (
-      <Fold setErrMsg={setErrMsg} label="running mean" foldFunc={runningMean} />
+      <Fold setErrMsg={setErrMsg} label="Running Mean" foldFunc={runningMean} />
     ),
     "Running Min": (
-      <Fold setErrMsg={setErrMsg} label="running min" foldFunc={runningMin} />
+      <Fold setErrMsg={setErrMsg} label="Running Min" foldFunc={runningMin} />
     ),
     "Running Max": (
-      <Fold setErrMsg={setErrMsg} label="running max" foldFunc={runningMax} />
+      <Fold setErrMsg={setErrMsg} label="Running Max" foldFunc={runningMax} />
     ),
     "Running Difference": (
-      <Fold setErrMsg={setErrMsg} label="difference" foldFunc={difference} />
+      <Fold setErrMsg={setErrMsg} label="Running Difference" foldFunc={difference} />
     ),
     "Difference From": <DifferenceFrom setErrMsg={setErrMsg} />,
     Sort: <Sort setErrMsg={setErrMsg} />,

--- a/src/transformation-components/BuildColumn.tsx
+++ b/src/transformation-components/BuildColumn.tsx
@@ -71,6 +71,7 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
         );
         await applyNewDataSet(
           built,
+          `Build Column of ${inputDataCtxt}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/BuildColumn.tsx
+++ b/src/transformation-components/BuildColumn.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useCallback, ReactElement } from "react";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 import {
   useInput,
   useContextUpdateListenerWithFlowEffect,
 } from "../utils/hooks";
 import { buildColumn } from "../transformations/buildColumn";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 import {
   CodapFlowTextArea,
   CodapFlowTextInput,
@@ -60,7 +60,7 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
         return;
       }
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
         const built = buildColumn(
@@ -71,7 +71,7 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
         );
         await applyNewDataSet(
           built,
-          `Build Column of ${inputDataCtxt}`,
+          `Build Column of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -64,6 +64,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
         );
         await applyNewDataSet(
           compared,
+          `Compare of ${inputDataContext1} and ${inputDataContext2}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, ReactElement } from "react";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useInput,
@@ -11,7 +11,7 @@ import {
   ContextSelector,
   TransformationSubmitButtons,
 } from "../ui-components";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 
 interface CompareProps {
   setErrMsg: (s: string | null) => void;
@@ -51,8 +51,10 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
         return;
       }
 
-      const dataset1 = await getDataSet(inputDataContext1);
-      const dataset2 = await getDataSet(inputDataContext2);
+      const { context: context1, dataset: dataset1 } =
+        await getContextAndDataSet(inputDataContext1);
+      const { context: context2, dataset: dataset2 } =
+        await getContextAndDataSet(inputDataContext2);
 
       try {
         const compared = compare(
@@ -64,7 +66,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
         );
         await applyNewDataSet(
           compared,
-          `Compare of ${inputDataContext1} and ${inputDataContext2}`,
+          `Compare of ${ctxtTitle(context1)} and ${ctxtTitle(context2)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, ReactElement, useState } from "react";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useInput,
@@ -10,7 +10,7 @@ import {
   ContextSelector,
   AttributeSelector,
 } from "../ui-components";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 
 interface CountProps {
   setErrMsg: (s: string | null) => void;
@@ -39,13 +39,13 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
         return;
       }
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
         const counted = count(dataset, attributeName);
         await applyNewDataSet(
           counted,
-          `Count of ${inputDataCtxt}`,
+          `Count of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -45,6 +45,7 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
         const counted = count(dataset, attributeName);
         await applyNewDataSet(
           counted,
+          `Count of ${inputDataCtxt}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -68,6 +68,7 @@ export function DifferenceFrom({
         );
         await applyNewDataSet(
           result,
+          `Difference From of ${inputDataCtxt}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, ReactElement, useState } from "react";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useInput,
@@ -11,7 +11,7 @@ import {
   TransformationSubmitButtons,
   ContextSelector,
 } from "../ui-components";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 
 export function DifferenceFrom({
   setErrMsg,
@@ -57,7 +57,7 @@ export function DifferenceFrom({
         );
       }
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
         const result = differenceFrom(
@@ -68,7 +68,7 @@ export function DifferenceFrom({
         );
         await applyNewDataSet(
           result,
-          `Difference From of ${inputDataCtxt}`,
+          `Difference From of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useCallback, ReactElement, useState } from "react";
 import {
   addContextUpdateListener,
   removeContextUpdateListener,
-  getDataSet,
+  getContextAndDataSet,
 } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
@@ -14,7 +14,7 @@ import {
   CodapFlowTextArea,
   ContextSelector,
 } from "../ui-components";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 
 interface FilterProps {
   setErrMsg: (s: string | null) => void;
@@ -45,13 +45,13 @@ export function Filter({ setErrMsg }: FilterProps): ReactElement {
       console.log(`Data context to filter: ${inputDataCtxt}`);
       console.log(`Filter predicate to apply:\n${transformPgrm}`);
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
         const filtered = filter(dataset, transformPgrm);
         await applyNewDataSet(
           filtered,
-          `Filter of ${inputDataCtxt}`,
+          `Filter of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -51,6 +51,7 @@ export function Filter({ setErrMsg }: FilterProps): ReactElement {
         const filtered = filter(dataset, transformPgrm);
         await applyNewDataSet(
           filtered,
+          `Filter of ${inputDataCtxt}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -37,6 +37,7 @@ export function Flatten({ setErrMsg }: FlattenProps): ReactElement {
         const flat = flatten(dataset);
         await applyNewDataSet(
           flat,
+          `Flatten of ${inputDataCtxt}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, ReactElement, useState } from "react";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useInput,
 } from "../utils/hooks";
 import { flatten } from "../transformations/flatten";
 import { TransformationSubmitButtons, ContextSelector } from "../ui-components";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 
 interface FlattenProps {
   setErrMsg: (s: string | null) => void;
@@ -31,13 +31,13 @@ export function Flatten({ setErrMsg }: FlattenProps): ReactElement {
         return;
       }
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
         const flat = flatten(dataset);
         await applyNewDataSet(
           flat,
-          `Flatten of ${inputDataCtxt}`,
+          `Flatten of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, ReactElement, useState } from "react";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useInput,
@@ -11,7 +11,7 @@ import {
   TransformationSubmitButtons,
   ContextSelector,
 } from "../ui-components";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 
 interface FoldProps extends TransformationProps {
   label: string;
@@ -52,13 +52,13 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
         return;
       }
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
         const result = foldFunc(dataset, inputColumnName, resultColumnName);
         await applyNewDataSet(
           result,
-          `Fold of ${inputDataCtxt}`,
+          `Fold of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -58,6 +58,7 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
         const result = foldFunc(dataset, inputColumnName, resultColumnName);
         await applyNewDataSet(
           result,
+          `Fold of ${inputDataCtxt}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -58,7 +58,7 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
         const result = foldFunc(dataset, inputColumnName, resultColumnName);
         await applyNewDataSet(
           result,
-          `Fold of ${ctxtTitle(context)}`,
+          `${label} of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,
@@ -75,6 +75,7 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
       setErrMsg,
       foldFunc,
       lastContextName,
+      label,
     ]
   );
 
@@ -89,7 +90,7 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
 
   return (
     <>
-      <p>Table to calculate {label} on</p>
+      <p>Table to calculate {label.toLowerCase()} on</p>
       <ContextSelector onChange={inputChange} value={inputDataCtxt} />
       <p>Input Column Name:</p>
       <CodapFlowTextInput

--- a/src/transformation-components/GroupBy.tsx
+++ b/src/transformation-components/GroupBy.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useCallback, ReactElement } from "react";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 import {
   useInput,
   useContextUpdateListenerWithFlowEffect,
 } from "../utils/hooks";
 import { groupBy } from "../transformations/groupBy";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 import {
   CodapFlowTextArea,
   TransformationSubmitButtons,
@@ -43,7 +43,7 @@ export function GroupBy({ setErrMsg }: GroupByProps): ReactElement {
         return;
       }
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       // extract attribute names from user's text
       const attributeNames = attributes.split("\n").map((s) => s.trim());
@@ -53,7 +53,7 @@ export function GroupBy({ setErrMsg }: GroupByProps): ReactElement {
         const grouped = groupBy(dataset, attributeNames, parentName);
         await applyNewDataSet(
           grouped,
-          `Group By of ${inputDataCtxt}`,
+          `Group By of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/GroupBy.tsx
+++ b/src/transformation-components/GroupBy.tsx
@@ -53,6 +53,7 @@ export function GroupBy({ setErrMsg }: GroupByProps): ReactElement {
         const grouped = groupBy(dataset, attributeNames, parentName);
         await applyNewDataSet(
           grouped,
+          `Group By of ${inputDataCtxt}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -56,6 +56,7 @@ export function SelectAttributes({
         const selected = selectAttributes(dataset, attributeNames, allBut);
         await applyNewDataSet(
           selected,
+          `Select Attributes of ${inputDataCtxt}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, ReactElement, useState } from "react";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useInput,
@@ -10,7 +10,7 @@ import {
   CodapFlowTextArea,
   ContextSelector,
 } from "../ui-components";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 
 interface SelectAttributesProps {
   setErrMsg: (s: string | null) => void;
@@ -44,7 +44,7 @@ export function SelectAttributes({
         return;
       }
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       // extract attribute names from user's text
       const attributeNames = attributes.split("\n").map((s) => s.trim());
@@ -56,7 +56,7 @@ export function SelectAttributes({
         const selected = selectAttributes(dataset, attributeNames, allBut);
         await applyNewDataSet(
           selected,
-          `Select Attributes of ${inputDataCtxt}`,
+          `Select Attributes of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -44,6 +44,7 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
         const result = sort(dataset, keyExpression);
         await applyNewDataSet(
           result,
+          `Sort of ${inputDataCtxt}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, ReactElement, useState } from "react";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 import {
   useContextUpdateListenerWithFlowEffect,
   useInput,
@@ -11,7 +11,7 @@ import {
   CodapFlowTextArea,
   ContextSelector,
 } from "../ui-components";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 
 export function Sort({ setErrMsg }: TransformationProps): ReactElement {
   const [inputDataCtxt, inputChange] = useInput<
@@ -38,13 +38,13 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
         return;
       }
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
         const result = sort(dataset, keyExpression);
         await applyNewDataSet(
           result,
-          `Sort of ${inputDataCtxt}`,
+          `Sort of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/TransformColumn.tsx
+++ b/src/transformation-components/TransformColumn.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, ReactElement } from "react";
 import { useInput } from "../utils/hooks";
 import { transformColumn } from "../transformations/transformColumn";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 import {
   CodapFlowTextArea,
   CodapFlowTextInput,
@@ -9,7 +9,7 @@ import {
   ContextSelector,
 } from "../ui-components";
 import { useContextUpdateListenerWithFlowEffect } from "../utils/hooks";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 
 interface TransformColumnProps {
   setErrMsg: (s: string | null) => void;
@@ -51,13 +51,13 @@ export function TransformColumn({
         return;
       }
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
         const transformed = transformColumn(dataset, attributeName, expression);
         await applyNewDataSet(
           transformed,
-          `Transform Column of ${inputDataCtxt}`,
+          `Transform Column of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/TransformColumn.tsx
+++ b/src/transformation-components/TransformColumn.tsx
@@ -57,6 +57,7 @@ export function TransformColumn({
         const transformed = transformColumn(dataset, attributeName, expression);
         await applyNewDataSet(
           transformed,
+          `Transform Column of ${inputDataCtxt}`,
           doUpdate,
           lastContextName,
           setLastContextName,

--- a/src/transformation-components/util.ts
+++ b/src/transformation-components/util.ts
@@ -1,5 +1,6 @@
 import { DataSet } from "../transformations/types";
 import { createTableWithDataSet, setContextItems } from "../utils/codapPhone";
+import { DataContext } from "../utils/codapPhone/types";
 
 /**
  * This function takes a dataset as well as a `doUpdate` flag and either
@@ -29,4 +30,11 @@ export async function applyNewDataSet(
   } catch (e) {
     setErrMsg(e.message);
   }
+}
+
+/**
+ * Returns the context's title, if any, or falls back to its name.
+ */
+export function ctxtTitle(context: DataContext): string {
+  return context.title ? context.title : context.name;
 }

--- a/src/transformation-components/util.ts
+++ b/src/transformation-components/util.ts
@@ -7,6 +7,7 @@ import { createTableWithDataSet, setContextItems } from "../utils/codapPhone";
  */
 export async function applyNewDataSet(
   dataSet: DataSet,
+  name: string | undefined,
   doUpdate: boolean,
   lastContextName: string | null,
   setLastContextName: (s: string) => void,
@@ -22,7 +23,7 @@ export async function applyNewDataSet(
       }
       setContextItems(lastContextName, dataSet.records);
     } else {
-      const [newContext] = await createTableWithDataSet(dataSet);
+      const [newContext] = await createTableWithDataSet(dataSet, name);
       setLastContextName(newContext.name);
     }
   } catch (e) {

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -26,6 +26,7 @@ import {
 } from "./types";
 import { contextUpdateListeners, callAllContextListeners } from "./listeners";
 import { DataSet } from "../../transformations/types";
+import { DirectoryWatcherCallback } from "typescript";
 
 export {
   addNewContextListener,
@@ -315,10 +316,21 @@ export async function getDataFromContext(
   );
 }
 
-export async function getDataSet(contextName: string): Promise<DataSet> {
+/**
+ * Retrieves both a context and a dataset constructed from the context,
+ * given a context name to lookup.
+ */
+export async function getContextAndDataSet(contextName: string): Promise<{
+  context: DataContext;
+  dataset: DataSet;
+}> {
+  const context = await getDataContext(contextName);
   return {
-    collections: (await getDataContext(contextName)).collections,
-    records: await getDataFromContext(contextName),
+    context,
+    dataset: {
+      collections: context.collections,
+      records: await getDataFromContext(contextName),
+    },
   };
 }
 

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -568,12 +568,14 @@ async function ensureUniqueName(
     return name;
   }
 
+  const numberedName = (name: string, i: number) => `${name} (${i})`;
+
   // Otherwise find a suffix for the name that makes it unique
   let i = 1;
-  while (names.includes(`${name}_(${i})`)) {
+  while (names.includes(numberedName(name, i))) {
     i += 1;
   }
-  return `${name}_(${i})`;
+  return numberedName(name, i);
 }
 
 export async function createTableWithDataSet(
@@ -588,8 +590,8 @@ export async function createTableWithDataSet(
   }
 
   // Generate names
-  let contextName = `${baseName}_context`;
-  let tableName = `${baseName}_table`;
+  let contextName = `${baseName} Context`;
+  let tableName = `${baseName}`;
 
   // Ensure names are unique
   contextName = await ensureUniqueName(


### PR DESCRIPTION
This updates the naming of tables/contexts to use names relevant to the performed transformation, such as "Filter of ____" or "Count of ___".

Note that with this approach names can get pretty unwieldy pretty quickly, if you are heavily composing transformations.

![table-names](https://user-images.githubusercontent.com/13399527/119708451-2a267780-be2a-11eb-9e6d-c5627d8b3d23.png)
