### PR TITLE
disable browser launch on `npm start`

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BROWSER=none


### PR DESCRIPTION
This makes it so that when you run `npm start`, it doesn't launch `localhost:3000` in the browser, since we are really never using the plugin as a standalone app.