### PR TITLE
add support for removing listeners after context deletion

### DIFF
--- a/src/transformation-components/Partition.tsx
+++ b/src/transformation-components/Partition.tsx
@@ -75,31 +75,38 @@ export function Partition({
     try {
       const transformed = await doTransform();
       let valueToContext: Record<string, string> = {};
+      const outputContexts: string[] = [];
 
       for (const [partitioned, name] of transformed) {
         const newContextName = await applyNewDataSet(partitioned.dataset, name);
         valueToContext[partitioned.distinctValueAsStr] = newContextName;
+        outputContexts.push(newContextName);
       }
 
       // listen for updates to the input data context
-      addContextUpdateListener(inputDataCtxt, async () => {
+      addContextUpdateListener(inputDataCtxt, outputContexts, async () => {
         try {
           setErrMsg(null);
           const transformed = await doTransform();
           const newValueToContext: Record<string, string> = {};
+          while (outputContexts.length > 0) {
+            outputContexts.pop();
+          }
 
           for (const [partitioned, name] of transformed) {
             const contextName = valueToContext[partitioned.distinctValueAsStr];
             if (contextName === undefined) {
+              const newName = await applyNewDataSet(partitioned.dataset, name);
               // this is a new table (a new distinct value)
-              newValueToContext[partitioned.distinctValueAsStr] =
-                await applyNewDataSet(partitioned.dataset, name);
+              newValueToContext[partitioned.distinctValueAsStr] = newName;
+              outputContexts.push(newName);
             } else {
               // apply an update to a previous dataset
               updateContextWithDataSet(contextName, partitioned.dataset);
 
               // copy over existing context name into new valueToContext mapping
               newValueToContext[partitioned.distinctValueAsStr] = contextName;
+              outputContexts.push(contextName);
             }
           }
 

--- a/src/transformation-components/util.ts
+++ b/src/transformation-components/util.ts
@@ -62,7 +62,7 @@ export function addUpdateListener(
   doTransform: () => Promise<[DataSet, string]>,
   setErrMsg: (msg: string | null) => void
 ): void {
-  addContextUpdateListener(inputContext, async () => {
+  addContextUpdateListener(inputContext, [outputContext], async () => {
     setErrMsg(null);
     try {
       const [transformed] = await doTransform();
@@ -79,7 +79,7 @@ export function addUpdateTextListener(
   doTransform: () => Promise<[number, string]>,
   setErrMsg: (msg: string) => void
 ): void {
-  addContextUpdateListener(inputContext, async () => {
+  addContextUpdateListener(inputContext, [textName], async () => {
     try {
       const [result] = await doTransform();
       updateText(textName, String(result));

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -117,6 +117,7 @@ function codapRequestHandler(
     return;
   }
 
+  // notification of which data context was deleted
   if (
     command.resource === CodapInitiatedResource.DocumentChangeNotice &&
     command.values.operation === DocumentChangeOperations.DataContextDeleted
@@ -127,6 +128,7 @@ function codapRequestHandler(
     return;
   }
 
+  // data context was added/deleted
   if (
     command.resource === CodapInitiatedResource.DocumentChangeNotice &&
     command.values.operation ===

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -29,6 +29,8 @@ import {
 import {
   callUpdateListenersForContext,
   callAllContextListeners,
+  removeContextUpdateListenersForContext,
+  removeListenersWithDependency,
 } from "./listeners";
 import { DataSet } from "../../transformations/types";
 import { CodapEvalError } from "./error";
@@ -155,6 +157,16 @@ function codapRequestHandler(
   console.groupEnd();
 
   if (command.action !== CodapActions.Notify) {
+    callback({ success: true });
+    return;
+  }
+
+  if (
+    command.resource === CodapInitiatedResource.DocumentChangeNotice &&
+    command.values.operation === DocumentChangeOperations.DataContextDeleted
+  ) {
+    removeContextUpdateListenersForContext(command.values.deletedContext);
+    removeListenersWithDependency(command.values.deletedContext);
     callback({ success: true });
     return;
   }

--- a/src/utils/codapPhone/listeners.ts
+++ b/src/utils/codapPhone/listeners.ts
@@ -18,16 +18,25 @@ export function callAllContextListeners(): void {
 
 // Listen for data context updates
 
-export const contextUpdateListeners: Record<string, Array<() => void>> = {};
+/**
+ * This maps context names to a list of [dependencies, listener] pairs.
+ * The dependencies indicate which other entities are required to be valid
+ * for the listener to be successfully called.
+ */
+export const contextUpdateListeners: Record<
+  string,
+  Array<[string[], () => void]>
+> = {};
 
 export function addContextUpdateListener(
   context: string,
+  dependencies: string[],
   listener: () => void
 ): void {
   if (contextUpdateListeners[context] === undefined) {
     contextUpdateListeners[context] = [];
   }
-  contextUpdateListeners[context].push(listener);
+  contextUpdateListeners[context].push([dependencies, listener]);
 }
 
 export function removeContextUpdateListener(
@@ -36,13 +45,36 @@ export function removeContextUpdateListener(
 ): void {
   if (contextUpdateListeners[context] !== undefined) {
     contextUpdateListeners[context] = contextUpdateListeners[context].filter(
-      (f) => f !== listener
+      ([, f]) => f !== listener
     );
   }
 }
 
+export function removeContextUpdateListenersForContext(context: string): void {
+  delete contextUpdateListeners[context];
+  console.log(
+    `Just removed all update listeners for ${context}: now ${contextUpdateListeners[context]}`
+  );
+}
+
+export function removeListenersWithDependency(dep: string): void {
+  console.log(`Removing update listeners that have a dependency on ${dep}`);
+  for (const [context, values] of Object.entries(contextUpdateListeners)) {
+    const keep: [string[], () => void][] = [];
+    for (const [dependencies, listener] of values) {
+      if (!dependencies.includes(dep)) {
+        keep.push([dependencies, listener]);
+      }
+    }
+    contextUpdateListeners[context] = keep;
+  }
+}
+
 export function callUpdateListenersForContext(context: string): void {
+  console.log(
+    `Calling update listeners for ${context}: ${contextUpdateListeners[context]}`
+  );
   if (contextUpdateListeners[context] !== undefined) {
-    contextUpdateListeners[context].forEach((f) => f());
+    contextUpdateListeners[context].forEach(([, f]) => f());
   }
 }

--- a/src/utils/codapPhone/listeners.ts
+++ b/src/utils/codapPhone/listeners.ts
@@ -52,13 +52,9 @@ export function removeContextUpdateListener(
 
 export function removeContextUpdateListenersForContext(context: string): void {
   delete contextUpdateListeners[context];
-  console.log(
-    `Just removed all update listeners for ${context}: now ${contextUpdateListeners[context]}`
-  );
 }
 
 export function removeListenersWithDependency(dep: string): void {
-  console.log(`Removing update listeners that have a dependency on ${dep}`);
   for (const [context, values] of Object.entries(contextUpdateListeners)) {
     const keep: [string[], () => void][] = [];
     for (const [dependencies, listener] of values) {
@@ -71,9 +67,6 @@ export function removeListenersWithDependency(dep: string): void {
 }
 
 export function callUpdateListenersForContext(context: string): void {
-  console.log(
-    `Calling update listeners for ${context}: ${contextUpdateListeners[context]}`
-  );
   if (contextUpdateListeners[context] !== undefined) {
     contextUpdateListeners[context].forEach(([, f]) => f());
   }

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -243,6 +243,7 @@ export const mutatingOperations = [
 
 export enum DocumentChangeOperations {
   DataContextCountChanged = "dataContextCountChanged",
+  DataContextDeleted = "dataContextDeleted",
 }
 
 export type CodapInitiatedCommand =
@@ -263,7 +264,15 @@ export type CodapInitiatedCommand =
       action: CodapActions.Notify;
       resource: CodapInitiatedResource.DocumentChangeNotice;
       values: {
-        operation: DocumentChangeOperations;
+        operation: DocumentChangeOperations.DataContextCountChanged;
+      };
+    }
+  | {
+      action: CodapActions.Notify;
+      resource: CodapInitiatedResource.DocumentChangeNotice;
+      values: {
+        operation: DocumentChangeOperations.DataContextDeleted;
+        deletedContext: string;
       };
     }
   | {

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -58,7 +58,7 @@ export function useAttributes(context: string | null): CodapIdentifyingInfo[] {
         refreshAttributes(context);
       };
       refreshAttributes(context);
-      addContextUpdateListener(context, updateFunc);
+      addContextUpdateListener(context, [], updateFunc);
       return () => removeContextUpdateListener(context, updateFunc);
     }
   }, [context]);
@@ -98,7 +98,7 @@ export function useContextUpdateListener(
   callback: () => void
 ): void {
   useEffect(() => {
-    addContextUpdateListener(contextName, callback);
+    addContextUpdateListener(contextName, [], callback);
     return () => removeContextUpdateListener(contextName, callback);
   }, [contextName, callback]);
 }


### PR DESCRIPTION
This, together with the [CODAP-side patch](https://github.com/stardust66/codap/commit/73212082dd7c6eae8346b6d44ff16217f83c8c03) that adds notifications for deleted contexts, allows us to deactivate any listeners that rely on a context existing when it is destroyed.

I added a notion of "dependencies" to the map from context names to listeners. When listeners are added, you indicate an array of context (or other component) names that identify which contexts must still be valid for the listener to be able to run. When a context is deleted, we remove any listeners on it as well as listeners that depend on it.

This fixes #81.