### PR TITLE
add join transformation

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -23,6 +23,7 @@ import {
 } from "./transformations/fold";
 import { PivotLonger } from "./transformation-components/PivotLonger";
 import { PivotWider } from "./transformation-components/PivotWider";
+import { Join } from "./transformation-components/Join";
 
 /**
  * Transformation represents an instance of the plugin, which applies a
@@ -64,6 +65,7 @@ function Transformation(): ReactElement {
     Sort: <Sort setErrMsg={setErrMsg} />,
     "Pivot Longer": <PivotLonger setErrMsg={setErrMsg} />,
     "Pivot Wider": <PivotWider setErrMsg={setErrMsg} />,
+    Join: <Join setErrMsg={setErrMsg} />,
   };
 
   const transformGroups: Record<string, string[]> = {
@@ -86,6 +88,7 @@ function Transformation(): ReactElement {
       "Sort",
       "Pivot Longer",
       "Pivot Wider",
+      "Join",
     ],
   };
 

--- a/src/transformation-components/Join.tsx
+++ b/src/transformation-components/Join.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useCallback, ReactElement } from "react";
+import { getContextAndDataSet } from "../utils/codapPhone";
+import {
+  useContextUpdateListenerWithFlowEffect,
+  useInput,
+} from "../utils/hooks";
+import { join } from "../transformations/join";
+import {
+  AttributeSelector,
+  ContextSelector,
+  TransformationSubmitButtons,
+} from "../ui-components";
+import { applyNewDataSet, ctxtTitle } from "./util";
+
+interface JoinProps {
+  setErrMsg: (s: string | null) => void;
+}
+
+export function Join({ setErrMsg }: JoinProps): ReactElement {
+  const [inputDataContext1, inputDataContext1OnChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+  const [inputDataContext2, inputDataContext2OnChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+  const [inputAttribute1, inputAttribute1OnChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+  const [inputAttribute2, inputAttribute2OnChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+
+  const [lastContextName, setLastContextName] = useState<null | string>(null);
+
+  const transform = useCallback(
+    async (doUpdate: boolean) => {
+      if (
+        !inputDataContext1 ||
+        !inputDataContext2 ||
+        !inputAttribute1 ||
+        !inputAttribute2
+      ) {
+        setErrMsg("Please choose two contexts and two attributes");
+        return;
+      }
+
+      const { context: context1, dataset: dataset1 } =
+        await getContextAndDataSet(inputDataContext1);
+      const { context: context2, dataset: dataset2 } =
+        await getContextAndDataSet(inputDataContext2);
+
+      try {
+        const joined = join(
+          dataset1,
+          inputAttribute1,
+          dataset2,
+          inputAttribute2
+        );
+        await applyNewDataSet(
+          joined,
+          `Join of ${ctxtTitle(context1)} and ${ctxtTitle(context2)}`,
+          doUpdate,
+          lastContextName,
+          setLastContextName,
+          setErrMsg
+        );
+      } catch (e) {
+        setErrMsg(e.message);
+      }
+    },
+    [
+      inputDataContext1,
+      inputDataContext2,
+      inputAttribute1,
+      inputAttribute2,
+      lastContextName,
+      setErrMsg,
+    ]
+  );
+
+  useContextUpdateListenerWithFlowEffect(
+    inputDataContext1,
+    lastContextName,
+    () => {
+      transform(true);
+    },
+    [transform]
+  );
+
+  useContextUpdateListenerWithFlowEffect(
+    inputDataContext2,
+    lastContextName,
+    () => {
+      transform(true);
+    },
+    [transform]
+  );
+
+  return (
+    <>
+      <p>Base Table</p>
+      <ContextSelector
+        value={inputDataContext1}
+        onChange={inputDataContext1OnChange}
+      />
+      <p>Joining Table</p>
+      <ContextSelector
+        value={inputDataContext2}
+        onChange={inputDataContext2OnChange}
+      />
+
+      <p>Base Attribute</p>
+      <AttributeSelector
+        onChange={inputAttribute1OnChange}
+        value={inputAttribute1}
+        context={inputDataContext1}
+      />
+
+      <p>Joining Attribute</p>
+      <AttributeSelector
+        onChange={inputAttribute2OnChange}
+        value={inputAttribute2}
+        context={inputDataContext2}
+      />
+
+      <br />
+      <TransformationSubmitButtons
+        onCreate={() => transform(false)}
+        onUpdate={() => transform(true)}
+        updateDisabled={!lastContextName}
+      />
+    </>
+  );
+}

--- a/src/transformations/join.ts
+++ b/src/transformations/join.ts
@@ -29,6 +29,7 @@ export function join(
   }
 
   const addedAttrs = collToJoin.attrs.slice();
+  const addedAttrOriginalNames = addedAttrs.map((attr) => attr.name);
 
   const collections = baseDataset.collections.slice();
   const collToJoinInto = findCollectionWithAttr(collections, baseAttr);
@@ -65,7 +66,10 @@ export function join(
     );
 
     if (matchingRecord !== undefined) {
-      copyValuesIntoRecord(record, matchingRecord, addedAttrs, attrToUnique);
+      for (const attrName of addedAttrOriginalNames) {
+        const unique = attrToUnique[attrName];
+        record[unique] = matchingRecord[attrName];
+      }
     }
   }
 
@@ -86,20 +90,4 @@ function findCollectionWithAttr(
   return collections.find((coll) =>
     coll.attrs?.find((attr) => attr.name === attribute)
   );
-}
-
-/**
- * Copies values of the given attributes from one record into another,
- * using unique names for the copies, given by attrToUnique.
- */
-function copyValuesIntoRecord(
-  baseRecord: Record<string, unknown>,
-  matchingRecord: Record<string, unknown>,
-  addedAttrs: CodapAttribute[],
-  attrToUnique: Record<string, string>
-): void {
-  for (const attr of addedAttrs) {
-    const unique = attrToUnique[attr.name];
-    baseRecord[unique] = matchingRecord[attr.name];
-  }
 }

