### PR TITLE
gracefully error when not embedded in CODAP

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,18 @@
+
+.loading, .initError {
+  font-size: 14px;
+  margin: 15px;
+}
+
+.initError {
+  margin-top: 10px;
+  display: inline-block;
+  background-color: #ffeeee;
+  padding: 6px;
+  border: solid 1px red;
+  border-radius: 5px;
+}
+
+p.initError {
+  color: red;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,57 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useState } from "react";
 import Transformation from "./Transformation";
 import { SavedTransformation } from "./transformation-components/types";
 import { initPhone } from "./utils/codapPhone";
+import "./App.css";
 
-// This should be a pure function (ie: only render once)
 export const App = (): ReactElement => {
-  const parsedUrl = new URL(window.location.href);
+  const [loading, setLoading] = useState<boolean>(true);
+  const loadingMsg = <p className="loading">Connecting to CODAP...</p>;
 
+  const [initError, setInitError] = useState<boolean>(false);
+  const initErrorMsg = (
+    <p className="initError">
+      Could not connect to CODAP. Please make sure you are using CODAP Flow
+      within CODAP.
+    </p>
+  );
+
+  /**
+   * Initializes a new data interactive (plugin) with the given name,
+   * and turns off loading once it has succeeded, or indicates an
+   * error should be displayed if it fails.
+   */
+  const initWithPluginName = (name: string): void => {
+    initPhone(name)
+      .then(() => {
+        setLoading(false);
+      })
+      .catch(() => {
+        setInitError(true);
+      });
+  };
+
+  const parsedUrl = new URL(window.location.href);
   const transformation = parsedUrl.searchParams.get("transform");
+  let pluginContent: JSX.Element;
 
   if (transformation === null) {
-    initPhone("CODAP Flow");
-    return <Transformation />;
+    initWithPluginName("CODAP Flow");
+    pluginContent = <Transformation />;
   } else {
     const parsedTransformation: SavedTransformation = JSON.parse(
       decodeURIComponent(transformation)
     );
 
-    initPhone(parsedTransformation.name);
+    initWithPluginName(parsedTransformation.name);
+    pluginContent = <Transformation transformation={parsedTransformation} />;
+  }
 
-    return <Transformation transformation={parsedTransformation} />;
+  if (initError) {
+    return initErrorMsg;
+  } else if (loading) {
+    return loadingMsg;
+  } else {
+    return pluginContent;
   }
 };

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -83,7 +83,9 @@ export async function initPhone(title: string): Promise<void> {
         },
       },
       (response) => {
-        if (response.success) {
+        // NOTE: Ensure the response exists, since if this is run
+        // without being embedded in CODAP, it will come back undefined.
+        if (response && response.success) {
           resolve();
         } else {
           reject(new Error("Failed to update CODAP interactive frame"));


### PR DESCRIPTION
This checks if the call to `initPhone` in `App.tsx` fails, and if it does, renders an error message. It also adds a loading screen which is rendered until the call to `initPhone` returns, so that we don't expose the UI to the user when it's not actually embedded in CODAP (this causes all sorts of problems). This loading screen is barely noticeable when the plugin is operating inside CODAP.

Fixes #99. 