### PR TITLE
Add generic fold

### DIFF
--- a/src/Transformation.tsx
+++ b/src/Transformation.tsx
@@ -51,6 +51,7 @@ function Transformation({
       "Running Min",
       "Running Max",
       "Running Difference",
+      "Reduce",
     ],
     "Copy Transformations": ["Copy", "Copy Schema"],
     Others: [
@@ -75,6 +76,7 @@ function Transformation({
     { name: "Running Min", content: { base: "Running Min" } },
     { name: "Running Max", content: { base: "Running Max" } },
     { name: "Running Difference", content: { base: "Running Difference" } },
+    { name: "Reduce", content: { base: "Reduce" } },
     { name: "Group By", content: { base: "Group By" } },
     { name: "Pivot Longer", content: { base: "Pivot Longer" } },
     { name: "Pivot Wider", content: { base: "Pivot Wider" } },

--- a/src/transformation-components/GenericFold.tsx
+++ b/src/transformation-components/GenericFold.tsx
@@ -40,9 +40,8 @@ export function GenericFold({
   >(saveData !== undefined ? saveData.outputAttributeName : "", () =>
     setErrMsg(null)
   );
-  const [base, baseChange] = useInput<string, HTMLInputElement>(
-    saveData !== undefined ? saveData.base : "",
-    () => setErrMsg(null)
+  const [base, baseChange] = useState<string>(
+    saveData !== undefined ? saveData.base : ""
   );
   const [expression, expressionChange] = useState<string>(
     saveData !== undefined ? saveData.expression : ""
@@ -124,7 +123,7 @@ export function GenericFold({
       />
 
       <h3>Starting Value</h3>
-      <CodapFlowTextInput
+      <ExpressionEditor
         value={base}
         onChange={baseChange}
         disabled={saveData !== undefined}

--- a/src/transformation-components/GenericFold.tsx
+++ b/src/transformation-components/GenericFold.tsx
@@ -1,0 +1,183 @@
+import React, { useCallback, ReactElement, useState } from "react";
+import { getContextAndDataSet } from "../utils/codapPhone";
+import { useInput, useAttributes } from "../utils/hooks";
+import { TransformationProps } from "./types";
+import { DataSet } from "../transformations/types";
+import {
+  TransformationSubmitButtons,
+  ContextSelector,
+  AttributeSelector,
+  CodapFlowTextInput,
+  ExpressionEditor,
+} from "../ui-components";
+import { applyNewDataSet, readableName, addUpdateListener } from "./util";
+import { genericFold } from "../transformations/fold";
+import TransformationSaveButton from "../ui-components/TransformationSaveButton";
+
+export interface GenericFoldSaveData {
+  inputAttributeName: string | null;
+  outputAttributeName: string;
+  expression: string;
+  base: string;
+  accumulatorName: string;
+}
+
+interface GenericFoldProps extends TransformationProps {
+  saveData?: GenericFoldSaveData;
+}
+
+export function GenericFold({
+  setErrMsg,
+  saveData,
+  errorDisplay,
+}: GenericFoldProps): ReactElement {
+  const [inputDataCtxt, inputChange] = useInput<
+    string | null,
+    HTMLSelectElement
+  >(null, () => setErrMsg(null));
+
+  const [inputAttributeName, inputAttributeNameChange] = useState<
+    string | null
+  >(saveData !== undefined ? saveData.inputAttributeName : null);
+  const [outputAttributeName, outputAttributeNameChange] = useInput<
+    string,
+    HTMLInputElement
+  >(saveData !== undefined ? saveData.outputAttributeName : "", () =>
+    setErrMsg(null)
+  );
+  const [base, baseChange] = useInput<string, HTMLInputElement>(
+    saveData !== undefined ? saveData.base : "",
+    () => setErrMsg(null)
+  );
+  const [expression, expressionChange] = useState<string>(
+    saveData !== undefined ? saveData.expression : ""
+  );
+  const [accumulatorName, accumulatorNameChange] = useInput<
+    string,
+    HTMLInputElement
+  >(saveData !== undefined ? saveData.accumulatorName : "", () =>
+    setErrMsg(null)
+  );
+
+  const attributes = useAttributes(inputDataCtxt);
+
+  const transform = useCallback(async () => {
+    setErrMsg(null);
+
+    if (inputDataCtxt === null) {
+      setErrMsg("Please choose a valid dataset to transform.");
+      return;
+    }
+    if (inputAttributeName === null) {
+      setErrMsg("Please select an attribute to aggregate");
+      return;
+    }
+    if (outputAttributeName === "") {
+      setErrMsg("Please enter a name for the new attribute");
+      return;
+    }
+    if (expression === "") {
+      setErrMsg("Please enter an expression");
+      return;
+    }
+    if (base === "") {
+      setErrMsg("Please enter a base value");
+      return;
+    }
+    if (accumulatorName === "") {
+      setErrMsg("Please enter an accumulator name");
+      return;
+    }
+
+    const doTransform: () => Promise<[DataSet, string]> = async () => {
+      const { context, dataset } = await getContextAndDataSet(inputDataCtxt);
+      const resultDescription = `A reduce of the values from the ${inputAttributeName} attribute in the ${readableName(
+        context
+      )} table.`;
+      const result = await genericFold(
+        dataset,
+        base,
+        expression,
+        inputAttributeName,
+        outputAttributeName,
+        accumulatorName,
+        resultDescription
+      );
+      return [result, `Reduce of ${readableName(context)}`];
+    };
+
+    try {
+      const newContextName = await applyNewDataSet(...(await doTransform()));
+      addUpdateListener(inputDataCtxt, newContextName, doTransform, setErrMsg);
+    } catch (e) {
+      setErrMsg(e.message);
+    }
+  }, [
+    inputDataCtxt,
+    inputAttributeName,
+    outputAttributeName,
+    expression,
+    accumulatorName,
+    base,
+    setErrMsg,
+  ]);
+
+  return (
+    <>
+      <h3>Table to reduce</h3>
+      <ContextSelector onChange={inputChange} value={inputDataCtxt} />
+
+      <h3>Attribute to Aggregate</h3>
+      <AttributeSelector
+        onChange={inputAttributeNameChange}
+        value={inputAttributeName}
+        context={inputDataCtxt}
+        disabled={saveData !== undefined}
+      />
+
+      <h3>Result Attribute Name</h3>
+      <CodapFlowTextInput
+        value={outputAttributeName}
+        onChange={outputAttributeNameChange}
+        disabled={saveData !== undefined}
+      />
+
+      <h3>Starting Value</h3>
+      <CodapFlowTextInput
+        value={base}
+        onChange={baseChange}
+        disabled={saveData !== undefined}
+      />
+
+      <h3>Accumulator Name</h3>
+      <CodapFlowTextInput
+        value={accumulatorName}
+        onChange={accumulatorNameChange}
+        disabled={saveData !== undefined}
+      />
+
+      <h3>Formula for Next Accumulator</h3>
+      <ExpressionEditor
+        value={expression}
+        onChange={expressionChange}
+        disabled={saveData !== undefined}
+        attributeNames={[...attributes.map((a) => a.name), accumulatorName]}
+      />
+
+      <br />
+      <TransformationSubmitButtons onCreate={transform} />
+      {errorDisplay}
+      {saveData === undefined && (
+        <TransformationSaveButton
+          generateSaveData={() => ({
+            inputAttributeName,
+            outputAttributeName,
+            expression,
+            base,
+            accumulatorName,
+          })}
+        />
+      )}
+    </>
+  );
+}

--- a/src/transformation-components/GenericFold.tsx
+++ b/src/transformation-components/GenericFold.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, ReactElement, useState } from "react";
 import { getContextAndDataSet } from "../utils/codapPhone";
-import { useInput, useAttributes } from "../utils/hooks";
+import { useInput } from "../utils/hooks";
 import { TransformationProps } from "./types";
 import { DataSet } from "../transformations/types";
 import {
@@ -58,8 +58,6 @@ export function GenericFold({
   >(saveData !== undefined ? saveData.accumulatorName : "", () =>
     setErrMsg(null)
   );
-
-  const attributes = useAttributes(inputDataCtxt);
 
   const transform = useCallback(async () => {
     setErrMsg(null);
@@ -161,7 +159,11 @@ export function GenericFold({
         value={expression}
         onChange={expressionChange}
         disabled={saveData !== undefined}
-        attributeNames={[...attributes.map((a) => a.name), accumulatorName]}
+        attributeNames={
+          inputAttributeName !== null
+            ? [inputAttributeName, accumulatorName]
+            : [accumulatorName]
+        }
       />
 
       <br />

--- a/src/transformation-components/PolymorphicComponent.tsx
+++ b/src/transformation-components/PolymorphicComponent.tsx
@@ -25,6 +25,7 @@ import { DotProduct } from "./DotProduct";
 import { Average } from "./Average";
 import { CopySchema } from "./CopySchema";
 import { CombineCases } from "./CombineCases";
+import { GenericFold } from "./GenericFold";
 
 interface PolymorphicComponentProps {
   transformation?: SavedTransformation;
@@ -224,6 +225,14 @@ export const PolymorphicComponent = ({
     case "Combine Cases":
       return (
         <CombineCases
+          setErrMsg={setErrMsg}
+          saveData={transformation.content.data}
+          errorDisplay={errorDisplay}
+        />
+      );
+    case "Reduce":
+      return (
+        <GenericFold
           setErrMsg={setErrMsg}
           saveData={transformation.content.data}
           errorDisplay={errorDisplay}

--- a/src/transformation-components/types.ts
+++ b/src/transformation-components/types.ts
@@ -18,6 +18,7 @@ import { TransformColumnSaveData } from "./TransformColumn";
 import { DotProductSaveData } from "./DotProduct";
 import { AverageSaveData } from "./Average";
 import { CombineCasesSaveData } from "./CombineCases";
+import { GenericFoldSaveData } from "./GenericFold";
 
 /**
  * The content associated with a saved transformation. Includes the base
@@ -116,6 +117,10 @@ export type SavedTransformationContent =
   | {
       base: "Combine Cases";
       data?: CombineCasesSaveData;
+    }
+  | {
+      base: "Reduce";
+      data?: GenericFoldSaveData;
     };
 
 /**

--- a/src/transformations/combineCases.ts
+++ b/src/transformations/combineCases.ts
@@ -1,6 +1,6 @@
 import { DataSet } from "./types";
 import { setEquality } from "../utils/sets";
-import { eraseFormulas } from "./util";
+import { eraseFormulas, allAttrNames } from "./util";
 
 /**
  * Stack combines a top and bottom table which have matching attributes
@@ -36,14 +36,4 @@ export function combineCases(base: DataSet, combining: DataSet): DataSet {
     collections: base.collections.slice(),
     records,
   };
-}
-
-/**
- * Extract all attribute names from the given dataset.
- */
-function allAttrNames(dataset: DataSet): string[] {
-  return dataset.collections
-    .map((coll) => coll.attrs || [])
-    .flat()
-    .map((attr) => attr.name);
 }

--- a/src/transformations/fold.ts
+++ b/src/transformations/fold.ts
@@ -50,14 +50,14 @@ function makeNumFold<T>(
 
 export async function genericFold(
   dataset: DataSet,
-  base: unknown,
+  base: string,
   expression: string,
   inputColumnName: string,
   resultColumnName: string,
   accumulatorName: string,
   resultColumnDescription = ""
 ): Promise<DataSet> {
-  let acc = base;
+  let acc: unknown = base;
   const resultRecords = [];
 
   for (const row of dataset.records) {
@@ -69,7 +69,7 @@ export async function genericFold(
     }
 
     environment[accumulatorName] = acc;
-    acc = await evalExpression(expression, [environment]);
+    acc = (await evalExpression(expression, [environment]))[0];
     resultRecords.push(insertInRow(row, resultColumnName, acc));
   }
 

--- a/src/transformations/fold.ts
+++ b/src/transformations/fold.ts
@@ -60,7 +60,7 @@ export async function genericFold(
   accumulatorName: string,
   resultColumnDescription = ""
 ): Promise<DataSet> {
-  let acc: unknown = base;
+  let acc = (await evalExpression(base, [{}]))[0];
   const resultRecords = [];
 
   for (const row of dataset.records) {

--- a/src/transformations/fold.ts
+++ b/src/transformations/fold.ts
@@ -3,8 +3,10 @@ import {
   insertColumnInLastCollection,
   insertInRow,
   codapValueToString,
+  allAttrNames,
 } from "./util";
 import { evalExpression } from "../utils/codapPhone";
+import { uniqueName } from "../utils/names";
 
 function makeNumFold<T>(
   foldName: string,
@@ -17,6 +19,7 @@ function makeNumFold<T>(
     resultColumnName: string,
     resultColumnDescription: string
   ): DataSet => {
+    resultColumnName = uniqueName(resultColumnName, allAttrNames(dataset));
     let acc = base;
 
     const resultRecords = dataset.records.map((row) => {
@@ -60,6 +63,8 @@ export async function genericFold(
   accumulatorName: string,
   resultColumnDescription = ""
 ): Promise<DataSet> {
+  resultColumnName = uniqueName(resultColumnName, allAttrNames(dataset));
+
   let acc = (await evalExpression(base, [{}]))[0];
   const resultRecords = [];
 
@@ -147,6 +152,7 @@ export function differenceFrom(
   resultColumnName: string,
   startingValue = 0
 ): DataSet {
+  resultColumnName = uniqueName(resultColumnName, allAttrNames(dataset));
   const resultRecords = dataset.records.map((row) => {
     if (row[inputColumnName] === undefined) {
       throw new Error(`Invalid attribute name: ${inputColumnName}`);

--- a/src/transformations/fold.ts
+++ b/src/transformations/fold.ts
@@ -56,7 +56,6 @@ export async function genericFold(
   dataset: DataSet,
   base: string,
   expression: string,
-  inputColumnName: string,
   resultColumnName: string,
   accumulatorName: string,
   resultColumnDescription = ""

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -198,3 +198,13 @@ export function codapValueToString(codapValue?: unknown): string {
   // value must be string
   return `"${codapValue}"`;
 }
+
+/**
+ * Extract all attribute names from the given dataset.
+ */
+export function allAttrNames(dataset: DataSet): string[] {
+  return dataset.collections
+    .map((coll) => coll.attrs || [])
+    .flat()
+    .map((attr) => attr.name);
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11802391/121595068-e7f55c80-ca0b-11eb-99e2-6a7c7f67690e.png)

Right now, we are having the user supply the name of the accumulator. If we always bind it to something like `acc`, then we might run into name conflicts if a column is also named `acc`. This avoids that but does add some complexity.

This "generic" version is also not very powerful. E.g., you can't write something like running average in it, because the expression language doesn't support tuples, so you can't accumulate multiple values that you can then use to calculate the output.