### PR TITLE
ensure all transformations avoid name collisions

### DIFF
--- a/src/transformers/compare.ts
+++ b/src/transformers/compare.ts
@@ -3,13 +3,18 @@ import { CodapAttribute, Collection } from "../utils/codapPhone/types";
 import { diffArrays } from "diff";
 import { intersectionWithPredicate, unionWithPredicate } from "../utils/sets";
 import { uncheckedFlatten } from "./flatten";
-import { eraseFormulas, getAttributeDataFromDataset } from "./util";
+import {
+  allAttrNames,
+  eraseFormulas,
+  getAttributeDataFromDataset,
+} from "./util";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { readableName } from "../transformer-components/util";
+import { uniqueName } from "../utils/names";
 
-const COMPARE_STATUS_COLUMN_NAME = "Compare Status";
-const COMPARE_VALUE_COLUMN_NAME = "Difference";
+const COMPARE_STATUS_COLUMN_BASE = "Compare Status";
+const COMPARE_VALUE_COLUMN_BASE = "Difference";
 const GREEN = "rgb(0,255,0)";
 const RED = "rgb(255,0,0)";
 const GREY = "rgb(100,100,100)";
@@ -87,10 +92,19 @@ function uncheckedCompare(
     );
   }
 
-  // Make sure that the two attributes don't have the same name by adding a
-  // suffix to attribute 2 if necessary
-  const safeAttributeName2 =
-    attributeName1 === attributeName2 ? attributeName2 + "(1)" : attributeName2;
+  // Make sure that the two attributes shown in comparison don't have the same name
+  const safeAttributeName2 = uniqueName(attributeName2, [attributeName1]);
+  const attributeNames = [attributeName1, safeAttributeName2];
+
+  // Ensure generated comparison attributes don't collide with attributes being compared
+  const compareValueColumnName = uniqueName(
+    COMPARE_VALUE_COLUMN_BASE,
+    attributeNames
+  );
+  const compareStatusColumnName = uniqueName(
+    COMPARE_STATUS_COLUMN_BASE,
+    attributeNames
+  );
 
   const collections: Collection[] = [
     {
@@ -108,7 +122,7 @@ function uncheckedCompare(
   // Only add this attribute if this is a numeric diff
   if (kind === "numeric") {
     collections[0].attrs?.push({
-      name: COMPARE_VALUE_COLUMN_NAME,
+      name: compareValueColumnName,
       description: "",
       editable: true,
       hidden: false,
@@ -116,7 +130,7 @@ function uncheckedCompare(
     });
   }
   collections[0].attrs?.push({
-    name: COMPARE_STATUS_COLUMN_NAME,
+    name: compareStatusColumnName,
     description: "",
     editable: true,
     hidden: false,
@@ -132,13 +146,16 @@ function uncheckedCompare(
           attributeName1,
           safeAttributeName2,
           values1,
-          values2
+          values2,
+          compareStatusColumnName
         )
       : compareRecordsNumerical(
           attributeName1,
           safeAttributeName2,
           values1,
-          values2
+          values2,
+          compareValueColumnName,
+          compareStatusColumnName
         );
 
   return {
@@ -151,7 +168,8 @@ function compareRecordsStructural(
   attributeName1: string,
   attributeName2: string,
   values1: unknown[],
-  values2: unknown[]
+  values2: unknown[],
+  compareStatusColumnName: string
 ): Record<string, unknown>[] {
   const changeObjects = diffArrays(values1, values2);
 
@@ -166,19 +184,19 @@ function compareRecordsStructural(
         records.push({
           [attributeName1]: change.value[j],
           [attributeName2]: "",
-          [COMPARE_STATUS_COLUMN_NAME]: RED,
+          [compareStatusColumnName]: RED,
         });
       } else if (change.added) {
         records.push({
           [attributeName1]: "",
           [attributeName2]: change.value[j],
-          [COMPARE_STATUS_COLUMN_NAME]: GREEN,
+          [compareStatusColumnName]: GREEN,
         });
       } else {
         records.push({
           [attributeName1]: change.value[j],
           [attributeName2]: change.value[j],
-          [COMPARE_STATUS_COLUMN_NAME]: GREY,
+          [compareStatusColumnName]: GREY,
         });
       }
     }
@@ -220,6 +238,17 @@ function compareCategorical(
   );
   eraseFormulas(attributesUnion);
   eraseFormulas(attributesIntersection);
+
+  const allAttributes = allAttrNames(dataset1).concat(allAttrNames(dataset2));
+
+  if (allAttributes.includes(DECISION_1_COLUMN_NAME)) {
+    throw new Error(`Attribute \`${DECISION_1_COLUMN_NAME}\` is needed by \
+    Compare. Please do not use it in the input datasets.`);
+  }
+  if (allAttributes.includes(DECISION_2_COLUMN_NAME)) {
+    throw new Error(`Attribute \`${DECISION_2_COLUMN_NAME}\` is needed by \
+    Compare. Please do not use it in the input datasets.`);
+  }
 
   const collections: Collection[] = [
     {
@@ -313,7 +342,9 @@ function compareRecordsNumerical(
   attributeName1: string,
   attributeName2: string,
   values1: unknown[],
-  values2: unknown[]
+  values2: unknown[],
+  compareValueColumnName: string,
+  compareStatusColumnName: string
 ): Record<string, unknown>[] {
   const records = [];
   for (let i = 0; i < Math.max(values1.length, values2.length); i++) {
@@ -325,8 +356,8 @@ function compareRecordsNumerical(
       records.push({
         [attributeName1]: values1[i],
         [attributeName2]: values2[i],
-        [COMPARE_VALUE_COLUMN_NAME]: "",
-        [COMPARE_STATUS_COLUMN_NAME]: "",
+        [compareValueColumnName]: "",
+        [compareStatusColumnName]: "",
       });
       continue;
     }
@@ -339,8 +370,8 @@ function compareRecordsNumerical(
       records.push({
         [attributeName1]: values1[i],
         [attributeName2]: values2[i],
-        [COMPARE_VALUE_COLUMN_NAME]: "",
-        [COMPARE_STATUS_COLUMN_NAME]: "",
+        [compareValueColumnName]: "",
+        [compareStatusColumnName]: "",
       });
       continue;
     }
@@ -349,8 +380,8 @@ function compareRecordsNumerical(
     records.push({
       [attributeName1]: values1[i],
       [attributeName2]: values2[i],
-      [COMPARE_VALUE_COLUMN_NAME]: difference,
-      [COMPARE_STATUS_COLUMN_NAME]:
+      [compareValueColumnName]: difference,
+      [compareStatusColumnName]:
         difference > 0 ? GREEN : difference < 0 ? RED : GREY,
     });
   }

--- a/src/transformers/compare.ts
+++ b/src/transformers/compare.ts
@@ -19,8 +19,8 @@ const GREEN = "rgb(0,255,0)";
 const RED = "rgb(255,0,0)";
 const GREY = "rgb(100,100,100)";
 
-const DECISION_1_COLUMN_NAME = "Category 1";
-const DECISION_2_COLUMN_NAME = "Category 2";
+const DECISION_1_COLUMN_BASE = "Category 1";
+const DECISION_2_COLUMN_BASE = "Category 2";
 
 export type CompareType = "numeric" | "categorical" | "structural";
 function isCompareType(s: unknown): s is CompareType {
@@ -241,14 +241,8 @@ function compareCategorical(
 
   const allAttributes = allAttrNames(dataset1).concat(allAttrNames(dataset2));
 
-  if (allAttributes.includes(DECISION_1_COLUMN_NAME)) {
-    throw new Error(`Attribute \`${DECISION_1_COLUMN_NAME}\` is needed by \
-    Compare. Please do not use it in the input datasets.`);
-  }
-  if (allAttributes.includes(DECISION_2_COLUMN_NAME)) {
-    throw new Error(`Attribute \`${DECISION_2_COLUMN_NAME}\` is needed by \
-    Compare. Please do not use it in the input datasets.`);
-  }
+  const decision1ColumnName = uniqueName(DECISION_1_COLUMN_BASE, allAttributes);
+  const decision2ColumnName = uniqueName(DECISION_2_COLUMN_BASE, allAttributes);
 
   const collections: Collection[] = [
     {
@@ -256,10 +250,10 @@ function compareCategorical(
       labels: {},
       attrs: [
         {
-          name: DECISION_1_COLUMN_NAME,
+          name: decision1ColumnName,
         },
         {
-          name: DECISION_2_COLUMN_NAME,
+          name: decision2ColumnName,
         },
       ],
     },
@@ -289,7 +283,7 @@ function compareCategorical(
       // If we didn't find a duplicate then just push the record
       records.push({
         ...record1,
-        [DECISION_1_COLUMN_NAME]: record1[attribute1Data.name],
+        [decision1ColumnName]: record1[attribute1Data.name],
       });
     } else {
       // If we did find a duplicate then merge the records, set the decision
@@ -297,8 +291,8 @@ function compareCategorical(
       records.push({
         ...record1,
         ...duplicate,
-        [DECISION_1_COLUMN_NAME]: record1[attribute1Data.name],
-        [DECISION_2_COLUMN_NAME]: duplicate[attribute2Data.name],
+        [decision1ColumnName]: record1[attribute1Data.name],
+        [decision2ColumnName]: duplicate[attribute2Data.name],
       });
     }
   }
@@ -317,7 +311,7 @@ function compareCategorical(
     } else {
       records.push({
         ...record2,
-        [DECISION_2_COLUMN_NAME]: record2[attribute2Data.name],
+        [decision2ColumnName]: record2[attribute2Data.name],
       });
     }
   }

--- a/src/transformers/fold.ts
+++ b/src/transformers/fold.ts
@@ -308,7 +308,10 @@ export async function differenceFrom({
 
   const { context, dataset } = await getContextAndDataSet(contextName);
   const ctxtName = readableName(context);
-  const resultAttributeName = `Difference From of ${inputAttributeName} in ${ctxtName}`;
+  const resultAttributeName = uniqueName(
+    `Difference From of ${inputAttributeName} in ${ctxtName}`,
+    allAttrNames(dataset)
+  );
 
   return [
     await uncheckedDifferenceFrom(

--- a/src/transformers/join.ts
+++ b/src/transformers/join.ts
@@ -1,10 +1,15 @@
-import { CodapAttribute, Collection } from "../utils/codapPhone/types";
+import { Collection } from "../utils/codapPhone/types";
 import { DataSet, TransformationOutput } from "./types";
 import { uniqueName } from "../utils/names";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { readableName } from "../transformer-components/util";
-import { shallowCopy, cloneCollection, cloneAttribute } from "./util";
+import {
+  shallowCopy,
+  cloneCollection,
+  cloneAttribute,
+  allAttrNames,
+} from "./util";
 
 /**
  * Joins two datasets together, using the baseDataset as a starting point
@@ -85,9 +90,7 @@ function uncheckedJoin(
   }
 
   // list of attributes whose names cannot be duplicated by the added attrs
-  const namesToAvoid = baseDataset.collections
-    .reduce((acc, coll) => acc.concat(coll.attrs || []), [] as CodapAttribute[])
-    .map((attr) => attr.name);
+  const namesToAvoid = allAttrNames(baseDataset);
 
   // ensure added attribute names are unique relative to attribute
   // names in base dataset (as well as all other added attributes)

--- a/src/transformers/pivot.ts
+++ b/src/transformers/pivot.ts
@@ -1,6 +1,7 @@
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
+import { uniqueName } from "../utils/names";
 import { DataSet, TransformationOutput } from "./types";
 import {
   eraseFormulas,
@@ -82,6 +83,11 @@ function uncheckedPivotLonger(
       `Pivot longer can only be used on a single-collection dataset`
     );
   }
+  if (namesTo === valuesTo) {
+    throw new Error(
+      `Please choose distinct names for the Names To and Values To attributes`
+    );
+  }
 
   // remove pivoting attributes
   const collection = { ...dataset.collections[0] };
@@ -91,7 +97,13 @@ function uncheckedPivotLonger(
   // NOTE: do not copy formulas: dependencies may be removed by the pivot
   eraseFormulas(collection.attrs);
 
-  const toPivotNames = toPivot.join(", ");
+  const toPivotNames = listAsString(toPivot);
+
+  // Ensure names to / values to are unique relative to attributes
+  // that will be included in pivoted table.
+  const remainingAttrs = collection.attrs?.map((attr) => attr.name) || [];
+  namesTo = uniqueName(namesTo, remainingAttrs);
+  valuesTo = uniqueName(valuesTo, remainingAttrs);
 
   // add namesTo and valuesTo attributes
   // NOTE: valuesTo might hold values of different types

--- a/src/transformers/util.ts
+++ b/src/transformers/util.ts
@@ -272,6 +272,13 @@ export function allAttrNames(dataset: DataSet): string[] {
 }
 
 /**
+ * Extract all collection names from the given dataset.
+ */
+export function allCollectionNames(dataset: DataSet): string[] {
+  return dataset.collections.map((coll) => coll.name);
+}
+
+/**
  * Type checks a certain attribute within a set of records. These checks are
  * fairly permissive since we can't count on the data returned from CODAP
  * being in a consistent format/type schema

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -39,7 +39,6 @@ import {
   itemFromContext,
   resourceFromComponent,
   collectionListFromContext,
-  attributeListFromCollection,
   caseById,
   allCasesWithSearch,
 } from "./resource";

--- a/src/utils/names.ts
+++ b/src/utils/names.ts
@@ -8,7 +8,9 @@ export function uniqueName(base: string, avoid: string[]): string {
     return base;
   }
 
-  const numberedName = (name: string, i: number) => `${name} (${i})`;
+  // NOTE: CODAP treats attribute names that have parenthesized expressions
+  // after them as indicating a unit. We use {} here to avoid this.
+  const numberedName = (name: string, i: number) => `${name} {${i}}`;
 
   // Otherwise find a suffix for the name that makes it unique
   let i = 1;


### PR DESCRIPTION
This goes back and patches some uses of generated names that weren't ensuring uniqueness. 

I also updated the centralized unique naming function to use `{n}` instead of `(n)` (not ideal, but `(n)` is interpreted as specifying a unit and so won't end up part of the attribute name. And it doesn't like `[n]` for data contexts for some reason).