### PR TITLE
fix difference from, name changes

### DIFF
--- a/src/transformer-components/transformerList.ts
+++ b/src/transformer-components/transformerList.ts
@@ -81,7 +81,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Partition",
+          title: "Dataset to Partition",
         },
         attribute1: {
           title: "Attribute to Partition By",
@@ -98,7 +98,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Flatten",
+          title: "Dataset to Flatten",
         },
       },
       transformerFunction: { kind: "datasetCreator", func: flatten },
@@ -109,7 +109,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Group",
+          title: "Dataset to Group",
         },
         attributeSet1: {
           title: "Attributes to Group By",
@@ -123,7 +123,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Pivot",
+          title: "Dataset to Pivot",
         },
         attributeSet1: {
           title: "Attributes to Pivot",
@@ -143,7 +143,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Pivot",
+          title: "Dataset to Pivot",
         },
         attribute1: {
           title: "Names From",
@@ -160,10 +160,10 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Base Table",
+          title: "Base Dataset",
         },
         context2: {
-          title: "Joining Table",
+          title: "Joining Dataset",
         },
         attribute1: {
           title: "Base Attribute",
@@ -180,10 +180,10 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Base Table",
+          title: "Base Dataset",
         },
         context2: {
-          title: "Combining Table",
+          title: "Combining Dataset",
         },
       },
       transformerFunction: {
@@ -197,7 +197,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Count",
+          title: "Dataset to Count",
         },
         attributeSet1: {
           title: "Attributes to Count",
@@ -211,10 +211,10 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "First Table to Compare",
+          title: "First Dataset to Compare",
         },
         context2: {
-          title: "Second Table to Compare",
+          title: "Second Dataset to Compare",
         },
         attribute1: {
           title: "First attribute to Compare",
@@ -240,7 +240,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to calculate running sum on",
+          title: "Dataset to calculate running sum on",
         },
         attribute1: {
           title: "Attribute to Aggregate",
@@ -254,7 +254,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to calculate running mean on",
+          title: "Dataset to calculate running mean on",
         },
         attribute1: {
           title: "Attribute to Aggregate",
@@ -268,7 +268,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to calculate running min on",
+          title: "Dataset to calculate running min on",
         },
         attribute1: {
           title: "Attribute to Aggregate",
@@ -282,7 +282,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to calculate running max on",
+          title: "Dataset to calculate running max on",
         },
         attribute1: {
           title: "Attribute to Aggregate",
@@ -296,7 +296,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to calculate difference on",
+          title: "Dataset to calculate difference on",
         },
         attribute1: {
           title: "Attribute to Aggregate",
@@ -310,7 +310,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to calculate difference on",
+          title: "Dataset to calculate difference on",
         },
         attribute1: {
           title: "Attribute to take difference from",
@@ -330,7 +330,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to reduce",
+          title: "Dataset to Reduce",
         },
         textInput1: {
           title: "Result Attribute Name",
@@ -353,7 +353,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Copy",
+          title: "Dataset to Copy",
         },
       },
       transformerFunction: { kind: "datasetCreator", func: copy },
@@ -364,7 +364,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Copy",
+          title: "Dataset to Copy",
         },
       },
       transformerFunction: { kind: "datasetCreator", func: copyStructure },
@@ -375,7 +375,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Take Dot Product of",
+          title: "Dataset to Take Dot Product of",
         },
         attributeSet1: {
           title: "Attributes to Take Dot Product of",
@@ -390,7 +390,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Take Average of",
+          title: "Dataset to Take Average of",
         },
         attribute1: {
           title: "Attribute to Average",
@@ -404,7 +404,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Filter",
+          title: "Dataset to Filter",
         },
         typeContract1: {
           title: "How to Filter",
@@ -423,7 +423,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Transform Column Of",
+          title: "Dataset to Transform Column Of",
         },
         attribute1: {
           title: "Attribute to Transform",
@@ -444,7 +444,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Add Attribute To",
+          title: "Dataset to Add Attribute To",
         },
         textInput1: {
           title: "Name of New Attribute",
@@ -468,7 +468,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to Select Attributes From",
+          title: "Dataset to Select Attributes From",
         },
         dropdown1: {
           title: "Mode",
@@ -499,7 +499,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         context1: {
-          title: "Table to sort",
+          title: "Dataset to sort",
         },
         typeContract1: {
           title: "Key expression",

--- a/src/transformer-components/transformerList.ts
+++ b/src/transformer-components/transformerList.ts
@@ -41,14 +41,14 @@ export type BaseTransformerName =
   | "Build Column"
   | "Compare"
   | "Count"
-  | "Difference From"
   | "Filter"
   | "Flatten"
   | "Running Sum"
   | "Running Mean"
   | "Running Min"
   | "Running Max"
-  | "Running Difference"
+  | "Difference"
+  | "Difference From"
   | "Group By"
   | "Pivot Longer"
   | "Pivot Wider"
@@ -291,18 +291,38 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: runningMax },
     },
   },
