### PR TITLE
Deep copy collections and attributes in transformations

### DIFF
--- a/src/transformations/buildColumn.ts
+++ b/src/transformations/buildColumn.ts
@@ -1,6 +1,6 @@
 import { CodapLanguageType, DataSet } from "./types";
 import { evalExpression } from "../utils/codapPhone/index";
-import { findTypeErrors, reportTypeErrorsForRecords } from "./util";
+import { reportTypeErrorsForRecords, cloneCollection } from "./util";
 
 /**
  * Builds a dataset with a new attribute added to one of the collections,
@@ -14,7 +14,7 @@ export async function buildColumn(
   outputType: CodapLanguageType
 ): Promise<DataSet> {
   // find collection to add attribute to
-  const collections = dataset.collections.slice();
+  const collections = dataset.collections.map(cloneCollection);
   const toAdd = collections.find((coll) => coll.name === collectionName);
 
   if (toAdd === undefined) {
@@ -40,15 +40,16 @@ export async function buildColumn(
     description: `An attribute whose values were computed with the formula ${expression}`,
   });
 
-  const records = dataset.records.slice();
-  const colValues = await evalExpression(expression, records);
+  const colValues = await evalExpression(expression, dataset.records);
 
   // Check for type errors (might throw error and abort transformation)
-  reportTypeErrorsForRecords(records, colValues, outputType);
+  reportTypeErrorsForRecords(dataset.records, colValues, outputType);
 
   // add values for new attribute to all records
-  colValues.forEach((value, i) => {
-    records[i][newAttributeName] = value;
+  const records = dataset.records.map((record, i) => {
+    const recordCopy = { ...record };
+    recordCopy[newAttributeName] = colValues[i];
+    return recordCopy;
   });
 
   return {

--- a/src/transformations/combineCases.ts
+++ b/src/transformations/combineCases.ts
@@ -1,6 +1,6 @@
 import { DataSet } from "./types";
 import { setEquality } from "../utils/sets";
-import { eraseFormulas, allAttrNames } from "./util";
+import { eraseFormulas, allAttrNames, cloneCollection } from "./util";
 
 /**
  * Stack combines a top and bottom table which have matching attributes
@@ -28,12 +28,12 @@ export function combineCases(base: DataSet, combining: DataSet): DataSet {
 
   // NOTE: do not preserve base table's formulas. It is possible the combining
   // table's values get clobbered by a formula.
-  const collections = base.collections.slice();
+  const collections = base.collections.map(cloneCollection);
   collections.forEach((coll) => eraseFormulas(coll.attrs || []));
 
   // same schema as base, with combined records
   return {
-    collections: base.collections.slice(),
+    collections,
     records,
   };
 }

--- a/src/transformations/copy.ts
+++ b/src/transformations/copy.ts
@@ -5,7 +5,7 @@ import { DataSet } from "./types";
  */
 export function copy(dataset: DataSet): DataSet {
   return {
-    collections: dataset.collections.slice(),
-    records: dataset.records.slice(),
+    collections: dataset.collections,
+    records: dataset.records,
   };
 }

--- a/src/transformations/copySchema.ts
+++ b/src/transformations/copySchema.ts
@@ -6,7 +6,7 @@ import { DataSet } from "./types";
  */
 export function copySchema(dataset: DataSet): DataSet {
   return {
-    collections: dataset.collections.slice(),
+    collections: dataset.collections,
     records: [],
   };
 }

--- a/src/transformations/count.ts
+++ b/src/transformations/count.ts
@@ -1,6 +1,6 @@
 import { DataSet } from "./types";
 import { CodapAttribute, Collection } from "../utils/codapPhone/types";
-import { eraseFormulas } from "./util";
+import { eraseFormulas, shallowCopy } from "./util";
 import { uniqueName } from "../utils/names";
 
 // TODO: allow for two modes:
