### PR TITLE
fixing single attribute selectors

### DIFF
--- a/src/transformation-components/Average.tsx
+++ b/src/transformation-components/Average.tsx
@@ -77,6 +77,7 @@ export function Average({ setErrMsg, saveData }: AverageProps): ReactElement {
         context={inputDataCtxt}
         value={attribute}
         onChange={setAttribute}
+        disabled={saveData !== undefined}
       />
       <br />
       <TransformationSubmitButtons

--- a/src/transformation-components/DifferenceFrom.tsx
+++ b/src/transformation-components/DifferenceFrom.tsx
@@ -107,16 +107,19 @@ export function DifferenceFrom({
         onChange={inputAttributeNameChange}
         value={inputAttributeName}
         context={inputDataCtxt}
+        disabled={saveData !== undefined}
       />
       <p>Result Attribute Name</p>
       <CodapFlowTextInput
         value={resultAttributeName}
         onChange={resultAttributeNameChange}
+        disabled={saveData !== undefined}
       />
       <p>Starting value for difference</p>
       <CodapFlowTextInput
         value={startingValue}
         onChange={startingValueChange}
+        disabled={saveData !== undefined}
       />
       <br />
       <TransformationSubmitButtons onCreate={transform} />

--- a/src/transformation-components/Fold.tsx
+++ b/src/transformation-components/Fold.tsx
@@ -166,6 +166,7 @@ export function Fold({
         onChange={inputAttributeNameChange}
         value={inputAttributeName}
         context={inputDataCtxt}
+        disabled={saveData !== undefined}
       />
 
       <br />

--- a/src/transformation-components/Join.tsx
+++ b/src/transformation-components/Join.tsx
@@ -105,6 +105,7 @@ export function Join({ setErrMsg, saveData }: JoinProps): ReactElement {
         onChange={inputAttribute1OnChange}
         value={inputAttribute1}
         context={inputDataContext1}
+        disabled={saveData !== undefined}
       />
 
       <p>Joining Attribute</p>
@@ -112,6 +113,7 @@ export function Join({ setErrMsg, saveData }: JoinProps): ReactElement {
         onChange={inputAttribute2OnChange}
         value={inputAttribute2}
         context={inputDataContext2}
+        disabled={saveData !== undefined}
       />
 
       <br />

--- a/src/transformation-components/PivotLonger.tsx
+++ b/src/transformation-components/PivotLonger.tsx
@@ -95,10 +95,18 @@ export function PivotLonger({
       />
 
       <p>Names To</p>
-      <CodapFlowTextInput value={namesTo} onChange={namesToChange} />
+      <CodapFlowTextInput
+        value={namesTo}
+        onChange={namesToChange}
+        disabled={saveData !== undefined}
+      />
 
       <p>Values To</p>
-      <CodapFlowTextInput value={valuesTo} onChange={valuesToChange} />
+      <CodapFlowTextInput
+        value={valuesTo}
+        onChange={valuesToChange}
+        disabled={saveData !== undefined}
+      />
 
       <br />
       <TransformationSubmitButtons onCreate={transform} />

--- a/src/transformation-components/TransformColumn.tsx
+++ b/src/transformation-components/TransformColumn.tsx
@@ -92,6 +92,7 @@ export function TransformColumn({
         onChange={attributeNameChange}
         value={attributeName}
         context={inputDataCtxt}
+        disabled={saveData !== undefined}
       />
 
       <p>How to Transform Column</p>

--- a/src/ui-components/AttributeSelector.tsx
+++ b/src/ui-components/AttributeSelector.tsx
@@ -18,18 +18,25 @@ export default function AttributeSelector({
   const attributes = useAttributes(context);
 
   useEffect(() => {
+    if (disabled) {
+      return;
+    }
     if (value && !attributes.map((a) => a.name).includes(value)) {
       onChange(null);
     }
-  }, [value, onChange, attributes]);
+  }, [value, onChange, attributes, disabled]);
 
   return (
     <CodapFlowSelect
       onChange={(e) => onChange(e.target.value)}
-      options={attributes.map((attribute) => ({
-        value: attribute.name,
-        title: attribute.title,
-      }))}
+      options={
+        disabled && value !== null
+          ? [{ value: value, title: value }]
+          : attributes.map((attribute) => ({
+              value: attribute.name,
+              title: attribute.title,
+            }))
+      }
       value={value}
       defaultValue="Select an attribute"
       disabled={disabled}


### PR DESCRIPTION
This is a WIP to fix the single attribute selectors when saved. They previously weren't appearing as grayed out because the `disabled` prop wasn't getting passed through (this was happening in a few other places too which I've changed). 

However now there's the behavior of attribute selectors not holding their saveData value when they are used in a saved transformation. I logged `saveData` and then `attributeName` from inside the body of the `TransformColumn` component during the creation of a saved transformation and saw this:

![Screenshot from 2021-06-08 19-11-10](https://user-images.githubusercontent.com/13399527/121269878-970c2980-c88e-11eb-98f5-cebec8cb54b9.png)

Which is suspicious, given it's happening twice and the second time `attributeName` is `null` though it is present in the `saveData`.

Let me know if you have ideas about a fix for this / feel free to commit anything