### PR TITLE
convert pivots/count to use multi-attribute select and new naming schema

### DIFF
--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -8,7 +8,7 @@ import { count } from "../transformations/count";
 import {
   TransformationSubmitButtons,
   ContextSelector,
-  CodapFlowTextArea,
+  MultiAttributeSelector,
 } from "../ui-components";
 import { applyNewDataSet, ctxtTitle } from "./util";
 
@@ -21,11 +21,7 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
     string | null,
     HTMLSelectElement
   >(null, () => setErrMsg(null));
-  const [attributes, attributesChange] = useInput<string, HTMLTextAreaElement>(
-    "",
-    () => setErrMsg(null)
-  );
-
+  const [attributes, setAttributes] = useState<string[]>([]);
   const [lastContextName, setLastContextName] = useState<null | string>(null);
 
   /**
@@ -38,20 +34,18 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
         setErrMsg("Please choose a valid data context to transform.");
         return;
       }
-
-      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
-      const attributeNames = attributes.split("\n").map((s) => s.trim());
-
-      if (attributeNames.length === 0) {
+      if (attributes.length === 0) {
         setErrMsg("Please choose at least one attribute to count");
         return;
       }
 
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
+
       try {
-        const counted = count(dataset, attributeNames);
+        const counted = count(dataset, attributes);
         await applyNewDataSet(
           counted,
-          `Count of ${ctxtTitle(context)}`,
+          `Count of ${attributes.join(", ")} in ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,
@@ -78,8 +72,11 @@ export function Count({ setErrMsg }: CountProps): ReactElement {
       <p>Table to Count</p>
       <ContextSelector onChange={inputChange} value={inputDataCtxt} />
 
-      <p>Attributes to Count (1 per line)</p>
-      <CodapFlowTextArea value={attributes} onChange={attributesChange} />
+      <p>Attributes to Count</p>
+      <MultiAttributeSelector
+        context={inputDataCtxt}
+        onChange={setAttributes}
+      />
 
       <br />
       <TransformationSubmitButtons

--- a/src/transformation-components/PivotWider.tsx
+++ b/src/transformation-components/PivotWider.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useCallback, ReactElement } from "react";
-import { getDataSet } from "../utils/codapPhone";
+import { getContextAndDataSet } from "../utils/codapPhone";
 import {
   useInput,
   useContextUpdateListenerWithFlowEffect,
 } from "../utils/hooks";
 import { pivotWider } from "../transformations/pivot";
-import { applyNewDataSet } from "./util";
+import { applyNewDataSet, ctxtTitle } from "./util";
 import {
   AttributeSelector,
   TransformationSubmitButtons,
@@ -51,12 +51,13 @@ export function PivotWider({ setErrMsg }: PivotWiderProps): ReactElement {
         return;
       }
 
-      const dataset = await getDataSet(inputDataCtxt);
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
         const pivoted = pivotWider(dataset, namesFrom, valuesFrom);
         await applyNewDataSet(
           pivoted,
+          `Pivot Wider of ${ctxtTitle(context)}`,
           doUpdate,
           lastContextName,
           setLastContextName,


### PR DESCRIPTION
Pivot / multi-attribute count were developed without the new names ("Pivot of ____") and the multi-attribute select component. This converts them to use those features in uniformity with the other transformations.