### PR TITLE
add a collection selector

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -24,7 +24,6 @@ import {
 } from "./transformations/fold";
 import { PivotLonger } from "./transformation-components/PivotLonger";
 import { PivotWider } from "./transformation-components/PivotWider";
-import { evalExpression } from "./utils/codapPhone";
 
 /**
  * Transformation represents an instance of the plugin, which applies a

--- a/src/transformation-components/BuildColumn.tsx
+++ b/src/transformation-components/BuildColumn.tsx
@@ -11,6 +11,7 @@ import {
   CodapFlowTextInput,
   TransformationSubmitButtons,
   ContextSelector,
+  CollectionSelector,
 } from "../ui-components";
 
 interface BuildColumnProps {
@@ -27,9 +28,9 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
     HTMLInputElement
   >("", () => setErrMsg(null));
   const [collectionName, collectionNameChange] = useInput<
-    string,
-    HTMLInputElement
-  >("", () => setErrMsg(null));
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
   const [expression, expressionChange] = useInput<string, HTMLTextAreaElement>(
     "",
     () => setErrMsg(null)
@@ -47,12 +48,12 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
         setErrMsg("Please choose a valid data context to transform.");
         return;
       }
-      if (attributeName === "") {
-        setErrMsg("Please enter a non-empty name for the new attribute");
+      if (collectionName === null) {
+        setErrMsg("Please select a collection to add to");
         return;
       }
-      if (collectionName === "") {
-        setErrMsg("Please enter a non-empty collection name to add to");
+      if (attributeName === "") {
+        setErrMsg("Please enter a non-empty name for the new attribute");
         return;
       }
       if (expression === "") {
@@ -104,16 +105,18 @@ export function BuildColumn({ setErrMsg }: BuildColumnProps): ReactElement {
     <>
       <p>Table to Add Attribute To</p>
       <ContextSelector onChange={inputChange} value={inputDataCtxt} />
+
+      <p>Collection to Add To</p>
+      <CollectionSelector
+        context={inputDataCtxt}
+        value={collectionName}
+        onChange={collectionNameChange}
+      />
+
       <p>Name of New Attribute</p>
       <CodapFlowTextInput
         value={attributeName}
         onChange={attributeNameChange}
-      />
-
-      <p>Collection to Add To</p>
-      <CodapFlowTextInput
-        value={collectionName}
-        onChange={collectionNameChange}
       />
 
       <p>Formula for Attribute Values</p>

--- a/src/ui-components/CollectionSelector.tsx
+++ b/src/ui-components/CollectionSelector.tsx
@@ -1,29 +1,29 @@
 import React, { ReactElement, ChangeEvent } from "react";
 import CodapFlowSelect from "./CodapFlowSelect";
-import { useAttributes } from "../utils/hooks";
+import { useCollections } from "../utils/hooks";
 
-interface AttributeSelectorProps {
+interface CollectionSelectorProps {
   context: string | null;
   value: string | null;
   onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
 }
 
-export default function AttributeSelector({
+export default function CollectionSelector({
   context,
   value,
   onChange,
-}: AttributeSelectorProps): ReactElement {
-  const attributes = useAttributes(context);
+}: CollectionSelectorProps): ReactElement {
+  const collections = useCollections(context);
 
   return (
     <CodapFlowSelect
       onChange={onChange}
-      options={attributes.map((attribute) => ({
-        value: attribute.name,
-        title: attribute.title,
+      options={collections.map((collection) => ({
+        value: collection.name,
+        title: collection.title,
       }))}
       value={value}
-      defaultValue="Select an attribute"
+      defaultValue="Select a collection"
       showValue={true}
     />
   );

--- a/src/ui-components/index.ts
+++ b/src/ui-components/index.ts
@@ -5,3 +5,4 @@ export { default as TransformationSubmitButtons } from "./TransformationSubmitBu
 export { default as ContextSelector } from "./ContextSelector";
 export { default as AttributeSelector } from "./AttributeSelector";
 export { default as MultiAttributeSelector } from "./MultiAttributeSelector";
+export { default as CollectionSelector } from "./CollectionSelector";

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -28,7 +28,6 @@ import {
 import { contextUpdateListeners, callAllContextListeners } from "./listeners";
 import { DataSet } from "../../transformations/types";
 import { CodapEvalError } from "./error";
-import { DirectoryWatcherCallback } from "typescript";
 
 export {
   addNewContextListener,

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -4,6 +4,7 @@ import {
   addNewContextListener,
   removeNewContextListener,
   getAllAttributes,
+  getAllCollections,
   removeContextUpdateListener,
   addContextUpdateListener,
 } from "./codapPhone";
@@ -26,8 +27,25 @@ export function useDataContexts(): CodapIdentifyingInfo[] {
   return dataContexts;
 }
 
+export function useCollections(context: string | null): CodapIdentifyingInfo[] {
+  const [collections, setCollections] = useState<CodapIdentifyingInfo[]>([]);
+
+  async function refreshCollections(context: string) {
+    setCollections(await getAllCollections(context));
+  }
+
+  // Update if context changes
+  useEffect(() => {
+    if (context) {
+      refreshCollections(context);
+    }
+  }, [context]);
+
+  return collections;
+}
+
 export function useAttributes(context: string | null): CodapIdentifyingInfo[] {
-  const [collections, setAttributes] = useState<CodapIdentifyingInfo[]>([]);
+  const [attributes, setAttributes] = useState<CodapIdentifyingInfo[]>([]);
 
   async function refreshAttributes(context: string) {
     setAttributes(await getAllAttributes(context));
@@ -40,7 +58,7 @@ export function useAttributes(context: string | null): CodapIdentifyingInfo[] {
     }
   }, [context]);
 
-  return collections;
+  return attributes;
 }
 
 interface ElementWithValue {


### PR DESCRIPTION
Adds a dropdown selector for collections much like the existing `ContextSelector` and `AttributeSelector`. This is used exclusively in build column at the moment but could be useful in the future. Also fixed up a few names that seemed to be left over from prior copying of code.