@@ -31,7 +31,9 @@ export function count(dataset: DataSet, attributes: string[]): DataSet {
   let countedAttrs: CodapAttribute[] = [];
   for (const coll of dataset.collections) {
     countedAttrs = countedAttrs.concat(
-      coll.attrs?.filter((attr) => attributes.includes(attr.name)).slice() || []
+      coll.attrs
+        ?.filter((attr) => attributes.includes(attr.name))
+        .map(shallowCopy) || []
     );
   }
   eraseFormulas(countedAttrs);

--- a/src/transformations/filter.ts
+++ b/src/transformations/filter.ts
@@ -31,7 +31,7 @@ export async function filter(
 
   return new Promise((resolve) =>
     resolve({
-      collections: dataset.collections.slice(),
+      collections: dataset.collections,
       records: filteredRecords,
     })
   );

--- a/src/transformations/flatten.ts
+++ b/src/transformations/flatten.ts
@@ -8,7 +8,7 @@ import { DataSet } from "./types";
 export function flatten(dataset: DataSet): DataSet {
   // flatten attributes of all collections into single list of attributes
   const attrs = dataset.collections
-    .map((collection) => collection.attrs?.slice() || [])
+    .map((collection) => collection.attrs || [])
     .flat();
 
   // create combined name for collection
@@ -24,6 +24,6 @@ export function flatten(dataset: DataSet): DataSet {
   // dataset with same records but single collection
   return {
     collections: [collection],
-    records: dataset.records.slice(),
+    records: dataset.records,
   };
 }

--- a/src/transformations/groupBy.ts
+++ b/src/transformations/groupBy.ts
@@ -1,6 +1,6 @@
 import { DataSet } from "./types";
 import { CodapAttribute, Collection } from "../utils/codapPhone/types";
-import { reparent } from "./util";
+import { reparent, cloneCollection, shallowCopy } from "./util";
 
 // TODO: add option for "collapse other groupings" which will
 // not only group by the indicated attributes, but ensure that
@@ -26,7 +26,7 @@ export function groupBy(
   newParentName: string
 ): DataSet {
   const groupedAttrs: CodapAttribute[] = [];
-  let collections = dataset.collections.slice();
+  let collections = dataset.collections.map(cloneCollection);
 
   // extract attributes from collections into a list
   attrLoop: for (const attrName of attrNames) {
@@ -80,7 +80,7 @@ export function groupBy(
     labels: {},
   };
 
-  const records = dataset.records.slice();
+  const records = dataset.records.map(shallowCopy);
   for (const record of records) {
     for (const attrName of attrNames) {
       // make copy of record data from original attr into grouped attr

--- a/src/transformations/join.ts
+++ b/src/transformations/join.ts
@@ -1,6 +1,7 @@
 import { CodapAttribute, Collection } from "../utils/codapPhone/types";
 import { DataSet } from "./types";
 import { uniqueName } from "../utils/names";
+import { shallowCopy, cloneCollection, cloneAttribute } from "./util";
 
 /**
  * Joins two datasets together, using the baseDataset as a starting point
@@ -31,10 +32,10 @@ export function join(
     throw new Error(`Invalid joining attribute: ${joiningAttr}`);
   }
 
-  const addedAttrs = joiningCollection.attrs.slice();
+  const addedAttrs = joiningCollection.attrs.map(cloneAttribute);
   const addedAttrOriginalNames = addedAttrs.map((attr) => attr.name);
 
-  const collections = baseDataset.collections.slice();
+  const collections = baseDataset.collections.map(cloneCollection);
   const baseCollection = findCollectionWithAttr(collections, baseAttr);
   if (baseCollection === undefined || baseCollection.attrs === undefined) {
     throw new Error(`Invalid base attribute: ${baseAttr}`);
@@ -59,7 +60,7 @@ export function join(
   baseCollection.attrs = baseCollection.attrs.concat(addedAttrs);
 
   // start with a copy of the base dataset's records
-  const records = baseDataset.records.slice();
+  const records = baseDataset.records.map(shallowCopy);
 
   // copy into the joined table the first matching record from
   // joiningDataset for each record from baseDataset.

--- a/src/transformations/partition.ts
+++ b/src/transformations/partition.ts
@@ -22,7 +22,7 @@ export function partition(
   // map from distinct values of an attribute to all records sharing that value
   const partitioned: Record<string, [unknown, Record<string, unknown>[]]> = {};
 
-  const records = dataset.records.slice();
+  const records = dataset.records;
   for (const record of records) {
     if (record[attribute] === undefined) {
       throw new Error(`Invalid attribute: ${attribute}`);
@@ -46,7 +46,7 @@ export function partition(
     // records that correspond to this value of the attribute
     results.push({
       dataset: {
-        collections: dataset.collections.slice(),
+        collections: dataset.collections,
         records,
       },
       distinctValue: value,

--- a/src/transformations/selectAttributes.ts
+++ b/src/transformations/selectAttributes.ts
@@ -1,5 +1,5 @@
 import { DataSet } from "./types";
-import { reparent, eraseFormulas } from "./util";
+import { reparent, eraseFormulas, cloneCollection } from "./util";
 
 /**
  * Constructs a dataset with only the indicated attributes from the
@@ -41,7 +41,7 @@ export function selectAttributes(
   }
 
   // copy collections
-  const allCollections = dataset.collections.slice();
+  const allCollections = dataset.collections.map(cloneCollection);
   const collections = [];
 
   // filter out any attributes that aren't in the selected list

--- a/src/transformations/sort.ts
+++ b/src/transformations/sort.ts
@@ -57,7 +57,7 @@ export async function sort(
   outputType: CodapLanguageType,
   sortDirection: SortDirection
 ): Promise<DataSet> {
-  const records = dataset.records.slice();
+  const records = dataset.records;
   const keyValues = await evalExpression(keyExpr, records);
 
   // Check for type errors (might throw error and abort transformation)
@@ -76,7 +76,7 @@ export async function sort(
 
   return new Promise((resolve) =>
     resolve({
-      collections: dataset.collections.slice(),
+      collections: dataset.collections,
       records: sorted,
     })
   );

--- a/src/transformations/transformColumn.ts
+++ b/src/transformations/transformColumn.ts
@@ -1,6 +1,10 @@
 import { CodapLanguageType, DataSet } from "./types";
 import { evalExpression } from "../utils/codapPhone";
-import { reportTypeErrorsForRecords } from "./util";
+import {
+  reportTypeErrorsForRecords,
+  cloneCollection,
+  shallowCopy,
+} from "./util";
 
 /**
  * Produces a dataset with the indicated attribute's values transformed
@@ -13,7 +17,7 @@ export async function transformColumn(
   expression: string,
   outputType: CodapLanguageType
 ): Promise<DataSet> {
-  const records = dataset.records.slice();
+  const records = dataset.records.map(shallowCopy);
   const exprValues = await evalExpression(expression, records);
 
   // Check for type errors (might throw error and abort transformation)
@@ -29,7 +33,7 @@ export async function transformColumn(
     record[attributeName] = value;
   });
 
-  const collections = dataset.collections.slice();
+  const collections = dataset.collections.map(cloneCollection);
   for (const coll of collections) {
     const attr = coll.attrs?.find((attr) => attr.name === attributeName);
 

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -84,7 +84,7 @@ export function insertColumnInLastCollection(
   collections: Collection[],
   attr: CodapAttribute
 ): Collection[] {
-  const newCollections = collections.slice();
+  const newCollections = collections.map(cloneCollection);
   const lastCollection = newCollections[newCollections.length - 1];
   newCollections[newCollections.length - 1] = insertColumn(
     lastCollection,
@@ -377,3 +377,16 @@ function findTypeErrorsBoolean(values: unknown[]): number | null {
 
   return null;
 }
+
+export function cloneCollection(c: Collection): Collection {
+  return {
+    ...c,
+    attrs: c.attrs?.map(shallowCopy),
+  };
+}
+
+export function shallowCopy<T>(x: T): T {
+  return { ...x };
+}
+
+export const cloneAttribute = shallowCopy;


### PR DESCRIPTION
Since `array.slice()` only shallow copies the array, we are actually mutating records and collections in some of our transformations, which interacts badly with caching. This PR replaces all slices with actual copies. In the case that we don't mutate the objects, the slices have been removed, since they are misleading.