--- a/src/transformations/join.ts
+++ b/src/transformations/join.ts
@@ -1,0 +1,105 @@
+import { CodapAttribute, Collection } from "../utils/codapPhone/types";
+import { DataSet } from "./types";
+import { uniqueAttrName } from "./util";
+
+/**
+ * Joins two datasets together, using the baseDataset as a starting point
+ * and incorporating values from the joiningDataset for any cases whose
+ * value for baseAttr matches the value for joiningAttr of a case in the
+ * joiningDataset.
+ *
+ * @param baseDataset dataset to which cases from joiningDataset will be added
+ * @param baseAttr attribute to join on from the baseDataset
+ * @param joiningDataset dataset to take cases from and add to baseDataset
+ * @param joiningAttr attribute to join on from joiningDataset
+ */
+export function join(
+  baseDataset: DataSet,
+  baseAttr: string,
+  joiningDataset: DataSet,
+  joiningAttr: string
+): DataSet {
+  // find collection containing joining attribute in joining dataset
+  const collToJoin = findCollectionWithAttr(
+    joiningDataset.collections,
+    joiningAttr
+  );
+  if (collToJoin === undefined || collToJoin.attrs === undefined) {
+    throw new Error(`invalid joining attribute: ${joiningAttr}`);
+  }
+
+  const addedAttrs = collToJoin.attrs.slice();
+
+  const collections = baseDataset.collections.slice();
+  const collToJoinInto = findCollectionWithAttr(collections, baseAttr);
+  if (collToJoinInto === undefined || collToJoinInto.attrs === undefined) {
+    throw new Error(`invalid base attribute: ${baseAttr}`);
+  }
+
+  const allBaseAttrs = baseDataset.collections.reduce(
+    (acc, coll) => acc.concat(coll.attrs || []),
+    [] as CodapAttribute[]
+  );
+
+  // ensure added attribute names are unique relative to attribute
+  // names in base dataset (as well as all other added attributes)
+  const namesToAvoid = allBaseAttrs;
+  const attrToUnique: Record<string, string> = {};
+  for (const attr of addedAttrs) {
+    attrToUnique[attr.name] = uniqueAttrName(attr.name, namesToAvoid);
+    attr.name = attrToUnique[attr.name];
+    namesToAvoid.push(attr);
+  }
+
+  // add the attrs from the joining collection into the collection being joined into
+  collToJoinInto.attrs = collToJoinInto.attrs.concat(addedAttrs);
+
+  // start with a copy of the base dataset's records
+  const records = baseDataset.records.slice();
+
+  // copy into the joined table the first matching record from
+  // joiningDataset for each record from baseDataset.
+  for (const record of records) {
+    const matchingRecord = joiningDataset.records.find(
+      (rec) => rec[joiningAttr] === record[baseAttr]
+    );
+
+    if (matchingRecord !== undefined) {
+      copyValuesIntoRecord(record, matchingRecord, addedAttrs, attrToUnique);
+    }
+  }
+
+  return {
+    collections,
+    records,
+  };
+}
+
+/**
+ * Finds a collection which contains an attribute of the given name,
+ * or undefined if no such collection exists.
+ */
+function findCollectionWithAttr(
+  collections: Collection[],
+  attribute: string
+): Collection | undefined {
+  return collections.find((coll) =>
+    coll.attrs?.find((attr) => attr.name === attribute)
+  );
+}
+
+/**
+ * Copies values of the given attributes from one record into another,
+ * using unique names for the copies, given by attrToUnique.
+ */
+function copyValuesIntoRecord(
+  baseRecord: Record<string, unknown>,
+  matchingRecord: Record<string, unknown>,
+  addedAttrs: CodapAttribute[],
+  attrToUnique: Record<string, string>
+): void {
+  for (const attr of addedAttrs) {
+    const unique = attrToUnique[attr.name];
+    baseRecord[unique] = matchingRecord[attr.name];
+  }
+}


### PR DESCRIPTION
This adds a join transformation that behaves similarly to the drag-and-drop way of joining in CODAP.

CODAP allows you to perform a join by dragging one attribute from a context onto an attribute from another. In effect, it joins _collections_ together by copying attributes from the dragged attribute's collection (what I've called the joining collection) into the dragged-onto attribute's collection (what I've called the base collection). It fills in case data by searching the joining collection for the first case for which the dragged-from and dragged-onto attributes' values match. If no such match is found, the case values for the new attributes are left missing.

CODAP's join effectively mutates the base collection, by literally adding attributes that then use a formula + lookup function to reference the data from another context/collection. Our join copies their functionality but produces a new table representing the join. See the following example:

![join-example](https://user-images.githubusercontent.com/13399527/120212764-60843e00-c200-11eb-85ec-aacf0d4d5f60.png)

Worth noting is that the base attribute and joining attribute ("State" and "State" here) are both present in the joined table. I figured this is useful since you can decide to delete one of them later if necessary, but they may be named different things and indeed you may want to use formulas/transformations that reference one or the other.