### PR TITLE
use attribute selectors instead of text inputs

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -38,19 +38,19 @@ function Transformation(): ReactElement {
 
   const transformComponents: Record<string, ReactElement> = {
     "Running Sum": (
-      <Fold setErrMsg={setErrMsg} label="running sum" foldFunc={runningSum} />
+      <Fold setErrMsg={setErrMsg} label="Running Sum" foldFunc={runningSum} />
     ),
     "Running Mean": (
-      <Fold setErrMsg={setErrMsg} label="running mean" foldFunc={runningMean} />
+      <Fold setErrMsg={setErrMsg} label="Running Mean" foldFunc={runningMean} />
     ),
     "Running Min": (
-      <Fold setErrMsg={setErrMsg} label="running min" foldFunc={runningMin} />
+      <Fold setErrMsg={setErrMsg} label="Running Min" foldFunc={runningMin} />
     ),
     "Running Max": (
-      <Fold setErrMsg={setErrMsg} label="running max" foldFunc={runningMax} />
+      <Fold setErrMsg={setErrMsg} label="Running Max" foldFunc={runningMax} />
     ),
     "Running Difference": (
-      <Fold setErrMsg={setErrMsg} label="difference" foldFunc={difference} />
+      <Fold setErrMsg={setErrMsg} label="Difference" foldFunc={difference} />
     ),
     Flatten: <Flatten setErrMsg={setErrMsg} />,
     "Group By": <GroupBy setErrMsg={setErrMsg} />,

--- a/src/transformation-components/BuildColumn.tsx
+++ b/src/transformation-components/BuildColumn.tsx
@@ -104,16 +104,17 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
     <>
       <p>Table to Add Attribute To</p>
       <ContextSelector onChange={inputChange} value={inputDataCtxt} />
-      <p>Name of New Attribute</p>
-      <CodapFlowTextInput
-        value={attributeName}
-        onChange={attributeNameChange}
-      />
 
       <p>Collection to Add To</p>
       <CodapFlowTextInput
         value={collectionName}
         onChange={collectionNameChange}
+      />
+
+      <p>Name of New Attribute</p>
+      <CodapFlowTextInput
+        value={attributeName}
+        onChange={attributeNameChange}
       />
 
       <p>Formula for Attribute Values</p>

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -10,6 +10,7 @@ import {
   CodapFlowTextInput,
   TransformationSubmitButtons,
   ContextSelector,
+  AttributeSelector,
 } from "../ui-components";
 import { applyNewDataSet, ctxtTitle } from "./util";
 
@@ -21,12 +22,12 @@ export function DifferenceFrom({
     HTMLSelectElement
   >(null, () => setErrMsg(null));
 
-  const [inputColumnName, inputColumnNameChange] = useInput<
-    string,
-    HTMLInputElement
-  >("", () => setErrMsg(null));
+  const [inputAttributeName, inputAttributeNameChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
 
-  const [resultColumnName, resultColumnNameChange] = useInput<
+  const [resultAttributeName, resultAttributeNameChange] = useInput<
     string,
     HTMLInputElement
   >("", () => setErrMsg(null));
@@ -44,8 +45,11 @@ export function DifferenceFrom({
         setErrMsg("Please choose a valid data context to transform.");
         return;
       }
-
-      if (resultColumnName === "") {
+      if (inputAttributeName === null) {
+        setErrMsg("Please choose an attribute to take the difference from");
+        return;
+      }
+      if (resultAttributeName === "") {
         setErrMsg("Please choose a non-empty result column name.");
         return;
       }
@@ -62,8 +66,8 @@ export function DifferenceFrom({
       try {
         const result = differenceFrom(
           dataset,
-          inputColumnName,
-          resultColumnName,
+          inputAttributeName,
+          resultAttributeName,
           differenceStartingValue
         );
         await applyNewDataSet(
@@ -80,8 +84,8 @@ export function DifferenceFrom({
     },
     [
       inputDataCtxt,
-      inputColumnName,
-      resultColumnName,
+      inputAttributeName,
+      resultAttributeName,
       setErrMsg,
       startingValue,
       lastContextName,
@@ -101,15 +105,16 @@ export function DifferenceFrom({
     <>
       <p>Table to calculate difference on</p>
       <ContextSelector onChange={inputChange} value={inputDataCtxt} />
-      <p>Input Column Name:</p>
-      <CodapFlowTextInput
-        value={inputColumnName}
-        onChange={inputColumnNameChange}
+      <p>Attribute to take difference from</p>
+      <AttributeSelector
+        onChange={inputAttributeNameChange}
+        value={inputAttributeName}
+        context={inputDataCtxt}
       />
-      <p>Result Column Name:</p>
+      <p>Result Attribute Name</p>
       <CodapFlowTextInput
-        value={resultColumnName}
-        onChange={resultColumnNameChange}
+        value={resultAttributeName}
+        onChange={resultAttributeNameChange}
       />
       <p>Starting value for difference</p>
       <CodapFlowTextInput

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -59,7 +59,11 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
-        const result = foldFunc(dataset, inputAttributeName, resultAttributeName);
+        const result = foldFunc(
+          dataset,
+          inputAttributeName,
+          resultAttributeName
+        );
         await applyNewDataSet(
           result,
           `${label} of ${ctxtTitle(context)}`,

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -10,6 +10,7 @@ import {
   CodapFlowTextInput,
   TransformationSubmitButtons,
   ContextSelector,
+  AttributeSelector,
 } from "../ui-components";
 import { applyNewDataSet, ctxtTitle } from "./util";
 
@@ -28,12 +29,12 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
     HTMLSelectElement
   >(null, () => setErrMsg(null));
 
-  const [inputColumnName, inputColumnNameChange] = useInput<
-    string,
-    HTMLInputElement
-  >("", () => setErrMsg(null));
+  const [inputAttributeName, inputAttributeNameChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
 
-  const [resultColumnName, resultColumnNameChange] = useInput<
+  const [resultAttributeName, resultAttributeNameChange] = useInput<
     string,
     HTMLInputElement
   >("", () => setErrMsg(null));
@@ -46,8 +47,11 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
         setErrMsg("Please choose a valid data context to transform.");
         return;
       }
-
-      if (resultColumnName === "") {
+      if (inputAttributeName === null) {
+        setErrMsg("Please select an attribute to aggregate");
+        return;
+      }
+      if (resultAttributeName === "") {
         setErrMsg("Please choose a non-empty result column name.");
         return;
       }
@@ -55,7 +59,7 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
-        const result = foldFunc(dataset, inputColumnName, resultColumnName);
+        const result = foldFunc(dataset, inputAttributeName, resultAttributeName);
         await applyNewDataSet(
           result,
           `${label} of ${ctxtTitle(context)}`,
@@ -70,8 +74,8 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
     },
     [
       inputDataCtxt,
-      inputColumnName,
-      resultColumnName,
+      inputAttributeName,
+      resultAttributeName,
       setErrMsg,
       foldFunc,
       lastContextName,
@@ -92,15 +96,16 @@ export function Fold({ setErrMsg, label, foldFunc }: FoldProps): ReactElement {
     <>
       <p>Table to calculate {label.toLowerCase()} on</p>
       <ContextSelector onChange={inputChange} value={inputDataCtxt} />
-      <p>Input Column Name:</p>
-      <CodapFlowTextInput
-        value={inputColumnName}
-        onChange={inputColumnNameChange}
+      <p>Attribute to Aggregate</p>
+      <AttributeSelector
+        onChange={inputAttributeNameChange}
+        value={inputAttributeName}
+        context={inputDataCtxt}
       />
-      <p>Result Column Name:</p>
+      <p>Result Attribute Name</p>
       <CodapFlowTextInput
-        value={resultColumnName}
-        onChange={resultColumnNameChange}
+        value={resultAttributeName}
+        onChange={resultAttributeNameChange}
       />
       <br />
       <TransformationSubmitButtons

--- a/src/transformation-components/TransformColumn.tsx
+++ b/src/transformation-components/TransformColumn.tsx
@@ -4,7 +4,7 @@ import { transformColumn } from "../transformations/transformColumn";
 import { applyNewDataSet, ctxtTitle } from "./util";
 import {
   CodapFlowTextArea,
-  CodapFlowTextInput,
+  AttributeSelector,
   TransformationSubmitButtons,
   ContextSelector,
 } from "../ui-components";
@@ -23,9 +23,9 @@ export function TransformColumn({
     HTMLSelectElement
   >(null, () => setErrMsg(null));
   const [attributeName, attributeNameChange] = useInput<
-    string,
-    HTMLInputElement
-  >("", () => setErrMsg(null));
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
   const [expression, expressionChange] = useInput<string, HTMLTextAreaElement>(
     "",
     () => setErrMsg(null)
@@ -42,8 +42,8 @@ export function TransformColumn({
         setErrMsg("Please choose a valid data context to transform.");
         return;
       }
-      if (attributeName === "") {
-        setErrMsg("Please enter a non-empty attribute name to transform");
+      if (attributeName === null) {
+        setErrMsg("Please select an attribute to transform");
         return;
       }
       if (expression === "") {
@@ -85,9 +85,10 @@ export function TransformColumn({
       <ContextSelector onChange={inputChange} value={inputDataCtxt} />
 
       <p>Attribute to Transform</p>
-      <CodapFlowTextInput
-        value={attributeName}
+      <AttributeSelector
         onChange={attributeNameChange}
+        value={attributeName}
+        context={inputDataCtxt}
       />
 
       <p>How to Transform Column</p>


### PR DESCRIPTION
This just converts a few transformations that were still using text boxes for user input of existing attribute names to now use the attribute selector component.

Also, I changed the fold transformations' naming so that their names appear capitalized in titles (e.g. "Running Sum of People").