### PR TITLE
improve appearance of names in dropdowns

### DIFF
--- a/src/transformations/count.ts
+++ b/src/transformations/count.ts
@@ -1,6 +1,7 @@
 import { DataSet } from "./types";
 import { CodapAttribute, Collection } from "../utils/codapPhone/types";
-import { eraseFormulas, uniqueAttrName } from "./util";
+import { eraseFormulas } from "./util";
+import { uniqueName } from "../utils/names";
 
 // TODO: allow for two modes:
 //  1) treat data like one table, values are counted across all cases
@@ -36,7 +37,10 @@ export function count(dataset: DataSet, attributes: string[]): DataSet {
   eraseFormulas(countedAttrs);
 
   // generate a unique attribute name for the `count` column
-  const countAttrName = uniqueAttrName("count", countedAttrs);
+  const countAttrName = uniqueName(
+    "count",
+    countedAttrs.map((attr) => attr.name)
+  );
 
   // single collection with copy of counted attributes, plus
   // a new "count" attribute for the frequencies

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -117,27 +117,3 @@ export function insertInRow(
 export function eraseFormulas(attrs: CodapAttribute[]): void {
   attrs.forEach((attr) => (attr.formula = undefined));
 }
-
-/**
- * Finds an attribute name with the given base that is unique relative
- * to the given list of attributes.
- */
-export function uniqueAttrName(base: string, attrs: CodapAttribute[]): string {
-  let name = base;
-  let counter = 0;
-  let conflicts = true;
-  while (conflicts) {
-    conflicts = false;
-    for (const attr of attrs) {
-      if (attr.name === name) {
-        conflicts = true;
-        break;
-      }
-    }
-    if (conflicts) {
-      counter++;
-      name = `${base} (${counter})`;
-    }
-  }
-  return name;
-}

--- a/src/ui-components/AttributeSelector.tsx
+++ b/src/ui-components/AttributeSelector.tsx
@@ -24,7 +24,6 @@ export default function AttributeSelector({
       }))}
       value={value}
       defaultValue="Select an attribute"
-      showValue={true}
     />
   );
 }

--- a/src/ui-components/CodapFlowSelect.tsx
+++ b/src/ui-components/CodapFlowSelect.tsx
@@ -8,7 +8,6 @@ interface CodapFlowSelectProps<T extends string | number> {
     value: T;
     title: string;
   }[];
-  showValue?: boolean;
 }
 
 export default function CodapFlowSelect<T extends string | number>({
@@ -16,11 +15,12 @@ export default function CodapFlowSelect<T extends string | number>({
   value,
   defaultValue,
   options,
-  showValue,
 }: CodapFlowSelectProps<T>): ReactElement {
-  // showValue is false by default
-  if (showValue === undefined || showValue === null) {
-    showValue = false;
+  const titles = options.map((option) => option.title);
+
+  // Determines if more than one option use the given title
+  function ambiguousTitle(title: string): boolean {
+    return titles.filter((t) => t === title).length > 1;
   }
 
   return (
@@ -30,7 +30,10 @@ export default function CodapFlowSelect<T extends string | number>({
       </option>
       {options.map((option) => (
         <option key={option.value} value={option.value}>
-          {showValue ? `${option.title} (${option.value})` : option.title}
+          {/* disambiguate titles by showing value also if needed */}
+          {ambiguousTitle(option.title)
+            ? `${option.title} (${option.value})`
+            : option.title}
         </option>
       ))}
     </select>

--- a/src/ui-components/CollectionSelector.tsx
+++ b/src/ui-components/CollectionSelector.tsx
@@ -24,7 +24,6 @@ export default function CollectionSelector({
       }))}
       value={value}
       defaultValue="Select a collection"
-      showValue={true}
     />
   );
 }

--- a/src/ui-components/ContextSelector.tsx
+++ b/src/ui-components/ContextSelector.tsx
@@ -22,7 +22,6 @@ export default function ContextSelector({
       }))}
       value={value}
       defaultValue="Select a Data Context"
-      showValue={true}
     />
   );
 }

--- a/src/ui-components/MultiAttributeSelector.tsx
+++ b/src/ui-components/MultiAttributeSelector.tsx
@@ -41,7 +41,6 @@ export default function MultiAttributeSelector({
             }))}
             value={selected[i]}
             defaultValue="Select an attribute"
-            showValue={true}
           />
           {i === count ? null : (
             <button

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -28,7 +28,7 @@ import {
 import { contextUpdateListeners, callAllContextListeners } from "./listeners";
 import { DataSet } from "../../transformations/types";
 import { CodapEvalError } from "./error";
-import { DirectoryWatcherCallback } from "typescript";
+import { uniqueName } from "../names";
 
 export {
   addNewContextListener,
@@ -789,21 +789,10 @@ async function ensureUniqueName(
     )
   );
 
-  const names = resourceList.map((x) => x.name);
-
-  // If the name doesn't already exist we can return it as is
-  if (!names.includes(name)) {
-    return name;
-  }
-
-  const numberedName = (name: string, i: number) => `${name} (${i})`;
-
-  // Otherwise find a suffix for the name that makes it unique
-  let i = 1;
-  while (names.includes(numberedName(name, i))) {
-    i += 1;
-  }
-  return numberedName(name, i);
+  return uniqueName(
+    name,
+    resourceList.map((x) => x.name)
+  );
 }
 
 export async function createTableWithDataSet(

--- a/src/utils/names.ts
+++ b/src/utils/names.ts
@@ -1,0 +1,19 @@
+/**
+ * Generates a unique name, given a starting point (base) and
+ * a list of names to avoid conflicts with.
+ */
+export function uniqueName(base: string, avoid: string[]): string {
+  // If the name doesn't already exist we can return it as is
+  if (!avoid.includes(base)) {
+    return base;
+  }
+
+  const numberedName = (name: string, i: number) => `${name} (${i})`;
+
+  // Otherwise find a suffix for the name that makes it unique
+  let i = 1;
+  while (avoid.includes(numberedName(base, i))) {
+    i += 1;
+  }
+  return numberedName(base, i);
+}


### PR DESCRIPTION
This alters `CodapFlowSelect` so that it only displays the option's underlying value if there are multiple options that share the exact same title. I.e., in a situation in which the value is necessary to disambiguate between like titles. This greatly reduces the length of the dropdowns and removes clutter in most situations (when titles are indeed unique).

I also consolidated the "generate unique name" functionality that was required in both codapPhone utils and certain transformations under one function instead of having multiple that effectively do the same thing.