### PR TITLE
switch to CODAP expression language

### DIFF
--- a/src/transformation-components/BuildColumn.tsx
+++ b/src/transformation-components/BuildColumn.tsx
@@ -12,6 +12,7 @@ import {
   TransformationSubmitButtons,
   ContextSelector,
 } from "../ui-components";
+import { CodapEvalError } from "../utils/codapPhone/error";
 
 interface BuildColumnProps {
   setErrMsg: (s: string | null) => void;
@@ -63,7 +64,7 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
-        const built = buildColumn(
+        const built = await buildColumn(
           dataset,
           attributeName,
           collectionName,
@@ -78,7 +79,11 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
           setErrMsg
         );
       } catch (e) {
-        setErrMsg(e.message);
+        if (e instanceof CodapEvalError) {
+          setErrMsg(e.error);
+        } else {
+          setErrMsg(e.toString());
+        }
       }
     },
     [

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -12,6 +12,7 @@ import {
   ContextSelector,
 } from "../ui-components";
 import { applyNewDataSet, ctxtTitle } from "./util";
+import { CodapEvalError } from "../utils/codapPhone/error";
 
 export function Sort({ setErrMsg }: TransformationProps): ReactElement {
   const [inputDataCtxt, inputChange] = useInput<
@@ -41,7 +42,7 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
-        const result = sort(dataset, keyExpression);
+        const result = await sort(dataset, keyExpression);
         await applyNewDataSet(
           result,
           `Sort of ${ctxtTitle(context)}`,
@@ -51,7 +52,11 @@ export function Sort({ setErrMsg }: TransformationProps): ReactElement {
           setErrMsg
         );
       } catch (e) {
-        setErrMsg(e.message);
+        if (e instanceof CodapEvalError) {
+          setErrMsg(e.error);
+        } else {
+          setErrMsg(e.toString());
+        }
       }
     },
     [inputDataCtxt, setErrMsg, keyExpression, lastContextName]

--- a/src/transformation-components/TransformColumn.tsx
+++ b/src/transformation-components/TransformColumn.tsx
@@ -10,6 +10,7 @@ import {
 } from "../ui-components";
 import { useContextUpdateListenerWithFlowEffect } from "../utils/hooks";
 import { getContextAndDataSet } from "../utils/codapPhone";
+import { CodapEvalError } from "../utils/codapPhone/error";
 
 interface TransformColumnProps {
   setErrMsg: (s: string | null) => void;
@@ -54,7 +55,11 @@ export function TransformColumn({
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
 
       try {
-        const transformed = transformColumn(dataset, attributeName, expression);
+        const transformed = await transformColumn(
+          dataset,
+          attributeName,
+          expression
+        );
         await applyNewDataSet(
           transformed,
           `Transform Column of ${ctxtTitle(context)}`,
@@ -64,7 +69,11 @@ export function TransformColumn({
           setErrMsg
         );
       } catch (e) {
-        setErrMsg(e.message);
+        if (e instanceof CodapEvalError) {
+          setErrMsg(e.error);
+        } else {
+          setErrMsg(e.toString());
+        }
       }
     },
     [inputDataCtxt, attributeName, expression, lastContextName, setErrMsg]


### PR DESCRIPTION
This updates the following transformations to use the new `evalExpression` functionality: 
- filter
- transform column
- build column
- sort

Note: with sort you may observe some weird behavior due to seemingly numeric attributes evaluating to string values in their language. (For instance, sort by Age will sort by Age _lexicographically_, so you have to use something like `number(Age)` to get the right result). We'll probably want to look into a way of mitigating this behavior.