### PR TITLE
Add "Categorical Compare" transformation

### DIFF
--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -134,7 +134,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
         options={[
           { value: "categorical", title: "Categorical" },
           { value: "numeric", title: "Numeric" },
-          { value: "decision", title: "Decision" },
+          { value: "structural", title: "Structural" },
         ]}
         value={compareType}
         defaultValue="Select a type"

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -4,7 +4,7 @@ import {
   useContextUpdateListenerWithFlowEffect,
   useInput,
 } from "../utils/hooks";
-import { compare } from "../transformations/compare";
+import { compare, CompareType } from "../transformations/compare";
 import {
   CodapFlowSelect,
   AttributeSelector,
@@ -33,7 +33,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
 
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
-  const [isCategorical, setIsCategorical] = useState<boolean>(false);
+  const [compareType, setCompareType] = useState<CompareType>("numeric");
 
   const transform = useCallback(
     async (doUpdate: boolean) => {
@@ -58,7 +58,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
           dataset2,
           inputAttribute1,
           inputAttribute2,
-          isCategorical
+          compareType
         );
         await applyNewDataSet(
           compared,
@@ -78,7 +78,7 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
       inputAttribute1,
       inputAttribute2,
       lastContextName,
-      isCategorical,
+      compareType,
       setErrMsg,
     ]
   );
@@ -103,12 +103,12 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
 
   return (
     <>
-      <p>Table to Compare 1</p>
+      <p>First Table to Compare </p>
       <ContextSelector
         value={inputDataContext1}
         onChange={inputDataContext1OnChange}
       />
-      <p>Table to Compare 2</p>
+      <p>Second Table to Compare</p>
       <ContextSelector
         value={inputDataContext2}
         onChange={inputDataContext2OnChange}
@@ -130,16 +130,13 @@ export function Compare({ setErrMsg }: CompareProps): ReactElement {
 
       <p>What kind of Comparison?</p>
       <CodapFlowSelect
-        onChange={(e) =>
-          e.target.value === "categorical"
-            ? setIsCategorical(true)
-            : setIsCategorical(false)
-        }
+        onChange={(e) => setCompareType(e.target.value as CompareType)}
         options={[
           { value: "categorical", title: "Categorical" },
           { value: "numeric", title: "Numeric" },
+          { value: "decision", title: "Decision" },
         ]}
-        value={isCategorical ? "categorical" : "numeric"}
+        value={compareType}
         defaultValue="Select a type"
       />
 

--- a/src/transformations/__tests__/util.test.js
+++ b/src/transformations/__tests__/util.test.js
@@ -1,0 +1,41 @@
+import {
+  setDifferenceWithPredicate,
+  intersectionWithPredicate,
+  unionWithPredicate,
+  symmetricDifferenceWithPredicate,
+} from "../util";
+
+test("set union works", () => {
+  const arr1 = [1, 2, 3, 4, 5, 6];
+  const arr2 = [2, 4, 6, 8, 10];
+  expect(unionWithPredicate(arr1, arr2, (x, y) => x === y)).toEqual([
+    1, 2, 3, 4, 5, 6, 8, 10,
+  ]);
+});
+
+test("set intersection works", () => {
+  const arr1 = [1, 2, 3, 4, 5, 6];
+  const arr2 = [2, 4, 6, 8, 10];
+  expect(intersectionWithPredicate(arr1, arr2, (x, y) => x === y)).toEqual([
+    2, 4, 6,
+  ]);
+});
+
+test("set difference works", () => {
+  const arr1 = [1, 2, 3, 4, 5, 6];
+  const arr2 = [2, 4, 6, 8, 10];
+  expect(setDifferenceWithPredicate(arr1, arr2, (x, y) => x === y)).toEqual([
+    1, 3, 5,
+  ]);
+  expect(setDifferenceWithPredicate(arr2, arr1, (x, y) => x === y)).toEqual([
+    8, 10,
+  ]);
+});
+
+test("set symmetric difference works", () => {
+  const arr1 = [1, 2, 3, 4, 5, 6];
+  const arr2 = [2, 4, 6, 8, 10];
+  expect(
+    symmetricDifferenceWithPredicate(arr1, arr2, (x, y) => x === y)
+  ).toEqual([1, 3, 5, 8, 10]);
+});

--- a/src/transformations/compare.ts
+++ b/src/transformations/compare.ts
@@ -256,7 +256,9 @@ function objectsAreEqualForKeys(
   object2: Record<string, unknown>,
   keys: string[]
 ): boolean {
-  return keys.every((key) => object1[key] === object2[key]);
+  return keys.every(
+    (key) => JSON.stringify(object1[key]) === JSON.stringify(object2[key])
+  );
 }
 
 function compareRecordsNumerical(

--- a/src/transformations/compare.ts
+++ b/src/transformations/compare.ts
@@ -11,8 +11,8 @@ const GREEN = "rgb(0,255,0)";
 const RED = "rgb(255,0,0)";
 const GREY = "rgb(100,100,100)";
 
-const DECISION_1_COLUMN_NAME = "Decision 1";
-const DECISION_2_COLUMN_NAME = "Decision 2";
+const DECISION_1_COLUMN_NAME = "Category 1";
+const DECISION_2_COLUMN_NAME = "Category 2";
 
 export type CompareType = "numeric" | "categorical" | "structural";
 

--- a/src/transformations/compare.ts
+++ b/src/transformations/compare.ts
@@ -196,7 +196,10 @@ function compareCategorical(
 
   const records = [];
 
+  // Loop through all records in the first data context
   for (const record1 of dataset1.records) {
+    // We consider a record a duplicate between the two contexts if
+    // it has equal values for all attributes which the two contexts share
     const duplicate = dataset2.records.find((record2) =>
       objectsAreEqualForKeys(
         record1,
@@ -204,16 +207,26 @@ function compareCategorical(
         attributesIntersection.map((attr) => attr.name)
       )
     );
-    if (duplicate !== undefined) {
+
+    if (duplicate === undefined) {
+      // If we didn't find a duplicate then just push the record
+      records.push({
+        record1,
+        [DECISION_1_COLUMN_NAME]: record1[attribute1Data.name],
+      });
+    } else {
+      // If we did find a duplicate then merge the records, set the decision
+      // attribute values, and push
       records.push({
         ...record1,
         ...duplicate,
+        [DECISION_1_COLUMN_NAME]: record1[attribute1Data.name],
+        [DECISION_2_COLUMN_NAME]: duplicate[attribute2Data.name],
       });
-    } else {
-      records.push(record1);
     }
   }
 
+  // Same logic as above loop
   for (const record2 of dataset2.records) {
     const duplicate = dataset1.records.find((record1) =>
       objectsAreEqualForKeys(
@@ -225,18 +238,12 @@ function compareCategorical(
     if (duplicate !== undefined) {
       // Skip this record since we already added it in the first loop
     } else {
-      records.push(record2);
+      records.push({
+        record2,
+        [DECISION_2_COLUMN_NAME]: record2[attribute2Data.name],
+      });
     }
   }
-
-  records.forEach((record) => {
-    if (record[attribute1Data.name] !== undefined) {
-      record[DECISION_1_COLUMN_NAME] = record[attribute1Data.name];
-    }
-    if (record[attribute2Data.name] !== undefined) {
-      record[DECISION_2_COLUMN_NAME] = record[attribute2Data.name];
-    }
-  });
 
   return {
     collections,

--- a/src/transformations/compare.ts
+++ b/src/transformations/compare.ts
@@ -211,7 +211,7 @@ function compareCategorical(
     if (duplicate === undefined) {
       // If we didn't find a duplicate then just push the record
       records.push({
-        record1,
+        ...record1,
         [DECISION_1_COLUMN_NAME]: record1[attribute1Data.name],
       });
     } else {
@@ -239,7 +239,7 @@ function compareCategorical(
       // Skip this record since we already added it in the first loop
     } else {
       records.push({
-        record2,
+        ...record2,
         [DECISION_2_COLUMN_NAME]: record2[attribute2Data.name],
       });
     }

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -117,3 +117,93 @@ export function insertInRow(
 export function eraseFormulas(attrs: CodapAttribute[]): void {
   attrs.forEach((attr) => (attr.formula = undefined));
 }
+
+/**
+ * Finds an attribute name with the given base that is unique relative
+ * to the given list of attributes.
+ */
+export function uniqueAttrName(base: string, attrs: CodapAttribute[]): string {
+  let name = base;
+  let counter = 0;
+  let conflicts = true;
+  while (conflicts) {
+    conflicts = false;
+    for (const attr of attrs) {
+      if (attr.name === name) {
+        conflicts = true;
+        break;
+      }
+    }
+    if (conflicts) {
+      counter++;
+      name = `${base} (${counter})`;
+    }
+  }
+  return name;
+}
+
+/**
+ * Compute the union of two arrays, using `pred` to determine equality
+ */
+export function unionWithPredicate<T>(
+  array1: T[],
+  array2: T[],
+  pred: (elt1: T, elt2: T) => boolean
+): T[] {
+  const out: T[] = [];
+
+  const merged: T[] = array1.concat(array2);
+
+  for (const elementToBeAdded of merged) {
+    if (
+      out.find((existingElement: T) =>
+        pred(existingElement, elementToBeAdded)
+      ) === undefined
+    ) {
+      out.push(elementToBeAdded);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Compute the intersection of two arrays, using `pred` to determine equality
+ */
+export function intersectionWithPredicate<T>(
+  array1: T[],
+  array2: T[],
+  pred: (elt1: T, elt2: T) => boolean
+): T[] {
+  return array1.filter(
+    (elt1) => array2.find((elt2) => pred(elt1, elt2)) !== undefined
+  );
+}
+
+/**
+ * Compute the difference of two arrays, using `pred` to determine equality
+ */
+export function setDifferenceWithPredicate<T>(
+  array1: T[],
+  array2: T[],
+  pred: (elt1: T, elt2: T) => boolean
+): T[] {
+  return array1.filter(
+    (elt1) => array2.find((elt2) => pred(elt1, elt2)) === undefined
+  );
+}
+
+/**
+ * Compute the symmetric difference of two arrays, using `pred` to determine equality
+ */
+export function symmetricDifferenceWithPredicate<T>(
+  array1: T[],
+  array2: T[],
+  pred: (elt1: T, elt2: T) => boolean
+): T[] {
+  return unionWithPredicate(
+    setDifferenceWithPredicate(array1, array2, pred),
+    setDifferenceWithPredicate(array2, array1, pred),
+    pred
+  );
+}

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -1,6 +1,7 @@
 import { Collection, CodapAttribute } from "../utils/codapPhone/types";
 import { Env } from "../language/interpret";
 import { Value } from "../language/ast";
+import { DataSet } from "./types";
 
 /**
  * Converts a data item object into an environment for our language. Only
@@ -142,68 +143,21 @@ export function uniqueAttrName(base: string, attrs: CodapAttribute[]): string {
   return name;
 }
 
-/**
- * Compute the union of two arrays, using `pred` to determine equality
- */
-export function unionWithPredicate<T>(
-  array1: T[],
-  array2: T[],
-  pred: (elt1: T, elt2: T) => boolean
-): T[] {
-  const out: T[] = [];
-
-  const merged: T[] = array1.concat(array2);
-
-  for (const elementToBeAdded of merged) {
-    if (
-      out.find((existingElement: T) =>
-        pred(existingElement, elementToBeAdded)
-      ) === undefined
-    ) {
-      out.push(elementToBeAdded);
-    }
+export function getAttributeDataFromDataset(
+  attributeName: string,
+  dataset: DataSet
+): CodapAttribute {
+  let attributeData: CodapAttribute | undefined;
+  for (const collection of dataset.collections) {
+    attributeData =
+      collection.attrs?.find((attribute) => attribute.name === attributeName) ??
+      attributeData;
+  }
+  if (!attributeData) {
+    throw new Error(
+      "Couldn't find first selected attribute in selected context"
+    );
   }
 
-  return out;
-}
-
-/**
- * Compute the intersection of two arrays, using `pred` to determine equality
- */
-export function intersectionWithPredicate<T>(
-  array1: T[],
-  array2: T[],
-  pred: (elt1: T, elt2: T) => boolean
-): T[] {
-  return array1.filter(
-    (elt1) => array2.find((elt2) => pred(elt1, elt2)) !== undefined
-  );
-}
-
-/**
- * Compute the difference of two arrays, using `pred` to determine equality
- */
-export function setDifferenceWithPredicate<T>(
-  array1: T[],
-  array2: T[],
-  pred: (elt1: T, elt2: T) => boolean
-): T[] {
-  return array1.filter(
-    (elt1) => array2.find((elt2) => pred(elt1, elt2)) === undefined
-  );
-}
-
-/**
- * Compute the symmetric difference of two arrays, using `pred` to determine equality
- */
-export function symmetricDifferenceWithPredicate<T>(
-  array1: T[],
-  array2: T[],
-  pred: (elt1: T, elt2: T) => boolean
-): T[] {
-  return unionWithPredicate(
-    setDifferenceWithPredicate(array1, array2, pred),
-    setDifferenceWithPredicate(array2, array1, pred),
-    pred
-  );
+  return attributeData;
 }

--- a/src/utils/__tests__/sets.test.js
+++ b/src/utils/__tests__/sets.test.js
@@ -3,7 +3,7 @@ import {
   intersectionWithPredicate,
   unionWithPredicate,
   symmetricDifferenceWithPredicate,
-} from "../util";
+} from "../sets";
 
 test("set union works", () => {
   const arr1 = [1, 2, 3, 4, 5, 6];

--- a/src/utils/sets.ts
+++ b/src/utils/sets.ts
@@ -1,0 +1,65 @@
+/**
+ * Compute the union of two arrays, using `pred` to determine equality
+ */
+export function unionWithPredicate<T>(
+  array1: T[],
+  array2: T[],
+  pred: (elt1: T, elt2: T) => boolean
+): T[] {
+  const out: T[] = [];
+
+  const merged: T[] = array1.concat(array2);
+
+  for (const elementToBeAdded of merged) {
+    if (
+      out.find((existingElement: T) =>
+        pred(existingElement, elementToBeAdded)
+      ) === undefined
+    ) {
+      out.push(elementToBeAdded);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Compute the intersection of two arrays, using `pred` to determine equality
+ */
+export function intersectionWithPredicate<T>(
+  array1: T[],
+  array2: T[],
+  pred: (elt1: T, elt2: T) => boolean
+): T[] {
+  return array1.filter(
+    (elt1) => array2.find((elt2) => pred(elt1, elt2)) !== undefined
+  );
+}
+
+/**
+ * Compute the difference of two arrays, using `pred` to determine equality
+ */
+export function setDifferenceWithPredicate<T>(
+  array1: T[],
+  array2: T[],
+  pred: (elt1: T, elt2: T) => boolean
+): T[] {
+  return array1.filter(
+    (elt1) => array2.find((elt2) => pred(elt1, elt2)) === undefined
+  );
+}
+
+/**
+ * Compute the symmetric difference of two arrays, using `pred` to determine equality
+ */
+export function symmetricDifferenceWithPredicate<T>(
+  array1: T[],
+  array2: T[],
+  pred: (elt1: T, elt2: T) => boolean
+): T[] {
+  return unionWithPredicate(
+    setDifferenceWithPredicate(array1, array2, pred),
+    setDifferenceWithPredicate(array2, array1, pred),
+    pred
+  );
+}


### PR DESCRIPTION
This adds a new transformation under the compare component that implements the functionality we've talked about with comparing packets.
![image](https://user-images.githubusercontent.com/40366824/119861532-800c2580-bee5-11eb-8260-2e2ecdf8d313.png)

There are still many many edge cases to work out involving what happens when the two data contexts don't have the same set of attributes, or when two cases are identical besides the decision. Also, I think a better name is in order, but nothing comes to mind.

EDIT: name changed from "decision" to "categorical." The existing categorical diff was renamed to structural.