### PR TITLE
errors with missing values

### DIFF
--- a/src/transformations/buildColumn.ts
+++ b/src/transformations/buildColumn.ts
@@ -1,5 +1,5 @@
 import { DataSet } from "./types";
-import { dataItemToEnv } from "./util";
+import { dataItemToEnv, guardAgainstMissingInFormula } from "./util";
 import { evaluate } from "../language";
 
 /**
@@ -12,6 +12,8 @@ export function buildColumn(
   collectionName: string,
   expression: string
 ): DataSet {
+  guardAgainstMissingInFormula(dataset, expression);
+
   // find collection to add attribute to
   const collections = dataset.collections.slice();
   const toAdd = collections.find((coll) => coll.name === collectionName);

--- a/src/transformations/filter.ts
+++ b/src/transformations/filter.ts
@@ -1,5 +1,5 @@
 import { DataSet } from "./types";
-import { dataItemToEnv } from "./util";
+import { dataItemToEnv, guardAgainstMissingInFormula } from "./util";
 import { evaluate } from "../language";
 
 /**
@@ -7,6 +7,8 @@ import { evaluate } from "../language";
  * depending on a given predicate.
  */
 export function filter(dataset: DataSet, predicate: string): DataSet {
+  guardAgainstMissingInFormula(dataset, predicate);
+
   const filteredRecords = [];
 
   for (const dataItem of dataset.records) {

--- a/src/transformations/fold.ts
+++ b/src/transformations/fold.ts
@@ -1,5 +1,9 @@
 import { DataSet } from "./types";
-import { insertColumnInLastCollection, insertInRow } from "./util";
+import {
+  checkAttrForMissing,
+  insertColumnInLastCollection,
+  insertInRow,
+} from "./util";
 
 function makeNumFold<T>(
   base: T,
@@ -87,6 +91,12 @@ export function differenceFrom(
   resultColumnName: string,
   startingValue = 0
 ): DataSet {
+  if (checkAttrForMissing(dataset.records, inputColumnName)) {
+    throw new Error(
+      `cannot take difference from attribute with missing values: ${inputColumnName}`
+    );
+  }
+
   const resultRecords = dataset.records.map((row) => {
     const numValue = Number(row[inputColumnName]);
     if (!isNaN(numValue)) {

--- a/src/transformations/transformColumn.ts
+++ b/src/transformations/transformColumn.ts
@@ -1,5 +1,5 @@
 import { DataSet } from "./types";
-import { dataItemToEnv } from "./util";
+import { dataItemToEnv, guardAgainstMissingInFormula } from "./util";
 import { evaluate } from "../language";
 
 /**
@@ -12,6 +12,8 @@ export function transformColumn(
   attributeName: string,
   expression: string
 ): DataSet {
+  guardAgainstMissingInFormula(dataset, expression);
+
   const records = dataset.records.slice();
   for (const record of records) {
     if (record[attributeName] === undefined) {

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -210,3 +210,19 @@ export function checkFormulaForMissing(
     new Set([...attrsInFormula].filter((attr) => attrsWithMissing.has(attr)))
   );
 }
+
+/**
+ * Raises an error if there is at least one attribute used
+ * in the given formula that has missing values.
+ */
+export function guardAgainstMissingInFormula(
+  dataset: DataSet,
+  formula: string
+): void {
+  const attrsWithMissing = checkFormulaForMissing(dataset, formula);
+  for (const attr of attrsWithMissing) {
+    throw new Error(
+      `cannot use attribute with missing values in formula: ${attr}`
+    );
+  }
+}


### PR DESCRIPTION
This adds checks in the following transformations preventing attributes with missing values from being used:
- filter
- transform column
- build column
- difference from

This is more a proof of concept of what might happen with missing values, since it will probably have to change upon integrating the CODAP expression language. 

Note that we'd probably also want to provide some transformations that deal explicitly with missing values (ie filter-out-missing or something).

Also note that this sort of gets in your way if you're trying to use build-column / transform-column to effectively make a _copy_ of another column. If that column has any missing values, you're out of luck (even though you're not doing anything truly illegal like using them in arithmetic).