### PR TITLE
better errors for boundary objects

### DIFF
--- a/src/transformations/pivot.ts
+++ b/src/transformations/pivot.ts
@@ -1,5 +1,5 @@
 import { DataSet } from "./types";
-import { eraseFormulas, codapValueToString } from "./util";
+import { eraseFormulas, codapValueToString, isBoundary } from "./util";
 
 /**
  * Turns selected attribute names into values of a new attribute, reorganizing
@@ -105,9 +105,14 @@ export function pivotWider(
             `Invalid attribute to retrieve names from: ${namesFrom}`
           );
         }
+        if (isBoundary(rec[namesFrom])) {
+          throw new Error(
+            `Cannot use boundaries (from attribute ${namesFrom}) as attribute names`
+          );
+        }
         if (typeof rec[namesFrom] === "object") {
           throw new Error(
-            `Cannot use object values (${namesFrom}) as attribute names`
+            `Cannot use object values (from attribute ${namesFrom}) as attribute names`
           );
         }
 

--- a/src/transformations/pivot.ts
+++ b/src/transformations/pivot.ts
@@ -1,5 +1,5 @@
 import { DataSet } from "./types";
-import { eraseFormulas, codapValueToString, isBoundary } from "./util";
+import { eraseFormulas, codapValueToString } from "./util";
 
 /**
  * Turns selected attribute names into values of a new attribute, reorganizing
@@ -99,20 +99,19 @@ export function pivotWider(
   // get list of names to make attributes for
   const newAttrs = Array.from(
     new Set(
-      dataset.records.map((rec) => {
+      dataset.records.map((rec, i) => {
         if (rec[namesFrom] === undefined) {
           throw new Error(
             `Invalid attribute to retrieve names from: ${namesFrom}`
           );
         }
-        if (isBoundary(rec[namesFrom])) {
-          throw new Error(
-            `Cannot use boundaries (from attribute ${namesFrom}) as attribute names`
-          );
-        }
         if (typeof rec[namesFrom] === "object") {
           throw new Error(
-            `Cannot use object values (from attribute ${namesFrom}) as attribute names`
+            `Cannot use ${codapValueToString(
+              rec[namesFrom]
+            )} (from attribute ${namesFrom} at case ${
+              i + 1
+            }) as an attribute name`
           );
         }
 

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -196,6 +196,11 @@ export function codapValueToString(codapValue: unknown): string {
     return "a boundary";
   }
 
+  // boundary maps
+  if (isBoundaryMap(codapValue)) {
+    return "a boundary map";
+  }
+
   // objects
   if (typeof codapValue === "object") {
     return "an object";
@@ -203,6 +208,15 @@ export function codapValueToString(codapValue: unknown): string {
 
   // value must be string
   return `"${codapValue}"`;
+}
+
+/**
+ * Maps such as `US_county_boundaries` contain a `map` property that has
+ * names as keys and boundary objects as values. These are used to lookup
+ * boundaries for a particular name (ie state, province, etc)
+ */
+export function isBoundaryMap(value: unknown): boolean {
+  return typeof value === "object" && value != null && "map" in value;
 }
 
 /**

--- a/src/transformations/util.ts
+++ b/src/transformations/util.ts
@@ -170,7 +170,7 @@ export function getAttributeDataFromDataset(
  * @param codapValue the value to convert to a string for printing
  * @returns string version of the value
  */
-export function codapValueToString(codapValue?: unknown): string {
+export function codapValueToString(codapValue: unknown): string {
   // missing values
   if (codapValue === "") {
     return "a missing value";
@@ -191,6 +191,11 @@ export function codapValueToString(codapValue?: unknown): string {
     return String(codapValue);
   }
 
+  // boundaries
+  if (isBoundary(codapValue)) {
+    return "a boundary";
+  }
+
   // objects
   if (typeof codapValue === "object") {
     return "an object";
@@ -198,6 +203,15 @@ export function codapValueToString(codapValue?: unknown): string {
 
   // value must be string
   return `"${codapValue}"`;
+}
+
+/**
+ * Determines if a given CODAP value is a boundary object.
+ */
+export function isBoundary(value: unknown): boolean {
+  return (
+    typeof value === "object" && value !== null && "jsonBoundaryObject" in value
+  );
 }
 
 export function reportTypeErrorsForRecords(
@@ -287,7 +301,7 @@ function findTypeErrorsBoundary(values: unknown[]): number | null {
   for (let i = 0; i < values.length; i++) {
     const value = values[i];
 
-    if (typeof value === "object" && value && "jsonBoundaryObject" in value) {
+    if (isBoundary(value)) {
       // value is a boundary and we're all set
     } else {
       return i;

--- a/src/utils/prettyPrint.ts
+++ b/src/utils/prettyPrint.ts
@@ -1,3 +1,5 @@
+import { isBoundary, isBoundaryMap } from "../transformations/util";
+
 export function prettyPrintCase(record: Record<string, unknown>): string {
   const keyValuePairs = [];
 
@@ -7,9 +9,10 @@ export function prettyPrintCase(record: Record<string, unknown>): string {
     if (value === null) {
       keyValuePairs.push(`${key}: <missing>`);
     } else if (typeof value === "object") {
-      // @ts-expect-error - typescript erroneously raises a null error below
-      if ("jsonBoundaryObject" in value) {
+      if (isBoundary(value)) {
         keyValuePairs.push(`${key}: <boundary>`);
+      } else if (isBoundaryMap(value)) {
+        keyValuePairs.push(`${key}: <boundary map>`);
       } else {
         keyValuePairs.push(`${key}: <unknown object>`);
       }


### PR DESCRIPTION
This makes our CODAP value printer aware of boundary objects (by looking for the property `jsonBoundaryObject` within them) and fixes pivot wider to give a more specific error message when boundary objects are used as attribute names.

This does beg the question of how many ways objects can show up as CODAP values, and it does seem like it's limited to boundary objects and a few others. I did find that using just the identifier `US_county_boundaries` as a formula value, for instance, yields an object that has a map from county names as keys to boundary objects as values, so this may be another kind of object we want to be aware of.