### PR TITLE
Fix attribute copying

### DIFF
--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -372,7 +372,6 @@ export function getDataContext(contextName: string): Promise<DataContext> {
       },
       (response: GetContextResponse) => {
         if (response.success) {
-          console.log(response.values);
           const context = normalizeDataContext(response.values);
           Cache.setContext(contextName, context);
           resolve(context);

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -16,10 +16,8 @@ import {
   CodapInitiatedCommand,
   ReturnedCase,
   Collection,
-  ReturnedCollection,
   ContextMetadata,
   DataContext,
-  ReturnedDataContext,
   CodapListResource,
   CodapIdentifyingInfo,
   CaseTable,
@@ -43,7 +41,11 @@ import {
   caseById,
   allCasesWithSearch,
 } from "./resource";
-import { fillCollectionWithDefaults, collectionsEqual } from "./util";
+import {
+  fillCollectionWithDefaults,
+  collectionsEqual,
+  normalizeDataContext,
+} from "./util";
 import { DataSet } from "../../transformers/types";
 import { CodapEvalError } from "./error";
 import { uniqueName } from "../names";
@@ -370,6 +372,7 @@ export function getDataContext(contextName: string): Promise<DataContext> {
       },
       (response: GetContextResponse) => {
         if (response.success) {
+          console.log(response.values);
           const context = normalizeDataContext(response.values);
           Cache.setContext(contextName, context);
           resolve(context);
@@ -397,61 +400,6 @@ export async function deleteDataContext(contextName: string): Promise<void> {
       }
     )
   );
-}
-
-// Copies a list of attributes, only copying the fields relevant to our
-// representation of attributes and omitting any extra fields (cid, etc).
-function copyAttrs(
-  attrs: CodapAttribute[] | undefined
-): CodapAttribute[] | undefined {
-  return attrs?.map((attr) => {
-    return {
-      name: attr.name,
-      title: attr.title,
-      type: attr.type,
-      colormap: attr.colormap,
-      description: attr.description,
-      editable: attr.editable,
-      formula: attr.formula,
-      hidden: attr.hidden,
-      precision: attr.type === "numeric" ? attr.precision : undefined,
-      unit: attr.type === "numeric" ? attr.unit : undefined,
-    };
-  }) as CodapAttribute[];
-}
-
-// In the returned collections, parents show up as numeric ids, so before
-// reusing, we need to look up the names of the parent collections.
-function normalizeParentNames(collections: ReturnedCollection[]): Collection[] {
-  const normalized = [];
-  for (const c of collections) {
-    let newParent;
-    if (c.parent) {
-      newParent = collections.find(
-        (collection) => collection.id === c.parent
-      )?.name;
-    }
-
-    normalized.push({
-      name: c.name,
-      title: c.title,
-      attrs: copyAttrs(c.attrs),
-      labels: c.labels,
-      parent: newParent,
-    });
-  }
-
-  return normalized as Collection[];
-}
-
-function normalizeDataContext(context: ReturnedDataContext): DataContext {
-  return {
-    name: context.name,
-    title: context.title,
-    description: context.description,
-    collections: normalizeParentNames(context.collections),
-    metadata: context.metadata,
-  };
 }
 
 async function createDataContext({

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -352,14 +352,10 @@ export interface ReturnedCollection extends Omit<Collection, "parent"> {
 }
 
 // https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#attributes
-export type CodapAttribute =
-  | BaseAttribute
-  | CategoricalAttribute
-  | NumericAttribute;
-
-export interface RawAttribute {
+export interface CodapAttribute {
   name: string;
   title?: string;
+  type?: "categorical" | "numeric" | "date" | "qualitative" | "boundary" | null;
   colormap?:
     | Record<string, string>
     | {
@@ -371,26 +367,8 @@ export interface RawAttribute {
   editable?: boolean;
   formula?: string;
   hidden?: boolean;
-}
-
-export interface BaseAttribute extends RawAttribute {
-  type?: null;
-}
-
-export interface CategoricalAttribute extends RawAttribute {
-  type?: "categorical";
-  colormap?: Record<string, string>;
-}
-
-export interface NumericAttribute extends RawAttribute {
-  type?: "numeric";
   precision?: number;
   unit?: string | null;
-  colormap?: {
-    "high-attribute-color": string;
-    "low-attribute-color": string;
-    "attribute-color": string;
-  };
 }
 
 // https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#attributelocations


### PR DESCRIPTION
Fixes #109. Makes `CodapAttribute` type less restrictive. Now, attributes do not need to be numeric to have the `precision` or `unit` properties, which better reflects what the CODAP UI allows. In addition, the type can also be "qualitative", "date", etc., which are options in the type dropdown in the CODAP UI. These options were not in the API documentation, but do have an effect on the UI. For example, the "qualitative" type turns attributes into horizontal bars, like

![image](https://user-images.githubusercontent.com/11802391/123863016-0b1e7800-d8f7-11eb-8347-833a8ab706a3.png)

so we should respect them.