### PR TITLE
Add eval demo

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -14,6 +14,7 @@ import { Compare } from "./transformation-components/Compare";
 import { Fold } from "./transformation-components/Fold";
 import { DifferenceFrom } from "./transformation-components/DifferenceFrom";
 import { Sort } from "./transformation-components/Sort";
+import { Eval } from "./transformation-components/Eval";
 import {
   runningSum,
   runningMean,
@@ -23,6 +24,7 @@ import {
 } from "./transformations/fold";
 import { PivotLonger } from "./transformation-components/PivotLonger";
 import { PivotWider } from "./transformation-components/PivotWider";
+import { evalExpression } from "./utils/codapPhone";
 
 /**
  * Transformation represents an instance of the plugin, which applies a
@@ -64,6 +66,7 @@ function Transformation(): ReactElement {
     Sort: <Sort setErrMsg={setErrMsg} />,
     "Pivot Longer": <PivotLonger setErrMsg={setErrMsg} />,
     "Pivot Wider": <PivotWider setErrMsg={setErrMsg} />,
+    Eval: <Eval setErrMsg={setErrMsg} />,
   };
 
   const transformGroups: Record<string, string[]> = {
@@ -86,6 +89,7 @@ function Transformation(): ReactElement {
       "Sort",
       "Pivot Longer",
       "Pivot Wider",
+      "Eval",
     ],
   };
 

--- a/src/transformation-components/Eval.tsx
+++ b/src/transformation-components/Eval.tsx
@@ -1,0 +1,55 @@
+import React, { ReactElement, useState } from "react";
+import { getContextAndDataSet, evalExpression } from "../utils/codapPhone";
+import { useInput } from "../utils/hooks";
+import { CodapFlowTextArea, ContextSelector } from "../ui-components";
+
+interface EvalProps {
+  setErrMsg: (s: string | null) => void;
+}
+
+export function Eval({ setErrMsg }: EvalProps): ReactElement {
+  const [inputDataCtxt, inputChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+  const [transformPgrm, pgrmChange] = useInput<string, HTMLTextAreaElement>(
+    "",
+    () => setErrMsg(null)
+  );
+  const [result, setResult] = useState<string>("");
+
+  async function evalExpr() {
+    setResult("");
+
+    if (inputDataCtxt === null) {
+      setErrMsg("Please select data context");
+      return;
+    }
+    const { dataset } = await getContextAndDataSet(inputDataCtxt);
+
+    if (dataset.records.length < 5) {
+      setErrMsg("Please pick a dataset with at least 5 elements");
+    }
+    const evalResult = await evalExpression(
+      transformPgrm,
+      dataset.records.slice(0, 5)
+    );
+    setResult(JSON.stringify(evalResult));
+  }
+
+  return (
+    <>
+      <p>Table to Filter</p>
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
+
+      <p>How to Filter</p>
+      <CodapFlowTextArea onChange={pgrmChange} value={transformPgrm} />
+
+      <br />
+      <button onClick={evalExpr}>Eval</button>
+
+      <p>Result</p>
+      <p>{result}</p>
+    </>
+  );
+}

--- a/src/transformation-components/Eval.tsx
+++ b/src/transformation-components/Eval.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useState } from "react";
 import { getContextAndDataSet, evalExpression } from "../utils/codapPhone";
+import { CodapEvalError } from "../utils/codapPhone/error";
 import { useInput } from "../utils/hooks";
 import { CodapFlowTextArea, ContextSelector } from "../ui-components";
 
@@ -30,11 +31,19 @@ export function Eval({ setErrMsg }: EvalProps): ReactElement {
     if (dataset.records.length < 5) {
       setErrMsg("Please pick a dataset with at least 5 elements");
     }
-    const evalResult = await evalExpression(
-      transformPgrm,
-      dataset.records.slice(0, 5)
-    );
-    setResult(JSON.stringify(evalResult));
+    try {
+      const evalResult = await evalExpression(
+        transformPgrm,
+        dataset.records.slice(0, 5)
+      );
+      setResult(JSON.stringify(evalResult));
+    } catch (e) {
+      if (e instanceof CodapEvalError) {
+        setErrMsg(e.error);
+      } else {
+        setErrMsg(e.toString());
+      }
+    }
   }
 
   return (

--- a/src/utils/codapPhone/error.ts
+++ b/src/utils/codapPhone/error.ts
@@ -1,0 +1,10 @@
+export class CodapEvalError extends Error {
+  expression: string;
+  error: string;
+
+  constructor(expression: string, error: string) {
+    super(`${expression} failed with error: ${error}`);
+    this.expression = expression;
+    this.error = error;
+  }
+}

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -67,6 +67,34 @@ phone.call(
   }
 );
 
+export function evalExpression(
+  expr: string,
+  records: Record<string, unknown>[]
+): Promise<unknown[]> {
+  return new Promise((resolve, reject) =>
+    phone.call(
+      {
+        action: CodapActions.Get,
+        resource: CodapResource.EvalExpression,
+        values: {
+          source: expr,
+          records: records,
+        },
+      },
+      (response) => {
+        if (response.success) {
+          console.group("Eval");
+          console.log(response.values);
+          console.groupEnd();
+          resolve(response.values);
+        } else {
+          reject(new Error(`Failed to evaluate expression: ${expr}`));
+        }
+      }
+    )
+  );
+}
+
 function resourceFromContext(context: string) {
   return `dataContext[${context}]`;
 }

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -27,6 +27,7 @@ import {
 } from "./types";
 import { contextUpdateListeners, callAllContextListeners } from "./listeners";
 import { DataSet } from "../../transformations/types";
+import { CodapEvalError } from "./error";
 import { DirectoryWatcherCallback } from "typescript";
 
 export {
@@ -66,34 +67,6 @@ phone.call(
     }
   }
 );
-
-export function evalExpression(
-  expr: string,
-  records: Record<string, unknown>[]
-): Promise<unknown[]> {
-  return new Promise((resolve, reject) =>
-    phone.call(
-      {
-        action: CodapActions.Get,
-        resource: CodapResource.EvalExpression,
-        values: {
-          source: expr,
-          records: records,
-        },
-      },
-      (response) => {
-        if (response.success) {
-          console.group("Eval");
-          console.log(response.values);
-          console.groupEnd();
-          resolve(response.values);
-        } else {
-          reject(new Error(`Failed to evaluate expression: ${expr}`));
-        }
-      }
-    )
-  );
-}
 
 function resourceFromContext(context: string) {
   return `dataContext[${context}]`;
@@ -863,4 +836,33 @@ export async function createTableWithDataSet(
 
   const newTable = await createTable(tableName, contextName);
   return [newContext, newTable];
+}
+
+export function evalExpression(
+  expr: string,
+  records: Record<string, unknown>[]
+): Promise<unknown[]> {
+  return new Promise((resolve, reject) =>
+    phone.call(
+      {
+        action: CodapActions.Get,
+        resource: CodapResource.EvalExpression,
+        values: {
+          source: expr,
+          records: records,
+        },
+      },
+      (response) => {
+        if (response.success) {
+          console.group("Eval");
+          console.log(response.values);
+          console.groupEnd();
+          resolve(response.values);
+        } else {
+          // In this case, values is an error message
+          reject(new CodapEvalError(expr, response.values.error));
+        }
+      }
+    )
+  );
 }

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -126,9 +126,17 @@ interface TableResponse extends CodapResponse {
   values: CaseTable;
 }
 
-interface EvalExpressionResponse extends CodapResponse {
-  values: unknown[];
-}
+type EvalExpressionResponse =
+  | {
+      success: true;
+      values: unknown[];
+    }
+  | {
+      success: false;
+      values: {
+        error: string;
+      };
+    };
 
 export type CodapPhone = {
   call(r: UpdateInteractiveFrameRequest, cb: (r: CodapResponse) => void): void;

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -5,6 +5,7 @@ export enum CodapResource {
   Component = "component",
   Collection = "collection",
   CollectionList = "collectionList",
+  EvalExpression = "evalExpression",
 }
 
 export enum CodapListResource {
@@ -76,6 +77,15 @@ type CreateTableRequest = {
   values: CaseTable;
 };
 
+interface EvalExpressionRequest {
+  action: CodapActions.Get;
+  resource: CodapResource.EvalExpression;
+  values: {
+    source: string;
+    records: Record<string, unknown>[];
+  };
+}
+
 export interface CodapResponse {
   success: boolean;
 }
@@ -116,6 +126,10 @@ interface TableResponse extends CodapResponse {
   values: CaseTable;
 }
 
+interface EvalExpressionResponse extends CodapResponse {
+  values: unknown[];
+}
+
 export type CodapPhone = {
   call(r: UpdateInteractiveFrameRequest, cb: (r: CodapResponse) => void): void;
   call(r: GetContextListRequest, cb: (r: ListResponse) => void): void;
@@ -130,6 +144,7 @@ export type CodapPhone = {
   call(r: CreateCollectionsRequest, cb: (r: ListResponse) => void): void;
   call(r: DeleteRequest, cb: (r: CodapResponse) => void): void;
   call(r: CreateTableRequest, cb: (r: TableResponse) => void): void;
+  call(r: EvalExpressionRequest, cb: (r: EvalExpressionResponse) => void): void;
 };
 
 export enum CodapInitiatedResource {


### PR DESCRIPTION
```patch
From 7338da6b9aff3bb5adfef2c14da37fe3e14e76a1 Mon Sep 17 00:00:00 2001
From: Jason Chen <kbtpodifo@gmail.com>
Date: Mon, 31 May 2021 16:12:18 -0400
Subject: [PATCH] Add eval handler for demo

---
 .../data_interactive_phone_handler.js         | 26 +++++++++++++++++++
 1 file changed, 26 insertions(+)

diff --git a/apps/dg/components/data_interactive/data_interactive_phone_handler.js b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
index 558f3f8c..1f525549 100644
--- a/apps/dg/components/data_interactive/data_interactive_phone_handler.js
+++ b/apps/dg/components/data_interactive/data_interactive_phone_handler.js
@@ -423,6 +423,32 @@ DG.DataInteractivePhoneHandler = SC.Object.extend(
       },
       handleOneCommand: function (iCmd) {
         var result = {success: false};
+
+        if (iCmd.resource === "evalExpression") {
+          try {
+            return {
+              success: true,
+              values: iCmd.values.records.map(r => {
+                const context = DG.FormulaContext.create({
+                  vars: r,
+                });
+                const formula = DG.Formula.create({
+                  source: iCmd.values.source,
+                  context: context,
+                });
+                return formula.evaluateDirect();
+              }),
+            }
+          } catch (ex) {
+            return {
+              success: false,
+              values: {
+                error: ex.toString(),
+              },
+            };
+          }
+        }
+
         try {
           // parse the resource name into constituent parts
           var selectorMap = iCmd.resource && this.parseResourceSelector(
-- 
2.30.2

```

![image](https://user-images.githubusercontent.com/11802391/120238931-3ac05e80-c22b-11eb-9c72-40810c9a895e.png)

The `Eval` transformation takes the given program and sends it to CODAP for evaluation. The program is evaluated for each of the first five rows in the chosen input data context for demo purposes. As seen in the screenshot, we have access to all the CODAP expression language functions.

Edit: update patch to throw error