### PR TITLE
Invalidate cache when attributes get moved

### DIFF
--- a/src/utils/codapPhone/cache.ts
+++ b/src/utils/codapPhone/cache.ts
@@ -1,8 +1,14 @@
 import { DataContext, ReturnedCase } from "./types";
+import { DefaultMap } from "./util";
 
 const contextCache = new Map<string, DataContext>();
 const recordsCache = new Map<string, Record<string, unknown>[]>();
 const caseCache = new Map<number, ReturnedCase>();
+
+// A map from context names to sets of case ids
+const caseContextLookup = new DefaultMap<string, Set<number>>(
+  () => new Set<number>()
+);
 
 export function getContext(contextName: string): DataContext | undefined {
   return contextCache.get(contextName);
@@ -29,7 +35,12 @@ export function setRecords(
   recordsCache.set(contextName, dataset);
 }
 
-export function setCase(id: number, caseData: ReturnedCase): void {
+export function setCase(
+  context: string,
+  id: number,
+  caseData: ReturnedCase
+): void {
+  caseContextLookup.get(context).add(id);
   caseCache.set(id, caseData);
 }
 
@@ -39,6 +50,11 @@ export function invalidateContext(contextName: string): void {
 }
 
 export function invalidateCase(id: number): void {
-  console.log(`Invalidating case ${id}`);
   caseCache.delete(id);
+}
+
+export function invalidateCasesInContext(context: string): void {
+  for (const id of caseContextLookup.get(context)) {
+    invalidateCase(id);
+  }
 }

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -174,6 +174,16 @@ function codapRequestHandler(
           caseIDs.map(Cache.invalidateCase);
         }
       }
+
+      // Invalidate all cases in a context if attributes get moved or deleted,
+      // etc. Cannot do this more granularly because attribute moves do not
+      // give enough information.
+      if (
+        value.operation === ContextChangeOperation.MoveAttribute ||
+        value.operation === ContextChangeOperation.DeleteAttribute
+      ) {
+        Cache.invalidateCasesInContext(contextName);
+      }
     }
 
     if (contextUpdate) {
@@ -248,7 +258,7 @@ function getCaseById(context: string, id: number): Promise<ReturnedCase> {
       (response: GetCaseResponse) => {
         if (response.success) {
           const result = response.values.case;
-          Cache.setCase(id, result);
+          Cache.setCase(context, id, result);
           resolve(result);
         } else {
           reject(new Error(`Failed to get case in ${context} with id ${id}`));

--- a/src/utils/codapPhone/util.ts
+++ b/src/utils/codapPhone/util.ts
@@ -146,3 +146,21 @@ function listEqual<T>(
 
   return true;
 }
+
+export class DefaultMap<K, V> extends Map<K, V> {
+  defaultValueFunc: () => V;
+
+  constructor(defaultValueFunc: () => V, entries?: Iterable<readonly [K, V]>) {
+    super(entries || []);
+    this.defaultValueFunc = defaultValueFunc;
+  }
+
+  get(key: K): V {
+    if (!this.has(key)) {
+      this.set(key, this.defaultValueFunc());
+    }
+
+    // Safe cast because we have already set the value above
+    return super.get(key) as V;
+  }
+}


### PR DESCRIPTION
Bug reported in messenger. Cases cache causes issues when attributes get moved, because that does not notify case updates for each individual case, so cached cases are not invalidated properly. This PR invalidates all cases in a context when attributes get moved or deleted.