-  "Running Difference": {
+  Difference: {
     group: "Running Aggregators",
     componentData: {
       init: {
         context1: {
-          title: "Table to calculate running difference on",
+          title: "Table to calculate difference on",
         },
         attribute1: {
           title: "Attribute to Aggregate",
         },
       },
       transformerFunction: { kind: "datasetCreator", func: difference },
+    },
+  },
+  "Difference From": {
+    group: "Running Aggregators",
+    componentData: {
+      init: {
+        context1: {
+          title: "Table to calculate difference on",
+        },
+        attribute1: {
+          title: "Attribute to take difference from",
+        },
+        textInput2: {
+          title: "Starting value for difference",
+        },
+      },
+      transformerFunction: {
+        kind: "datasetCreator",
+        func: differenceFrom,
+      },
     },
   },
   Reduce: {
@@ -471,30 +491,6 @@ const transformerList: TransformerList = {
       transformerFunction: {
         kind: "datasetCreator",
         func: selectAttributes,
-      },
-    },
-  },
-
-  "Difference From": {
-    group: "Others",
-    componentData: {
-      init: {
-        context1: {
-          title: "Table to calculate difference on",
-        },
-        attribute1: {
-          title: "Attribute to take difference from",
-        },
-        textInput1: {
-          title: "Result Attribute Name",
-        },
-        textInput2: {
-          title: "Starting value for difference",
-        },
-      },
-      transformerFunction: {
-        kind: "datasetCreator",
-        func: differenceFrom,
       },
     },
   },

--- a/src/transformer-components/transformerList.ts
+++ b/src/transformer-components/transformerList.ts
@@ -10,7 +10,7 @@ import { sort } from "../transformers/sort";
 import { pivotLonger, pivotWider } from "../transformers/pivot";
 import { join } from "../transformers/join";
 import { copy } from "../transformers/copy";
-import { copySchema } from "../transformers/copySchema";
+import { copyStructure } from "../transformers/copyStructure";
 import { combineCases } from "../transformers/combineCases";
 import {
   difference,
@@ -56,7 +56,7 @@ export type BaseTransformerName =
   | "Sort"
   | "Transform Column"
   | "Copy"
-  | "Copy Schema"
+  | "Copy Structure"
   | "Join"
   | "Dot Product"
   | "Average"
@@ -359,7 +359,7 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: copy },
     },
   },
