### PR TITLE
delete formulas when using transform column on formula-based attribute

### DIFF
--- a/src/transformations/transformColumn.ts
+++ b/src/transformations/transformColumn.ts
@@ -24,9 +24,20 @@ export async function transformColumn(
     record[attributeName] = value;
   });
 
+  const collections = dataset.collections.slice();
+  for (const coll of collections) {
+    const attr = coll.attrs?.find((attr) => attr.name === attributeName);
+
+    // erase the transformed attribute's formula
+    if (attr !== undefined) {
+      attr.formula = undefined;
+      break;
+    }
+  }
+
   return new Promise((resolve) =>
     resolve({
-      collections: dataset.collections.slice(),
+      collections,
       records,
     })
   );


### PR DESCRIPTION
This fixes a bug that occurred when using transform column on a formula-based attribute. If the formula is preserved in the output, then it governs the values and the computed values during the transform are effectively replaced. I updated transform column to always wipe the formula of the transforming attribute.