### PR TITLE
Use existing DI creation endpoint

### DIFF
--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -497,10 +497,11 @@ export async function createDataInteractive(
     phone.call(
       {
         action: CodapActions.Create,
-        resource: CodapResource.InteractiveFrame,
+        resource: CodapResource.Component,
         values: {
-          url,
+          URL: url,
           name,
+          type: "game",
         },
       },
       (response) => {

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -40,9 +40,9 @@ export type CodapRequest =
 
 export type CreateInteractiveFrameRequest = {
   action: CodapActions.Create;
-  resource: CodapResource.InteractiveFrame;
+  resource: CodapResource.Component;
 
-  values: { url: string; name: string };
+  values: { URL: string; name: string; type: "game" };
 };
 
 export type UpdateInteractiveFrameRequest = {


### PR DESCRIPTION
This PR changes over CODAP-phone to use the existing endpoint for creating data interactive instead of the one we added. This allows us to remove the endpoint we added.