### PR TITLE
cover pyret table operations

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -58,6 +58,7 @@ function Transformation({
       "Join",
       "Eval",
       "Copy",
+      "Combine Cases",
     ],
   };
 
@@ -82,6 +83,7 @@ function Transformation({
     { name: "Join", content: { base: "Join" } },
     { name: "Eval", content: { base: "Eval" } },
     { name: "Copy", content: { base: "Copy" } },
+    { name: "Combine Cases", content: { base: "Combine Cases" } },
   ];
 
   function addTransformation(name: string, data: TransformationSaveData) {

--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -58,6 +58,7 @@ function Transformation({
       "Join",
       "Eval",
       "Copy",
+      "Copy Schema",
       "Combine Cases",
     ],
   };
@@ -83,6 +84,7 @@ function Transformation({
     { name: "Join", content: { base: "Join" } },
     { name: "Eval", content: { base: "Eval" } },
     { name: "Copy", content: { base: "Copy" } },
+    { name: "Copy Schema", content: { base: "Copy Schema" } },
     { name: "Combine Cases", content: { base: "Combine Cases" } },
   ];
 

--- a/src/transformation-components/CombineCases.tsx
+++ b/src/transformation-components/CombineCases.tsx
@@ -8,8 +8,7 @@ import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
 import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
-// eslint-disable-next-line
-export interface CombineCasesSaveData {}
+export type CombineCasesSaveData = Record<string, never>;
 
 interface CombineCasesProps extends TransformationProps {
   saveData?: CombineCasesSaveData;

--- a/src/transformation-components/CombineCases.tsx
+++ b/src/transformation-components/CombineCases.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback, ReactElement } from "react";
+import { getContextAndDataSet } from "../utils/codapPhone";
+import { useInput } from "../utils/hooks";
+import { combineCases } from "../transformations/combineCases";
+import { DataSet } from "../transformations/types";
+import { ContextSelector, TransformationSubmitButtons } from "../ui-components";
+import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { TransformationProps } from "./types";
+import TransformationSaveButton from "../ui-components/TransformationSaveButton";
+
+// eslint-disable-next-line
+export interface CombineCasesSaveData {}
+
+interface CombineCasesProps extends TransformationProps {
+  saveData?: CombineCasesSaveData;
+}
+
+export function CombineCases({
+  setErrMsg,
+  saveData,
+}: CombineCasesProps): ReactElement {
+  const [inputDataContext1, inputDataContext1OnChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+  const [inputDataContext2, inputDataContext2OnChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+
+  const transform = useCallback(async () => {
+    setErrMsg(null);
+
+    if (!inputDataContext1 || !inputDataContext2) {
+      setErrMsg("Please choose two contexts to stack.");
+      return;
+    }
+
+    const doTransform: () => Promise<[DataSet, string]> = async () => {
+      const { context: context1, dataset: dataset1 } =
+        await getContextAndDataSet(inputDataContext1);
+      const { context: context2, dataset: dataset2 } =
+        await getContextAndDataSet(inputDataContext2);
+      const combined = combineCases(dataset1, dataset2);
+      return [
+        combined,
+        `Combined Cases of ${ctxtTitle(context1)} and ${ctxtTitle(context2)}`,
+      ];
+    };
+
+    try {
+      const newContextName = await applyNewDataSet(...(await doTransform()));
+      addUpdateListener(
+        inputDataContext1,
+        newContextName,
+        doTransform,
+        setErrMsg
+      );
+      addUpdateListener(
+        inputDataContext2,
+        newContextName,
+        doTransform,
+        setErrMsg
+      );
+    } catch (e) {
+      setErrMsg(e.message);
+    }
+  }, [inputDataContext1, inputDataContext2, setErrMsg]);
+
+  return (
+    <>
+      <p>Base Table</p>
+      <ContextSelector
+        value={inputDataContext1}
+        onChange={inputDataContext1OnChange}
+      />
+      <p>Combining Table</p>
+      <ContextSelector
+        value={inputDataContext2}
+        onChange={inputDataContext2OnChange}
+      />
+
+      <br />
+      <TransformationSubmitButtons onCreate={transform} />
+      {saveData === undefined && (
+        <TransformationSaveButton generateSaveData={() => ({})} />
+      )}
+    </>
+  );
+}

--- a/src/transformation-components/Compare.tsx
+++ b/src/transformation-components/Compare.tsx
@@ -14,8 +14,8 @@ import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
 export interface CompareSaveData {
-  inputAttribute1: string;
-  inputAttribute2: string;
+  inputAttribute1: string | null;
+  inputAttribute2: string | null;
   compareType: CompareType;
 }
 

--- a/src/transformation-components/Copy.tsx
+++ b/src/transformation-components/Copy.tsx
@@ -8,8 +8,7 @@ import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
 import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
-// eslint-disable-next-line
-export interface CopySaveData {}
+export type CopySaveData = Record<string, never>;
 
 interface CopyProps extends TransformationProps {
   saveData?: CopySaveData;

--- a/src/transformation-components/CopySchema.tsx
+++ b/src/transformation-components/CopySchema.tsx
@@ -8,8 +8,7 @@ import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
 import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
-// eslint-disable-next-line
-export interface CopySchemaSaveData {}
+export type CopySchemaSaveData = Record<string, never>;
 
 interface CopySchemaProps extends TransformationProps {
   saveData?: CopySchemaSaveData;

--- a/src/transformation-components/CopySchema.tsx
+++ b/src/transformation-components/CopySchema.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback, ReactElement } from "react";
+import { getContextAndDataSet } from "../utils/codapPhone";
+import { useInput } from "../utils/hooks";
+import { copySchema } from "../transformations/copySchema";
+import { DataSet } from "../transformations/types";
+import { TransformationSubmitButtons, ContextSelector } from "../ui-components";
+import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
+import { TransformationProps } from "./types";
+import TransformationSaveButton from "../ui-components/TransformationSaveButton";
+
+// eslint-disable-next-line
+export interface CopySchemaSaveData {}
+
+interface CopySchemaProps extends TransformationProps {
+  saveData?: CopySchemaSaveData;
+}
+export function CopySchema({
+  setErrMsg,
+  saveData,
+}: CopySchemaProps): ReactElement {
+  const [inputDataCtxt, inputChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+
+  /**
+   * Applies the copy transformation to the input data context,
+   * producing an output table in CODAP.
+   */
+  const transform = useCallback(async () => {
+    if (inputDataCtxt === null) {
+      setErrMsg("Please choose a valid data context to flatten.");
+      return;
+    }
+
+    const doTransform: () => Promise<[DataSet, string]> = async () => {
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
+      const copied = copySchema(dataset);
+      return [copied, `Schema Copy of ${ctxtTitle(context)}`];
+    };
+
+    try {
+      const newContextName = await applyNewDataSet(...(await doTransform()));
+      addUpdateListener(inputDataCtxt, newContextName, doTransform, setErrMsg);
+    } catch (e) {
+      setErrMsg(e.message);
+    }
+  }, [inputDataCtxt, setErrMsg]);
+
+  return (
+    <>
+      <p>Table to Copy the Schema of</p>
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
+
+      <br />
+      <TransformationSubmitButtons onCreate={transform} />
+      {saveData === undefined && (
+        <TransformationSaveButton generateSaveData={() => ({})} />
+      )}
+    </>
+  );
+}

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -14,7 +14,7 @@ import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
 export interface DifferenceFromSaveData {
-  inputAttributeName: string;
+  inputAttributeName: string | null;
   resultAttributeName: string;
   startingValue: string;
 }

--- a/src/transformation-components/Eval.tsx
+++ b/src/transformation-components/Eval.tsx
@@ -5,8 +5,7 @@ import { useInput, useAttributes } from "../utils/hooks";
 import { ContextSelector, ExpressionEditor } from "../ui-components";
 import { TransformationProps } from "./types";
 
-// eslint-disable-next-line
-export interface EvalSaveData {}
+export type EvalSaveData = Record<string, never>;
 
 interface EvalProps extends TransformationProps {
   saveData?: EvalSaveData;

--- a/src/transformation-components/Flatten.tsx
+++ b/src/transformation-components/Flatten.tsx
@@ -8,8 +8,7 @@ import { applyNewDataSet, ctxtTitle, addUpdateListener } from "./util";
 import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
-// eslint-disable-next-line
-export interface FlattenSaveData {}
+export type FlattenSaveData = Record<string, never>;
 
 interface FlattenProps extends TransformationProps {
   saveData?: FlattenSaveData;

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -20,7 +20,7 @@ import TransformationSaveButton from "../ui-components/TransformationSaveButton"
 import { uniqueName } from "../utils/names";
 
 export interface FoldSaveData {
-  inputAttributeName: string;
+  inputAttributeName: string | null;
 }
 
 interface FoldProps extends TransformationProps {

--- a/src/transformation-components/Join.tsx
+++ b/src/transformation-components/Join.tsx
@@ -13,8 +13,8 @@ import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
 export interface JoinSaveData {
-  inputAttribute1: string;
-  inputAttribute2: string;
+  inputAttribute1: string | null;
+  inputAttribute2: string | null;
 }
 
 interface JoinProps extends TransformationProps {

--- a/src/transformation-components/PivotWider.tsx
+++ b/src/transformation-components/PivotWider.tsx
@@ -13,8 +13,8 @@ import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 
 export interface PivotWiderSaveData {
-  namesFrom: string;
-  valuesFrom: string;
+  namesFrom: string | null;
+  valuesFrom: string | null;
 }
 
 interface PivotWiderProps extends TransformationProps {

--- a/src/transformation-components/PolymorphicComponent.tsx
+++ b/src/transformation-components/PolymorphicComponent.tsx
@@ -22,6 +22,7 @@ import { SavedTransformation } from "./types";
 import { Join } from "./Join";
 import { Eval } from "./Eval";
 import { Copy } from "./Copy";
+import { CombineCases } from "./CombineCases";
 
 interface PolymorphicComponentProps {
   transformation?: SavedTransformation;
@@ -152,6 +153,13 @@ export const PolymorphicComponent = ({
     case "Copy":
       return (
         <Copy setErrMsg={setErrMsg} saveData={transformation.content.data} />
+      );
+    case "Combine Cases":
+      return (
+        <CombineCases
+          setErrMsg={setErrMsg}
+          saveData={transformation.content.data}
+        />
       );
   }
 };

--- a/src/transformation-components/PolymorphicComponent.tsx
+++ b/src/transformation-components/PolymorphicComponent.tsx
@@ -22,6 +22,7 @@ import { SavedTransformation } from "./types";
 import { Join } from "./Join";
 import { Eval } from "./Eval";
 import { Copy } from "./Copy";
+import { CopySchema } from "./CopySchema";
 import { CombineCases } from "./CombineCases";
 
 interface PolymorphicComponentProps {
@@ -153,6 +154,13 @@ export const PolymorphicComponent = ({
     case "Copy":
       return (
         <Copy setErrMsg={setErrMsg} saveData={transformation.content.data} />
+      );
+    case "Copy Schema":
+      return (
+        <CopySchema
+          setErrMsg={setErrMsg}
+          saveData={transformation.content.data}
+        />
       );
     case "Combine Cases":
       return (

--- a/src/transformation-components/TransformColumn.tsx
+++ b/src/transformation-components/TransformColumn.tsx
@@ -15,7 +15,7 @@ import TransformationSaveButton from "../ui-components/TransformationSaveButton"
 import { CodapEvalError } from "../utils/codapPhone/error";
 
 export interface TransformColumnSaveData {
-  attributeName: string;
+  attributeName: string | null;
   expression: string;
 }
 

--- a/src/transformation-components/types.ts
+++ b/src/transformation-components/types.ts
@@ -15,6 +15,7 @@ import { PivotWiderSaveData } from "./PivotWider";
 import { SelectAttributesSaveData } from "./SelectAttributes";
 import { SortSaveData } from "./Sort";
 import { TransformColumnSaveData } from "./TransformColumn";
+import { CombineCasesSaveData } from "./CombineCases";
 
 /**
  * The content associated with a saved transformation. Includes the base
@@ -101,6 +102,10 @@ export type SavedTransformationContent =
   | {
       base: "Eval";
       data?: EvalSaveData;
+    }
+  | {
+      base: "Combine Cases";
+      data?: CombineCasesSaveData;
     };
 
 /**

--- a/src/transformation-components/types.ts
+++ b/src/transformation-components/types.ts
@@ -2,6 +2,7 @@ import { ReactElement } from "react";
 import { BuildColumnSaveData } from "./BuildColumn";
 import { CompareSaveData } from "./Compare";
 import { CopySaveData } from "./Copy";
+import { CopySchemaSaveData } from "./CopySchema";
 import { CountSaveData } from "./Count";
 import { DifferenceFromSaveData } from "./DifferenceFrom";
 import { EvalSaveData } from "./Eval";
@@ -94,6 +95,10 @@ export type SavedTransformationContent =
   | {
       base: "Copy";
       data?: CopySaveData;
+    }
+  | {
+      base: "Copy Schema";
+      data?: CopySchemaSaveData;
     }
   | {
       base: "Join";

--- a/src/transformations/combineCases.ts
+++ b/src/transformations/combineCases.ts
@@ -1,0 +1,49 @@
+import { DataSet } from "./types";
+import { setEquality } from "../utils/sets";
+import { eraseFormulas } from "./util";
+
+/**
+ * Stack combines a top and bottom table which have matching attributes
+ * into a single table that has all the top cases, followed by all
+ * the bottom cases.
+ *
+ * NOTE: The output table's schema will match that of the `top` input.
+ * The top and bottom must have the same set of attributes for stack
+ * to succeed.
+ */
+export function combineCases(base: DataSet, combining: DataSet): DataSet {
+  const baseAttrs = allAttrNames(base);
+  const combiningAttrs = allAttrNames(combining);
+
+  if (
+    !setEquality(baseAttrs, combiningAttrs, (name1, name2) => name1 === name2)
+  ) {
+    throw new Error(
+      `base and combining tables must have the same attribute names`
+    );
+  }
+
+  // add combining records
+  const records = base.records.concat(combining.records);
+
+  // NOTE: do not preserve base table's formulas. It is possible the combining
+  // table's values get clobbered by a formula.
+  const collections = base.collections.slice();
+  collections.forEach((coll) => eraseFormulas(coll.attrs || []));
+
+  // same schema as base, with combined records
+  return {
+    collections: base.collections.slice(),
+    records,
+  };
+}
+
+/**
+ * Extract all attribute names from the given dataset.
+ */
+function allAttrNames(dataset: DataSet): string[] {
+  return dataset.collections
+    .map((coll) => coll.attrs || [])
+    .flat()
+    .map((attr) => attr.name);
+}

--- a/src/transformations/copySchema.ts
+++ b/src/transformations/copySchema.ts
@@ -1,0 +1,12 @@
+import { DataSet } from "./types";
+
+/**
+ * Produces a dataset with an identical schema (collection structure,
+ * attributes) to the input, but with no records.
+ */
+export function copySchema(dataset: DataSet): DataSet {
+  return {
+    collections: dataset.collections.slice(),
+    records: [],
+  };
+}

--- a/src/utils/sets.ts
+++ b/src/utils/sets.ts
@@ -63,3 +63,16 @@ export function symmetricDifferenceWithPredicate<T>(
     pred
   );
 }
+
+/**
+ * Check if two sets are equal, given a predicate for comparing elements.
+ */
+export function setEquality<T>(
+  array1: T[],
+  array2: T[],
+  pred: (elt1: T, elt2: T) => boolean
+): boolean {
+  // symmetric difference should be empty if equal since
+  // all elements are in both array1 and array2
+  return symmetricDifferenceWithPredicate(array1, array2, pred).length === 0;
+}


### PR DESCRIPTION
This adds two transformations, "combine cases" and "copy schema", which mirror the `stack` and `empty` methods from the [Pyret tables documentation](https://www.pyret.org/docs/latest/tables.html).

Combine cases builds a table with the combined cases of two tables who share the same attribute set. Copy schema creates a copy of a table, but without any records (just the schema is copied).

With these added, we pretty much cover what I would say are the Pyret table operations that apply to our context. There may be more possibilities in the future with transformations that yield a single value, but for now I think this is good.