### PR TITLE
change fold names + use attribute descriptions

### DIFF
--- a/src/transformation-components/BuildColumn.tsx
+++ b/src/transformation-components/BuildColumn.tsx
@@ -3,7 +3,7 @@ import { getContextAndDataSet } from "../utils/codapPhone";
 import { useInput, useAttributes } from "../utils/hooks";
 import { buildColumn } from "../transformations/buildColumn";
 import { DataSet } from "../transformations/types";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import {
   ExpressionEditor,
   CodapFlowTextInput,
@@ -83,7 +83,7 @@ export function BuildColumn({
         collectionName,
         expression
       );
-      return [built, `Build Column of ${ctxtTitle(context)}`];
+      return [built, `Build Column of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -9,7 +9,7 @@ import {
   ContextSelector,
   TransformationSubmitButtons,
 } from "../ui-components";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
@@ -68,7 +68,7 @@ export function Compare({ setErrMsg, saveData }: CompareProps): ReactElement {
       );
       return [
         compared,
-        `Compare of ${ctxtTitle(context1)} and ${ctxtTitle(context2)}`,
+        `Compare of ${readableName(context1)} and ${readableName(context2)}`,
       ];
     };
 

--- a/src/transformation-components/Copy.tsx
+++ b/src/transformation-components/Copy.tsx
@@ -4,7 +4,7 @@ import { useInput } from "../utils/hooks";
 import { copy } from "../transformations/copy";
 import { DataSet } from "../transformations/types";
 import { TransformationSubmitButtons, ContextSelector } from "../ui-components";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
@@ -33,7 +33,7 @@ export function Copy({ setErrMsg, saveData }: CopyProps): ReactElement {
     const doTransform: () => Promise<[DataSet, string]> = async () => {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
       const copied = copy(dataset);
-      return [copied, `Copy of ${ctxtTitle(context)}`];
+      return [copied, `Copy of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/Count.tsx
+++ b/src/transformation-components/Count.tsx
@@ -8,7 +8,7 @@ import {
   ContextSelector,
   MultiAttributeSelector,
 } from "../ui-components";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
@@ -50,7 +50,7 @@ export function Count({ setErrMsg, saveData }: CountProps): ReactElement {
       const counted = count(dataset, attributes);
       return [
         counted,
-        `Count of ${attributes.join(", ")} in ${ctxtTitle(context)}`,
+        `Count of ${attributes.join(", ")} in ${readableName(context)}`,
       ];
     };
 

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -10,7 +10,7 @@ import {
   ContextSelector,
   AttributeSelector,
 } from "../ui-components";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
 export interface DifferenceFromSaveData {
@@ -81,7 +81,7 @@ export function DifferenceFrom({
         resultAttributeName,
         differenceStartingValue
       );
-      return [result, `Difference From of ${ctxtTitle(context)}`];
+      return [result, `Difference From of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/Filter.tsx
+++ b/src/transformation-components/Filter.tsx
@@ -8,7 +8,7 @@ import {
   ContextSelector,
   ExpressionEditor,
 } from "../ui-components";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 import { TransformationProps } from "./types";
 import { CodapEvalError } from "../utils/codapPhone/error";
@@ -51,7 +51,7 @@ export function Filter({ setErrMsg, saveData }: FilterProps): ReactElement {
     const doTransform: () => Promise<[DataSet, string]> = async () => {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
       const filtered = await filter(dataset, predicate);
-      return [filtered, `Filter of ${ctxtTitle(context)}`];
+      return [filtered, `Filter of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -4,7 +4,7 @@ import { useInput } from "../utils/hooks";
 import { flatten } from "../transformations/flatten";
 import { DataSet } from "../transformations/types";
 import { TransformationSubmitButtons, ContextSelector } from "../ui-components";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
@@ -36,7 +36,7 @@ export function Flatten({ setErrMsg, saveData }: FlattenProps): ReactElement {
     const doTransform: () => Promise<[DataSet, string]> = async () => {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
       const flat = flatten(dataset);
-      return [flat, `Flatten of ${ctxtTitle(context)}`];
+      return [flat, `Flatten of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -28,7 +28,8 @@ interface FoldProps extends TransformationProps {
   foldFunc: (
     dataset: DataSet,
     inputName: string,
-    outputName: string
+    outputName: string,
+    outputDescrip: string
   ) => DataSet;
   saveData?: FoldSaveData;
 }
@@ -43,7 +44,7 @@ export const RunningSum = (props: FoldConsumerProps): ReactElement => {
     <Fold
       {...{
         ...props,
-        label: "running sum",
+        label: "Running Sum",
         foldFunc: runningSum,
       }}
     />
@@ -54,7 +55,7 @@ export const RunningMean = (props: FoldConsumerProps): ReactElement => {
     <Fold
       {...{
         ...props,
-        label: "running mean",
+        label: "Running Mean",
         foldFunc: runningMean,
       }}
     />
@@ -65,7 +66,7 @@ export const RunningMin = (props: FoldConsumerProps): ReactElement => {
     <Fold
       {...{
         ...props,
-        label: "running min",
+        label: "Running Min",
         foldFunc: runningMin,
       }}
     />
@@ -76,7 +77,7 @@ export const RunningMax = (props: FoldConsumerProps): ReactElement => {
     <Fold
       {...{
         ...props,
-        label: "running max",
+        label: "Running Max",
         foldFunc: runningMax,
       }}
     />
@@ -87,7 +88,7 @@ export const RunningDifference = (props: FoldConsumerProps): ReactElement => {
     <Fold
       {...{
         ...props,
-        label: "difference",
+        label: "Running Difference",
         foldFunc: difference,
       }}
     />
@@ -125,10 +126,22 @@ export function Fold({
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
       const attrs = dataset.collections.map((coll) => coll.attrs || []).flat();
       const resultAttributeName = uniqueName(
-        `${label} of ${inputAttributeName}`,
+        `${label} of ${
+          inputAttributeName.includes(" ")
+            ? `(${inputAttributeName})`
+            : inputAttributeName
+        } from ${ctxtTitle(context)}`,
         attrs.map((attr) => attr.name)
       );
-      const result = foldFunc(dataset, inputAttributeName, resultAttributeName);
+      const resultDescription = `A ${label.toLowerCase()} of the values from the ${inputAttributeName} attribute in the ${ctxtTitle(
+        context
+      )} table.`;
+      const result = foldFunc(
+        dataset,
+        inputAttributeName,
+        resultAttributeName,
+        resultDescription
+      );
       return [result, `${label} of ${ctxtTitle(context)}`];
     };
 

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -8,7 +8,12 @@ import {
   ContextSelector,
   AttributeSelector,
 } from "../ui-components";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import {
+  applyNewDataSet,
+  readableName,
+  parenthesizeName,
+  addUpdateListener,
+} from "./util";
 import {
   difference,
   runningMax,
@@ -29,7 +34,7 @@ interface FoldProps extends TransformationProps {
     dataset: DataSet,
     inputName: string,
     outputName: string,
-    outputDescrip: string
+    outputDescription: string
   ) => DataSet;
   saveData?: FoldSaveData;
 }
@@ -126,14 +131,12 @@ export function Fold({
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
       const attrs = dataset.collections.map((coll) => coll.attrs || []).flat();
       const resultAttributeName = uniqueName(
-        `${label} of ${
-          inputAttributeName.includes(" ")
-            ? `(${inputAttributeName})`
-            : inputAttributeName
-        } from ${ctxtTitle(context)}`,
+        `${label} of ${parenthesizeName(
+          inputAttributeName
+        )} from ${readableName(context)}`,
         attrs.map((attr) => attr.name)
       );
-      const resultDescription = `A ${label.toLowerCase()} of the values from the ${inputAttributeName} attribute in the ${ctxtTitle(
+      const resultDescription = `A ${label.toLowerCase()} of the values from the ${inputAttributeName} attribute in the ${readableName(
         context
       )} table.`;
       const result = foldFunc(
@@ -142,7 +145,7 @@ export function Fold({
         resultAttributeName,
         resultDescription
       );
-      return [result, `${label} of ${ctxtTitle(context)}`];
+      return [result, `${label} of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/GroupBy.tsx
+++ b/src/transformation-components/GroupBy.tsx
@@ -3,7 +3,7 @@ import { getContextAndDataSet } from "../utils/codapPhone";
 import { useInput } from "../utils/hooks";
 import { groupBy } from "../transformations/groupBy";
 import { DataSet } from "../transformations/types";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import {
   TransformationSubmitButtons,
   ContextSelector,
@@ -49,7 +49,7 @@ export function GroupBy({ setErrMsg, saveData }: GroupByProps): ReactElement {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
       const parentName = `Grouped by ${attributes.join(", ")}`;
       const grouped = groupBy(dataset, attributes, parentName);
-      return [grouped, `Group By of ${ctxtTitle(context)}`];
+      return [grouped, `Group By of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/Join.tsx
+++ b/src/transformation-components/Join.tsx
@@ -8,7 +8,7 @@ import {
   ContextSelector,
   TransformationSubmitButtons,
 } from "../ui-components";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
@@ -58,7 +58,7 @@ export function Join({ setErrMsg, saveData }: JoinProps): ReactElement {
       const joined = join(dataset1, inputAttribute1, dataset2, inputAttribute2);
       return [
         joined,
-        `Join of ${ctxtTitle(context1)} and ${ctxtTitle(context2)}`,
+        `Join of ${readableName(context1)} and ${readableName(context2)}`,
       ];
     };
 

--- a/src/transformation-components/PivotLonger.tsx
+++ b/src/transformation-components/PivotLonger.tsx
@@ -3,7 +3,7 @@ import { getContextAndDataSet } from "../utils/codapPhone";
 import { useInput } from "../utils/hooks";
 import { pivotLonger } from "../transformations/pivot";
 import { DataSet } from "../transformations/types";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import {
   MultiAttributeSelector,
   TransformationSubmitButtons,
@@ -70,7 +70,7 @@ export function PivotLonger({
     const doTransform: () => Promise<[DataSet, string]> = async () => {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
       const pivoted = pivotLonger(dataset, attributes, namesTo, valuesTo);
-      return [pivoted, `Pivot Longer of ${ctxtTitle(context)}`];
+      return [pivoted, `Pivot Longer of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/PivotWider.tsx
+++ b/src/transformation-components/PivotWider.tsx
@@ -3,7 +3,7 @@ import { getContextAndDataSet } from "../utils/codapPhone";
 import { useInput } from "../utils/hooks";
 import { pivotWider } from "../transformations/pivot";
 import { DataSet } from "../transformations/types";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import {
   AttributeSelector,
   TransformationSubmitButtons,
@@ -60,7 +60,7 @@ export function PivotWider({
     const doTransform: () => Promise<[DataSet, string]> = async () => {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
       const pivoted = pivotWider(dataset, namesFrom, valuesFrom);
-      return [pivoted, `Pivot Wider of ${ctxtTitle(context)}`];
+      return [pivoted, `Pivot Wider of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/SelectAttributes.tsx
+++ b/src/transformation-components/SelectAttributes.tsx
@@ -9,7 +9,7 @@ import {
   MultiAttributeSelector,
   CodapFlowSelect,
 } from "../ui-components";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
@@ -56,7 +56,7 @@ export function SelectAttributes({
     const doTransform: () => Promise<[DataSet, string]> = async () => {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
       const selected = selectAttributes(dataset, attributes, allBut);
-      return [selected, `Select Attributes of ${ctxtTitle(context)}`];
+      return [selected, `Select Attributes of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/Sort.tsx
+++ b/src/transformation-components/Sort.tsx
@@ -9,7 +9,7 @@ import {
   ExpressionEditor,
   ContextSelector,
 } from "../ui-components";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 import { CodapEvalError } from "../utils/codapPhone/error";
 
@@ -47,7 +47,7 @@ export function Sort({ setErrMsg, saveData }: SortProps): ReactElement {
     const doTransform: () => Promise<[DataSet, string]> = async () => {
       const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
       const result = await sort(dataset, keyExpression);
-      return [result, `Sort of ${ctxtTitle(context)}`];
+      return [result, `Sort of ${readableName(context)}`];
     };
 
     try {

--- a/src/transformation-components/TransformColumn.tsx
+++ b/src/transformation-components/TransformColumn.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, ReactElement } from "react";
 import { useInput, useAttributes } from "../utils/hooks";
 import { transformColumn } from "../transformations/transformColumn";
 import { DataSet } from "../transformations/types";
-import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
 import {
   ExpressionEditor,
   AttributeSelector,
@@ -66,7 +66,7 @@ export function TransformColumn({
         attributeName,
         expression
       );
-      const newName = `Transform Column of ${ctxtTitle(context)}`;
+      const newName = `Transform Column of ${readableName(context)}`;
       return [transformed, newName];
     };
 

--- a/src/transformation-components/util.ts
+++ b/src/transformation-components/util.ts
@@ -23,10 +23,27 @@ export async function applyNewDataSet(
 }
 
 /**
- * Returns the context's title, if any, or falls back to its name.
+ * Returns the context's title, if any, or falls back to its name. Also
+ * adds parentheses around the name if it determines the name
+ * is not a single word.
+ *
+ * @param context the data context to produce a readable name for
+ * @returns readable name of the context
  */
-export function ctxtTitle(context: DataContext): string {
-  return context.title ? context.title : context.name;
+export function readableName(context: DataContext): string {
+  return parenthesizeName(context.title ? context.title : context.name);
+}
+
+/**
+ * If the given name contains spaces, this will add parentheses
+ * to it, to keep it readable as a unit. Otherwise, returns
+ * the name unchanged.
+ *
+ * @param name the name to parenthesize
+ * @returns the input name, with parentheses added or not
+ */
+export function parenthesizeName(name: string): string {
+  return name.includes(" ") ? `(${name})` : name;
 }
 
 /**

--- a/src/transformations/buildColumn.ts
+++ b/src/transformations/buildColumn.ts
@@ -35,6 +35,7 @@ export async function buildColumn(
   // add new attribute
   toAdd.attrs.push({
     name: newAttributeName,
+    description: `An attribute whose values were computed with the formula ${expression}`,
   });
 
   const records = dataset.records.slice();

--- a/src/transformations/count.ts
+++ b/src/transformations/count.ts
@@ -42,13 +42,20 @@ export function count(dataset: DataSet, attributes: string[]): DataSet {
     countedAttrs.map((attr) => attr.name)
   );
 
+  const attributeNames = attributes.join(", ");
   // single collection with copy of counted attributes, plus
   // a new "count" attribute for the frequencies
   const collections: Collection[] = [
     {
-      name: `Count (${attributes.join(", ")})`,
+      name: `Count (${attributeNames})`,
       labels: {},
-      attrs: [...countedAttrs, { name: countAttrName }],
+      attrs: [
+        ...countedAttrs,
+        {
+          name: countAttrName,
+          description: `The frequency of each tuple of (${attributeNames})`,
+        },
+      ],
     },
   ];
 

--- a/src/transformations/fold.ts
+++ b/src/transformations/fold.ts
@@ -8,7 +8,8 @@ function makeNumFold<T>(
   return (
     dataset: DataSet,
     inputColumnName: string,
-    resultColumnName: string
+    resultColumnName: string,
+    resultColumnDescrip: string
   ): DataSet => {
     let acc = base;
 
@@ -29,6 +30,7 @@ function makeNumFold<T>(
     const newCollections = insertColumnInLastCollection(dataset.collections, {
       name: resultColumnName,
       type: "numeric",
+      description: resultColumnDescrip,
     });
 
     return {

--- a/src/transformations/fold.ts
+++ b/src/transformations/fold.ts
@@ -9,7 +9,7 @@ function makeNumFold<T>(
     dataset: DataSet,
     inputColumnName: string,
     resultColumnName: string,
-    resultColumnDescrip: string
+    resultColumnDescription: string
   ): DataSet => {
     let acc = base;
 
@@ -30,7 +30,7 @@ function makeNumFold<T>(
     const newCollections = insertColumnInLastCollection(dataset.collections, {
       name: resultColumnName,
       type: "numeric",
-      description: resultColumnDescrip,
+      description: resultColumnDescription,
     });
 
     return {

--- a/src/transformations/groupBy.ts
+++ b/src/transformations/groupBy.ts
@@ -45,6 +45,7 @@ export function groupBy(
           ...attr,
           name: groupedAttrName(attr.name), // rename attribute uniquely
           formula: undefined, // do not copy formulas
+          description: `All values of the ${attrName} attribute that appear in distinct tuples.`,
         });
         continue attrLoop;
       }

--- a/src/transformations/pivot.ts
+++ b/src/transformations/pivot.ts
@@ -34,6 +34,8 @@ export function pivotLonger(
   // NOTE: do not copy formulas: dependencies may be removed by the pivot
   eraseFormulas(collection.attrs);
 
+  const toPivotNames = toPivot.join(", ");
+
   // add namesTo and valuesTo attributes
   // NOTE: valuesTo might hold values of different types
   // so we can't be sure it's either numeric / categorical
@@ -41,9 +43,11 @@ export function pivotLonger(
     {
       name: namesTo,
       type: "categorical",
+      description: `Contains the names of attributes (${toPivotNames}) that were pivoted into values.`,
     },
     {
       name: valuesTo,
+      description: `Contains the values previously under the ${toPivotNames} attributes.`,
     }
   );
 
@@ -140,6 +144,7 @@ export function pivotWider(
       ...valuesFromAttr,
       formula: undefined,
       name: attrName,
+      description: `Attribute created by pivoting the values of ${namesFrom} into separate attributes.`,
     });
   }
 

--- a/src/transformations/transformColumn.ts
+++ b/src/transformations/transformColumn.ts
@@ -28,9 +28,10 @@ export async function transformColumn(
   for (const coll of collections) {
     const attr = coll.attrs?.find((attr) => attr.name === attributeName);
 
-    // erase the transformed attribute's formula
+    // erase the transformed attribute's formula and set description
     if (attr !== undefined) {
       attr.formula = undefined;
+      attr.description = `The ${attributeName} attribute, transformed by the formula ${expression}`;
       break;
     }
   }


### PR DESCRIPTION
This updates the naming of fold operations to incorporate the name of the table on which they were computed in their attribute:

![running-mean](https://user-images.githubusercontent.com/13399527/121063469-562fea00-c794-11eb-8507-e6c4dc69821a.png)

The format is now "\<fold type\> of \<attribute\> from \<data context\>". If it detects a long attribute name (one that contains spaces), it will parenthesize the inner attribute.

The attribute `description` property (which appears in a tooltip) is used to provide a full description of the fold that took place. I've also incorporated this `description` property into other transformations that create new attributes or significantly modify them.