### PR TITLE
Speed up updates

### DIFF
--- a/src/utils/codapPhone/listeners.ts
+++ b/src/utils/codapPhone/listeners.ts
@@ -66,8 +66,12 @@ export function removeListenersWithDependency(dep: string): void {
   }
 }
 
-export function callUpdateListenersForContext(context: string): void {
+export async function callUpdateListenersForContext(
+  context: string
+): Promise<void> {
   if (contextUpdateListeners[context] !== undefined) {
-    contextUpdateListeners[context].forEach(([, f]) => f());
+    for (const [, f] of contextUpdateListeners[context]) {
+      await f();
+    }
   }
 }


### PR DESCRIPTION
This makes update listeners execute sequentially, which actually speeds up data fetching. Previously, since the update functions fire off data fetching requests before any data is returned, the same data is fetched multiple times, not making use of our cache. Now, each data fetch waits for the previous one to finish, which means if the same piece of data is fetched multiple times, it will be in the cache by the second fetch.