### PR TITLE
add partition

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -60,6 +60,7 @@ function Transformation({
       "Build Column",
       "Select Attributes",
       "Difference From",
+      "Partition",
     ],
   };
 
@@ -87,6 +88,7 @@ function Transformation({
     { name: "Average", content: { base: "Average" } },
     { name: "Copy Schema", content: { base: "Copy Schema" } },
     { name: "Combine Cases", content: { base: "Combine Cases" } },
+    { name: "Partition", content: { base: "Partition" } },
   ];
 
   function addTransformation(name: string, data: TransformationSaveData) {

--- a/src/transformation-components/Partition.tsx
+++ b/src/transformation-components/Partition.tsx
@@ -106,7 +106,8 @@ export function Partition({
         for (const [value, context] of Object.entries(valueToContext)) {
           // if there is no longer a partition for this value
           if (
-            transformed.find(([pd]) => pd.distinctValue === value) === undefined
+            transformed.find(([pd]) => pd.distinctValueAsStr === value) ===
+            undefined
           ) {
             deleteDataContext(context);
           }

--- a/src/transformation-components/Partition.tsx
+++ b/src/transformation-components/Partition.tsx
@@ -16,8 +16,7 @@ import { applyNewDataSet, readableName } from "./util";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 import { TransformationProps } from "./types";
 
-// FIXME: this should be attributeName: string, but it doesn't type check
-// and I'm not sure why.
+// FIXME: this should be attributeName: string
 export interface PartitionSaveData {
   attributeName: string | null;
 }

--- a/src/transformation-components/Partition.tsx
+++ b/src/transformation-components/Partition.tsx
@@ -58,7 +58,7 @@ export function Partition({
     const doTransform: () => Promise<[PartitionDataset, string][]> =
       async () => {
         const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
-        const partitioned = await partition(dataset, attributeName);
+        const partitioned = partition(dataset, attributeName);
 
         // assign names to each partitioned dataset
         const readableContext = readableName(context);

--- a/src/transformation-components/Partition.tsx
+++ b/src/transformation-components/Partition.tsx
@@ -1,0 +1,112 @@
+import React, { useCallback, ReactElement, useState } from "react";
+import { getContextAndDataSet } from "../utils/codapPhone";
+import { useInput } from "../utils/hooks";
+import { partition, PartitionDataset } from "../transformations/partition";
+import { DataSet } from "../transformations/types";
+import {
+  TransformationSubmitButtons,
+  ContextSelector,
+  AttributeSelector,
+} from "../ui-components";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
+import TransformationSaveButton from "../ui-components/TransformationSaveButton";
+import { TransformationProps } from "./types";
+
+export interface PartitionSaveData {
+  attributeName: string | null;
+}
+
+interface PartitionProps extends TransformationProps {
+  saveData?: PartitionSaveData;
+}
+
+export function Partition({
+  setErrMsg,
+  saveData,
+  errorDisplay,
+}: PartitionProps): ReactElement {
+  const [inputDataCtxt, inputChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+  const [attributeName, attributeNameChange] = useState<string | null>(
+    saveData !== undefined ? saveData.attributeName : null
+  );
+
+  /**
+   * Applies the user-defined transformation to the indicated input data,
+   * and generates an output table into CODAP containing the transformed data.
+   */
+  const transform = useCallback(async () => {
+    setErrMsg(null);
+
+    if (inputDataCtxt === null) {
+      setErrMsg("Please choose a valid dataset to transform.");
+      return;
+    }
+    if (attributeName === null) {
+      setErrMsg("Please select an attribute to partition by.");
+      return;
+    }
+
+    const doTransform: () => Promise<[PartitionDataset, string][]> =
+      async () => {
+        const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
+        const partitioned = await partition(dataset, attributeName);
+
+        // assign names to each partitioned dataset
+        const readableContext = readableName(context);
+
+        // return both the datasets and their names
+        return partitioned.map((dataset) => [
+          dataset,
+          `Partition of ${readableContext} by ${attributeName} = ${dataset.distinctValue}`,
+        ]);
+      };
+
+    try {
+      const transformed = await doTransform();
+
+      for (const [partitioned, name] of transformed) {
+        const newContextName = await applyNewDataSet(partitioned.dataset, name);
+
+        // FIXME: what to do about updating when a transformation
+        // generates multiple output contexts
+        // addUpdateListener(
+        //   inputDataCtxt,
+        //   newContextName,
+        //   doTransform,
+        //   setErrMsg
+        // );
+      }
+    } catch (e) {
+      setErrMsg(e.message);
+    }
+  }, [inputDataCtxt, attributeName, setErrMsg]);
+
+  return (
+    <>
+      <h3>Table to Partition</h3>
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
+
+      <h3>Attribute to Partition By</h3>
+      <AttributeSelector
+        onChange={attributeNameChange}
+        value={attributeName}
+        context={inputDataCtxt}
+        disabled={saveData !== undefined}
+      />
+
+      <br />
+      <TransformationSubmitButtons onCreate={transform} />
+      {errorDisplay}
+      {saveData === undefined && (
+        <TransformationSaveButton
+          generateSaveData={() => ({
+            attributeName,
+          })}
+        />
+      )}
+    </>
+  );
+}

--- a/src/transformation-components/Partition.tsx
+++ b/src/transformation-components/Partition.tsx
@@ -15,6 +15,7 @@ import {
 import { applyNewDataSet, readableName } from "./util";
 import TransformationSaveButton from "../ui-components/TransformationSaveButton";
 import { TransformationProps } from "./types";
+import { codapValueToString } from "../transformations/util";
 
 // FIXME: this should be attributeName: string
 export interface PartitionSaveData {
@@ -65,7 +66,9 @@ export function Partition({
         // return both the datasets and their names
         return partitioned.map((pd) => [
           pd,
-          `Partition of ${readableContext} by ${attributeName} = ${pd.distinctValue}`,
+          `Partition of ${readableContext} by ${attributeName} = ${codapValueToString(
+            pd.distinctValue
+          )}`,
         ]);
       };
 
@@ -75,7 +78,7 @@ export function Partition({
 
       for (const [partitioned, name] of transformed) {
         const newContextName = await applyNewDataSet(partitioned.dataset, name);
-        valueToContext[partitioned.distinctValue] = newContextName;
+        valueToContext[partitioned.distinctValueAsStr] = newContextName;
       }
 
       // listen for updates to the input data context
@@ -86,17 +89,17 @@ export function Partition({
         const newValueToContext: Record<string, string> = {};
 
         for (const [partitioned, name] of transformed) {
-          const contextName = valueToContext[partitioned.distinctValue];
+          const contextName = valueToContext[partitioned.distinctValueAsStr];
           if (contextName === undefined) {
             // this is a new table (a new distinct value)
-            newValueToContext[partitioned.distinctValue] =
+            newValueToContext[partitioned.distinctValueAsStr] =
               await applyNewDataSet(partitioned.dataset, name);
           } else {
             // apply an update to a previous dataset
             updateContextWithDataSet(contextName, partitioned.dataset);
 
             // copy over existing context name into new valueToContext mapping
-            newValueToContext[partitioned.distinctValue] = contextName;
+            newValueToContext[partitioned.distinctValueAsStr] = contextName;
           }
         }
 

--- a/src/transformation-components/PolymorphicComponent.tsx
+++ b/src/transformation-components/PolymorphicComponent.tsx
@@ -25,6 +25,7 @@ import { DotProduct } from "./DotProduct";
 import { Average } from "./Average";
 import { CopySchema } from "./CopySchema";
 import { CombineCases } from "./CombineCases";
+import { Partition } from "./Partition";
 
 interface PolymorphicComponentProps {
   transformation?: SavedTransformation;
@@ -224,6 +225,14 @@ export const PolymorphicComponent = ({
     case "Combine Cases":
       return (
         <CombineCases
+          setErrMsg={setErrMsg}
+          saveData={transformation.content.data}
+          errorDisplay={errorDisplay}
+        />
+      );
+    case "Partition":
+      return (
+        <Partition
           setErrMsg={setErrMsg}
           saveData={transformation.content.data}
           errorDisplay={errorDisplay}

--- a/src/transformation-components/types.ts
+++ b/src/transformation-components/types.ts
@@ -18,6 +18,7 @@ import { TransformColumnSaveData } from "./TransformColumn";
 import { DotProductSaveData } from "./DotProduct";
 import { AverageSaveData } from "./Average";
 import { CombineCasesSaveData } from "./CombineCases";
+import { PartitionSaveData } from "./Partition";
 
 /**
  * The content associated with a saved transformation. Includes the base
@@ -116,6 +117,10 @@ export type SavedTransformationContent =
   | {
       base: "Combine Cases";
       data?: CombineCasesSaveData;
+    }
+  | {
+      base: "Partition";
+      data?: PartitionSaveData;
     };
 
 /**

--- a/src/transformations/partition.ts
+++ b/src/transformations/partition.ts
@@ -1,0 +1,56 @@
+import { DataSet } from "./types";
+
+/**
+ * Contains a dataset as a result of a partition, and the distinct
+ * value that all records of the dataset contain for the attribute
+ * by which partitioning was performed.
+ */
+export interface PartitionDataset {
+  dataset: DataSet;
+  distinctValue: string;
+}
+
+/**
+ * Breaks a dataset into multiple datasets, each which contain all
+ * cases with a given distinct value of the indicated attribute.
+ */
+export function partition(
+  dataset: DataSet,
+  attribute: string
+): PartitionDataset[] {
+  // map from distinct values of an attribute to all records sharing that value
+  const partitioned: Record<string, Record<string, unknown>[]> = {};
+
+  const records = dataset.records.slice();
+  for (const record of records) {
+    if (record[attribute] === undefined) {
+      throw new Error(`Invalid attribute: ${attribute}`);
+    }
+
+    // convert CODAP value to string to use as a key
+    const valueAsStr = JSON.stringify(record[attribute]);
+
+    // initialize this category if needed
+    if (partitioned[valueAsStr] === undefined) {
+      partitioned[valueAsStr] = [];
+    }
+
+    // add the record to its corresponding category of records
+    partitioned[valueAsStr].push(record);
+  }
+
+  const results = [];
+  for (const value in partitioned) {
+    // construct new dataset with same collections but only
+    // records that correspond to this value of the attribute
+    results.push({
+      dataset: {
+        collections: dataset.collections.slice(),
+        records: partitioned[value],
+      },
+      distinctValue: value,
+    });
+  }
+
+  return results;
+}

--- a/src/transformations/partition.ts
+++ b/src/transformations/partition.ts
@@ -7,7 +7,8 @@ import { DataSet } from "./types";
  */
 export interface PartitionDataset {
   dataset: DataSet;
-  distinctValue: string;
+  distinctValue: unknown;
+  distinctValueAsStr: string;
 }
 
 /**
@@ -19,7 +20,7 @@ export function partition(
   attribute: string
 ): PartitionDataset[] {
   // map from distinct values of an attribute to all records sharing that value
-  const partitioned: Record<string, Record<string, unknown>[]> = {};
+  const partitioned: Record<string, [unknown, Record<string, unknown>[]]> = {};
 
   const records = dataset.records.slice();
   for (const record of records) {
@@ -32,23 +33,24 @@ export function partition(
 
     // initialize this category if needed
     if (partitioned[valueAsStr] === undefined) {
-      partitioned[valueAsStr] = [];
+      partitioned[valueAsStr] = [record[attribute], []];
     }
 
     // add the record to its corresponding category of records
-    partitioned[valueAsStr].push(record);
+    partitioned[valueAsStr][1].push(record);
   }
 
   const results = [];
-  for (const value in partitioned) {
+  for (const [valueStr, [value, records]] of Object.entries(partitioned)) {
     // construct new dataset with same collections but only
     // records that correspond to this value of the attribute
     results.push({
       dataset: {
         collections: dataset.collections.slice(),
-        records: partitioned[value],
+        records,
       },
       distinctValue: value,
+      distinctValueAsStr: valueStr,
     });
   }
 

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -383,6 +383,24 @@ export function getDataContext(contextName: string): Promise<DataContext> {
   );
 }
 
+export async function deleteDataContext(contextName: string): Promise<void> {
+  return new Promise<void>((resolve, reject) =>
+    phone.call(
+      {
+        action: CodapActions.Delete,
+        resource: resourceFromContext(contextName),
+      },
+      (response) => {
+        if (response.success) {
+          resolve();
+        } else {
+          reject(new Error("Failed to delete data context"));
+        }
+      }
+    )
+  );
+}
+
 // Copies a list of attributes, only copying the fields relevant to our
 // representation of attributes and omitting any extra fields (cid, etc).
 function copyAttrs(


### PR DESCRIPTION
This adds a partition transformation, which generates separate datasets for all distinct values of a given attribute in an input dataset.

![partition](https://user-images.githubusercontent.com/13399527/121580772-21719c00-c9fb-11eb-9485-b038f479a145.png)

Updates currently work by maintaining which contexts currently exist as a result of the partition, and then updating existing contexts, adding new ones for new distinct values, and deleting contexts that no longer appear in the partition output.