### PR TITLE
Fix attribute selector bugs

### DIFF
--- a/src/transformation-components/transformationList.ts
+++ b/src/transformation-components/transformationList.ts
@@ -166,9 +166,6 @@ const transformationList: Record<
       context1: {
         title: "Table to Select Attributes From",
       },
-      textInput1: {
-        title: "Name of New Attribute",
-      },
       dropdown1: {
         title: "Mode",
         options: [

--- a/src/ui-components/AttributeSelector.tsx
+++ b/src/ui-components/AttributeSelector.tsx
@@ -32,10 +32,13 @@ export default function AttributeSelector({
       options={
         disabled && value !== null
           ? [{ value: value, title: value }]
-          : attributes.map((attribute) => ({
-              value: attribute.name,
-              title: attribute.title || attribute.name,
-            }))
+          : attributes
+              // filter out hidden attrs (keep attrs that have hidden undefined)
+              .filter((attr) => !attr.hidden)
+              .map((attribute) => ({
+                value: attribute.name,
+                title: attribute.title || attribute.name,
+              }))
       }
       value={value}
       defaultValue="Select an attribute"

--- a/src/ui-components/AttributeSelector.tsx
+++ b/src/ui-components/AttributeSelector.tsx
@@ -34,7 +34,7 @@ export default function AttributeSelector({
           ? [{ value: value, title: value }]
           : attributes.map((attribute) => ({
               value: attribute.name,
-              title: attribute.title,
+              title: attribute.title || attribute.name,
             }))
       }
       value={value}

--- a/src/ui-components/MultiAttributeSelector.tsx
+++ b/src/ui-components/MultiAttributeSelector.tsx
@@ -50,7 +50,7 @@ export default function MultiAttributeSelector({
             }}
             options={attributes.map((attribute) => ({
               value: attribute.name,
-              title: attribute.title,
+              title: attribute.title || attribute.name,
             }))}
             value={selected[i]}
             defaultValue="Select an attribute"

--- a/src/ui-components/MultiAttributeSelector.tsx
+++ b/src/ui-components/MultiAttributeSelector.tsx
@@ -48,10 +48,16 @@ export default function MultiAttributeSelector({
               newSelected[i] = e.target.value;
               setSelected(newSelected);
             }}
-            options={attributes.map((attribute) => ({
-              value: attribute.name,
-              title: attribute.title || attribute.name,
-            }))}
+            options={attributes
+              .map((attribute) => ({
+                value: attribute.name,
+                title: attribute.title || attribute.name,
+              }))
+              .filter(
+                (option) =>
+                  !selected.includes(option.value) ||
+                  option.value === selected[i]
+              )}
             value={selected[i]}
             defaultValue="Select an attribute"
             disabled={disabled}

--- a/src/ui-components/MultiAttributeSelector.tsx
+++ b/src/ui-components/MultiAttributeSelector.tsx
@@ -49,6 +49,8 @@ export default function MultiAttributeSelector({
               setSelected(newSelected);
             }}
             options={attributes
+              // filter out hidden attrs (keep attrs that have hidden undefined)
+              .filter((attr) => !attr.hidden)
               .map((attribute) => ({
                 value: attribute.name,
                 title: attribute.title || attribute.name,

--- a/src/ui-components/MultiAttributeSelector.tsx
+++ b/src/ui-components/MultiAttributeSelector.tsx
@@ -53,6 +53,7 @@ export default function MultiAttributeSelector({
                 value: attribute.name,
                 title: attribute.title || attribute.name,
               }))
+              // Disallow duplicate attributes by filtering
               .filter(
                 (option) =>
                   !selected.includes(option.value) ||

--- a/src/ui-components/MultiAttributeSelector.tsx
+++ b/src/ui-components/MultiAttributeSelector.tsx
@@ -26,7 +26,7 @@ export default function MultiAttributeSelector({
     if (disabled) {
       return;
     }
-    const attrNames = attributes.map((a) => a.name);
+    const attrNames = attributes.filter((a) => !a.hidden).map((a) => a.name);
     if (selected.some((a) => !attrNames.includes(a))) {
       setSelected(selected.filter((a) => attrNames.includes(a)));
     }

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -260,38 +260,15 @@ function getCaseById(context: string, id: number): Promise<ReturnedCase> {
 
 export async function getAllAttributes(
   context: string
-): Promise<CodapIdentifyingInfo[]> {
-  // Get the name (as a string) of each collection in the context
-  const collections = (await getAllCollections(context)).map(
-    (collection) => collection.name
+): Promise<CodapAttribute[]> {
+  const collections = (await getDataContext(context)).collections;
+
+  const attributes: CodapAttribute[] = [];
+  collections.forEach((collection) =>
+    collection.attrs?.forEach((attr) => attributes.push(attr))
   );
 
-  // Make a request to get the attributes for each collection
-  const promises = collections.map(
-    (collectionName) =>
-      new Promise<CodapIdentifyingInfo[]>((resolve, reject) =>
-        phone.call(
-          {
-            action: CodapActions.Get,
-            resource: attributeListFromCollection(context, collectionName),
-          },
-          (response: GetDataListResponse) => {
-            if (response.success) {
-              resolve(response.values);
-            } else {
-              reject(new Error("Failed to get attributes."));
-            }
-          }
-        )
-      )
-  );
-
-  // Wait for all promises to return
-  const attributes = await Promise.all(promises);
-
-  // flatten and return the set of attributes
-  // return attributes.reduce((acc, elt) => [...acc, ...elt]);
-  return attributes.flat();
+  return attributes;
 }
 
 /**

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -227,11 +227,13 @@ export enum ContextChangeOperation {
   // Triggered when sorting a column.
   MoveCases = "moveCases",
 
-  // Despite the documentation, the first three of these are plural, while the
+  // Despite the documentation, the first five of these are plural, while the
   // last is singular
   CreateAttribute = "createAttributes",
   UpdateAttribute = "updateAttributes",
   DeleteAttribute = "deleteAttributes",
+  HideAttribute = "hideAttributes",
+  UnhideAttribute = "unhideAttributes",
   MoveAttribute = "moveAttribute",
 
   // Not sure where this is documented, but it is triggered when a collection
@@ -260,6 +262,8 @@ export const mutatingOperations = [
   ContextChangeOperation.CreateCollection,
   ContextChangeOperation.DeleteCollection,
   ContextChangeOperation.DependentCases,
+  ContextChangeOperation.HideAttribute,
+  ContextChangeOperation.UnhideAttribute,
 ];
 
 export enum DocumentChangeOperations {

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -8,7 +8,7 @@ import {
   removeContextUpdateListener,
   addContextUpdateListener,
 } from "./codapPhone";
-import { CodapIdentifyingInfo } from "./codapPhone/types";
+import { CodapAttribute, CodapIdentifyingInfo } from "./codapPhone/types";
 
 export function useDataContexts(): CodapIdentifyingInfo[] {
   const [dataContexts, setDataContexts] = useState<CodapIdentifyingInfo[]>([]);
@@ -44,8 +44,8 @@ export function useCollections(context: string | null): CodapIdentifyingInfo[] {
   return collections;
 }
 
-export function useAttributes(context: string | null): CodapIdentifyingInfo[] {
-  const [attributes, setAttributes] = useState<CodapIdentifyingInfo[]>([]);
+export function useAttributes(context: string | null): CodapAttribute[] {
+  const [attributes, setAttributes] = useState<CodapAttribute[]>([]);
 
   async function refreshAttributes(context: string) {
     setAttributes(await getAllAttributes(context));


### PR DESCRIPTION
Fixes #97 and #98. Also removes an extraneous UI component in `Select Attributes`.

@stardust66 I had to include hiding and unhiding attributes as mutating operations to make sure they invalidated the cache. Can you make sure I did everything right? I'm no super familiar with the caching code.