### PR TITLE
Add save data for dot product and fix graphical issue on multi attribute selector

### DIFF
--- a/src/transformation-components/Average.tsx
+++ b/src/transformation-components/Average.tsx
@@ -13,7 +13,7 @@ import TransformationSaveButton from "../ui-components/TransformationSaveButton"
 import AttributeSelector from "../ui-components/AttributeSelector";
 
 export interface AverageSaveData {
-  attribute: string;
+  attribute: string | null;
 }
 
 interface AverageProps extends TransformationProps {
@@ -90,7 +90,7 @@ export function Average({
       />
       {errorDisplay}
       {saveData === undefined && (
-        <TransformationSaveButton generateSaveData={() => ({})} />
+        <TransformationSaveButton generateSaveData={() => ({ attribute })} />
       )}
     </>
   );

--- a/src/transformation-components/DotProduct.tsx
+++ b/src/transformation-components/DotProduct.tsx
@@ -12,8 +12,9 @@ import { TransformationProps } from "./types";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 import { MultiAttributeSelector } from "../ui-components";
 
-export type DotProductSaveData = Record<string, never>;
-
+export interface DotProductSaveData {
+  attributes: string[];
+}
 interface DotProductProps extends TransformationProps {
   saveData?: DotProductSaveData;
 }
@@ -28,7 +29,11 @@ export function DotProduct({
     HTMLSelectElement
   >(null, () => setErrMsg(null));
 
-  const [attributes, setAttributes] = useState<string[]>([]);
+  const [attributes, setAttributes] = useState<string[]>(
+    saveData !== undefined ? saveData.attributes : []
+  );
+
+  console.log(attributes);
 
   /**
    * Applies the user-defined transformation to the indicated input data,
@@ -78,6 +83,7 @@ export function DotProduct({
         context={inputDataCtxt}
         setSelected={setAttributes}
         selected={attributes}
+        disabled={saveData !== undefined}
       />
 
       <br />
@@ -87,7 +93,7 @@ export function DotProduct({
       />
       {errorDisplay}
       {saveData === undefined && (
-        <TransformationSaveButton generateSaveData={() => ({})} />
+        <TransformationSaveButton generateSaveData={() => ({ attributes })} />
       )}
     </>
   );

--- a/src/transformation-components/DotProduct.tsx
+++ b/src/transformation-components/DotProduct.tsx
@@ -33,8 +33,6 @@ export function DotProduct({
     saveData !== undefined ? saveData.attributes : []
   );
 
-  console.log(attributes);
-
   /**
    * Applies the user-defined transformation to the indicated input data,
    * and generates an output table into CODAP containing the transformed data.

--- a/src/ui-components/MultiAttributeSelector.css
+++ b/src/ui-components/MultiAttributeSelector.css
@@ -1,5 +1,9 @@
-
 .deleteButton {
   padding: 2px;
   margin-left: 2px;
+}
+
+.deleteButton:disabled:hover {
+  background-color: inherit;
+  cursor: default;
 }


### PR DESCRIPTION
This PR
* adds save data for the dot product transformation
* fixes a graphical issue where disabled buttons in a multi-attribute selector would still highlight on hover and change the cursor type