### PR TITLE
add copy transformation

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -25,6 +25,7 @@ import {
 import { PivotLonger } from "./transformation-components/PivotLonger";
 import { PivotWider } from "./transformation-components/PivotWider";
 import { Join } from "./transformation-components/Join";
+import { Copy } from "./transformation-components/Copy";
 
 /**
  * Transformation represents an instance of the plugin, which applies a
@@ -68,6 +69,7 @@ function Transformation(): ReactElement {
     "Pivot Wider": <PivotWider setErrMsg={setErrMsg} />,
     Join: <Join setErrMsg={setErrMsg} />,
     Eval: <Eval setErrMsg={setErrMsg} />,
+    Copy: <Copy setErrMsg={setErrMsg} />,
   };
 
   const transformGroups: Record<string, string[]> = {
@@ -92,6 +94,7 @@ function Transformation(): ReactElement {
       "Pivot Wider",
       "Join",
       "Eval",
+      "Copy",
     ],
   };
 

--- a/src/transformation-components/Copy.tsx
+++ b/src/transformation-components/Copy.tsx
@@ -1,0 +1,75 @@
+import React, { useCallback, ReactElement, useState } from "react";
+import { getContextAndDataSet } from "../utils/codapPhone";
+import {
+  useContextUpdateListenerWithFlowEffect,
+  useInput,
+} from "../utils/hooks";
+import { copy } from "../transformations/copy";
+import { TransformationSubmitButtons, ContextSelector } from "../ui-components";
+import { applyNewDataSet, ctxtTitle } from "./util";
+
+interface CopyProps {
+  setErrMsg: (s: string | null) => void;
+}
+
+export function Copy({ setErrMsg }: CopyProps): ReactElement {
+  const [inputDataCtxt, inputChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+
+  const [lastContextName, setLastContextName] = useState<null | string>(null);
+
+  /**
+   * Applies the copy transformation to the input data context,
+   * producing an output table in CODAP.
+   */
+  const transform = useCallback(
+    async (doUpdate: boolean) => {
+      if (inputDataCtxt === null) {
+        setErrMsg("Please choose a valid data context to flatten.");
+        return;
+      }
+
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
+
+      try {
+        const copied = copy(dataset);
+        await applyNewDataSet(
+          copied,
+          `Copy of ${ctxtTitle(context)}`,
+          doUpdate,
+          lastContextName,
+          setLastContextName,
+          setErrMsg
+        );
+      } catch (e) {
+        setErrMsg(e.message);
+      }
+    },
+    [inputDataCtxt, setErrMsg, lastContextName]
+  );
+
+  useContextUpdateListenerWithFlowEffect(
+    inputDataCtxt,
+    lastContextName,
+    () => {
+      transform(true);
+    },
+    [transform]
+  );
+
+  return (
+    <>
+      <p>Table to Copy</p>
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
+
+      <br />
+      <TransformationSubmitButtons
+        onCreate={() => transform(false)}
+        onUpdate={() => transform(true)}
+        updateDisabled={true}
+      />
+    </>
+  );
+}

--- a/src/transformations/copy.ts
+++ b/src/transformations/copy.ts
@@ -1,0 +1,11 @@
+import { DataSet } from "./types";
+
+/**
+ * Produces a dataset identical to the original.
+ */
+export function copy(dataset: DataSet): DataSet {
+  return {
+    collections: dataset.collections.slice(),
+    records: dataset.records.slice(),
+  };
+}


### PR DESCRIPTION
This adds a transformation that produces an identical copy of the input table. This could be desirable because CODAP doesn't seem to have any native copying feature.