-  "Copy Schema": {
+  "Copy Structure": {
     group: "Copy Transformers",
     componentData: {
       init: {
@@ -367,7 +367,7 @@ const transformerList: TransformerList = {
           title: "Table to Copy",
         },
       },
-      transformerFunction: { kind: "datasetCreator", func: copySchema },
+      transformerFunction: { kind: "datasetCreator", func: copyStructure },
     },
   },
   "Dot Product": {

--- a/src/transformers/combineCases.ts
+++ b/src/transformers/combineCases.ts
@@ -46,7 +46,7 @@ function uncheckedCombineCases(base: DataSet, combining: DataSet): DataSet {
     !setEquality(baseAttrs, combiningAttrs, (name1, name2) => name1 === name2)
   ) {
     throw new Error(
-      `Base and combining tables must have the same attribute names`
+      `Base and combining datasets must have the same attribute names`
     );
   }
 

--- a/src/transformers/copyStructure.ts
+++ b/src/transformers/copyStructure.ts
@@ -4,27 +4,27 @@ import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
 
 /**
- * Produces a dataset with an identical schema (collection structure,
+ * Produces a dataset with an identical structure (collection hierarchy,
  * attributes) to the input, but with no records.
  */
-export async function copySchema({
+export async function copyStructure({
   context1: contextName,
 }: DDTransformerState): Promise<TransformationOutput> {
   if (contextName === null) {
-    throw new Error("Please choose a valid data context to transform.");
+    throw new Error("Please choose a valid dataset to transform.");
   }
 
   const { context, dataset } = await getContextAndDataSet(contextName);
   const ctxtName = readableName(context);
 
   return [
-    await uncheckedCopySchema(dataset),
-    `Schema Copy of ${ctxtName}`,
-    `A copy of the ${ctxtName} dataset, but with no cases.`,
+    await uncheckedCopyStructure(dataset),
+    `Structure Copy of ${ctxtName}`,
+    `A copy of the collections and attributes of the ${ctxtName} dataset, but with no cases.`,
   ];
 }
 
-function uncheckedCopySchema(dataset: DataSet): DataSet {
+function uncheckedCopyStructure(dataset: DataSet): DataSet {
   return {
     collections: dataset.collections,
     records: [],

--- a/src/transformers/fold.ts
+++ b/src/transformers/fold.ts
@@ -17,7 +17,15 @@ type FoldFunction = (
   resultColumnDescription: string
 ) => DataSet;
 
-function makeFoldWrapper(label: string, innerFoldFunction: FoldFunction) {
+function makeFoldWrapper(
+  label: string,
+  innerFoldFunction: FoldFunction,
+  makeDescriptions: (
+    label: string,
+    inputAttribute: string,
+    contextName: string
+  ) => [string, string]
+) {
   return async ({
     context1: contextName,
     attribute1: inputAttributeName,
@@ -30,28 +38,31 @@ function makeFoldWrapper(label: string, innerFoldFunction: FoldFunction) {
     }
 
     const { context, dataset } = await getContextAndDataSet(contextName);
-    const attrs = dataset.collections.map((coll) => coll.attrs || []).flat();
     const resultAttributeName = uniqueName(
       `${label} of ${parenthesizeName(inputAttributeName)} from ${readableName(
         context
       )}`,
-      attrs.map((attr) => attr.name)
+      allAttrNames(dataset)
     );
-    const resultDescription = `A ${label.toLowerCase()} of the values from the ${inputAttributeName} attribute in the ${readableName(
-      context
-    )} table.`;
 
     const ctxtName = readableName(context);
+
+    // Generate a description of the fold by calling the custom maker, or using a default.
+    const [attributeDescription, datasetDescription] = makeDescriptions(
+      label,
+      inputAttributeName,
+      ctxtName
+    );
 
     return [
       await innerFoldFunction(
         dataset,
         inputAttributeName,
         resultAttributeName,
-        resultDescription
+        attributeDescription
       ),
       `${label} of ${ctxtName}`,
-      `A ${label.toLowerCase()} of the ${inputAttributeName} attribute from the ${ctxtName} dataset.`,
+      datasetDescription,
     ];
   };
 }
@@ -223,7 +234,7 @@ const uncheckedRunningMax = makeNumFold<{ max: number | null }>(
   }
 );
 const uncheckedDifference = makeNumFold<{ numAbove: number | null }>(
-  "Running Difference",
+  "Difference",
   { numAbove: null },
   (acc, input) => {
     if (acc.numAbove === null) {
@@ -234,19 +245,53 @@ const uncheckedDifference = makeNumFold<{ numAbove: number | null }>(
   }
 );
 
-export const runningSum = makeFoldWrapper("Running Sum", uncheckedRunningSum);
+function defaultDescriptions(
+  label: string,
+  attribute: string,
+  contextName: string
+): [string, string] {
+  const attributeDescription = `A ${label} of the ${attribute} attribute from the ${contextName} dataset.`;
+  const datasetDescription = `A copy of the ${contextName} dataset with a new attribute added which contains a ${label} of the ${attribute} attribute.`;
+
+  return [attributeDescription, datasetDescription];
+}
+
+export const runningSum = makeFoldWrapper(
+  "Running Sum",
+  uncheckedRunningSum,
+  defaultDescriptions
+);
 export const runningMean = makeFoldWrapper(
   "Running Mean",
-  uncheckedRunningMean
+  uncheckedRunningMean,
+  defaultDescriptions
 );
-export const runningMin = makeFoldWrapper("Running Min", uncheckedRunningMin);
-export const runningMax = makeFoldWrapper("Running Max", uncheckedRunningMax);
-export const difference = makeFoldWrapper("Difference", uncheckedDifference);
+export const runningMin = makeFoldWrapper(
+  "Running Min",
+  uncheckedRunningMin,
+  defaultDescriptions
+);
+export const runningMax = makeFoldWrapper(
+  "Running Max",
+  uncheckedRunningMax,
+  defaultDescriptions
+);
+export const difference = makeFoldWrapper(
+  "Difference",
+  uncheckedDifference,
+  (label: string, attribute: string, contextName: string) => {
+    return [
+      `The difference of each case with the case above it (from the ${attribute} attribute in the ${contextName} dataset).`,
+      `A copy of ${contextName} with a new column whose values are the difference between ` +
+        `the value of ${attribute} in the current case and the value of ${attribute} ` +
+        `in the case above. The first case subtracts 0 from itself.`,
+    ];
+  }
+);
 
 export async function differenceFrom({
   context1: contextName,
   attribute1: inputAttributeName,
-  textInput1: resultAttributeName,
   textInput2: startingValue,
 }: DDTransformerState): Promise<TransformationOutput> {
   if (contextName === null) {
@@ -254,9 +299,6 @@ export async function differenceFrom({
   }
   if (inputAttributeName === null) {
     throw new Error("Please choose an attribute to take the difference from");
-  }
-  if (resultAttributeName === "") {
-    throw new Error("Please choose a non-empty result column name.");
   }
   if (isNaN(Number(startingValue))) {
     throw new Error(
@@ -266,6 +308,7 @@ export async function differenceFrom({
 
   const { context, dataset } = await getContextAndDataSet(contextName);
   const ctxtName = readableName(context);
+  const resultAttributeName = `Difference From of ${inputAttributeName} in ${ctxtName}`;
 
   return [
     await uncheckedDifferenceFrom(
@@ -277,7 +320,7 @@ export async function differenceFrom({
     `Difference From of ${ctxtName}`,
     `A copy of ${ctxtName} with a new column whose values are the difference between ` +
       `the value of ${inputAttributeName} in the current case and the value of ${inputAttributeName} ` +
-      `in the case above. The starting value is ${startingValue}.`,
+      `in the case above. The first case subtracts ${startingValue} from itself.`,
   ];
 }
 
@@ -287,31 +330,19 @@ function uncheckedDifferenceFrom(
   resultColumnName: string,
   startingValue = 0
 ): DataSet {
-  resultColumnName = uniqueName(resultColumnName, allAttrNames(dataset));
-  const resultRecords = dataset.records.map((row) => {
-    if (row[inputColumnName] === undefined) {
-      throw new Error(`Invalid attribute name: ${inputColumnName}`);
+  // Construct a fold that computes the difference of each case with
+  // the case above, but uses the given startingValue to begin
+  const differenceFromFold = makeNumFold<{ numAbove: number | null }>(
+    "Difference From",
+    { numAbove: startingValue },
+    (acc, input) => {
+      if (acc.numAbove === null) {
+        return [{ numAbove: input }, input];
+      } else {
+        return [{ numAbove: input }, input - acc.numAbove];
+      }
     }
+  );
 
-    const numValue = Number(row[inputColumnName]);
-    if (!isNaN(numValue)) {
-      return insertInRow(row, resultColumnName, numValue - startingValue);
-    } else {
-      throw new Error(
-        `Difference from expected number, instead got ${codapValueToString(
-          row[inputColumnName]
-        )}`
-      );
-    }
-  });
-
-  const newCollections = insertColumnInLastCollection(dataset.collections, {
-    name: resultColumnName,
-    type: "numeric",
-  });
-
-  return {
-    collections: newCollections,
-    records: resultRecords,
-  };
+  return differenceFromFold(dataset, inputColumnName, resultColumnName, "");
 }

--- a/src/transformers/fold.ts
+++ b/src/transformers/fold.ts
@@ -139,7 +139,7 @@ export async function genericFold({
 
   const { context, dataset } = await getContextAndDataSet(contextName);
 
-  const resultDescription = `A reduce of the ${readableName(context)} table.`;
+  const resultDescription = `A reduce of the ${readableName(context)} dataset.`;
   const ctxtName = readableName(context);
 
   return [


### PR DESCRIPTION
This changes difference from to match the [corresponding Pyret function](https://www.pyret.org/docs/latest/tables.html#%28part._tables_difference-from%29), and updates the generated dataset descriptions (for this and plain difference) to better explain what they do.

I also did the following name changes:
- "Copy Schema" --> "Copy Structure" since this seems like a more approachable/understandable term
- In several places in the UI where we mention tables, I changed this to "dataset" to match the others we already changed (dropdowns).


## To do
Pick new name for "Running Aggregators"