### PR TITLE
Add undo functionality for transformer application

### DIFF
--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -304,13 +304,6 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
 
         const textName = await createText(name, String(result));
 
-        // Add action to undo stack
-        pushToUndoStack(
-          `Apply ${base} transformer`,
-          () => deleteText(textName),
-          transform
-        );
-
         // Workaround because the text doesn't show up after creation
         // See https://codap.concord.org/forums/topic/issue-creating-and-updating-text-views-through-data-interactive-api/#post-6483
         updateText(textName, String(result));

--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -244,7 +244,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
   useEffect(() => {
     async function fetchSavedState() {
       const savedState = (await getInteractiveFrame()).savedState;
-      if (savedState.DDTransformation) {
+      if (savedState && savedState.DDTransformation) {
         setState(savedState.DDTransformation);
       }
     }

--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -326,7 +326,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
       } else if (typeof result === "object") {
         // This is the case where the transformation returns a dataset
         const newContextName = await applyNewDataSet(result, name, description);
-        pushToUndoStack("Transformation applied", () =>
+        pushToUndoStack(`Undo ${base} transformer`, () =>
           deleteDataContext(newContextName)
         );
         if (order.includes("context1") && state["context1"] !== null) {

--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -305,7 +305,11 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
         const textName = await createText(name, String(result));
 
         // Add action to undo stack
-        pushToUndoStack(`Undo ${base} transformer`, () => deleteText(textName));
+        pushToUndoStack(
+          `Apply ${base} transformer`,
+          () => deleteText(textName),
+          transform
+        );
 
         // Workaround because the text doesn't show up after creation
         // See https://codap.concord.org/forums/topic/issue-creating-and-updating-text-views-through-data-interactive-api/#post-6483
@@ -332,8 +336,10 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
         const newContextName = await applyNewDataSet(result, name, description);
 
         // Add action to undo stack
-        pushToUndoStack(`Undo ${base} transformer`, () =>
-          deleteDataContext(newContextName)
+        pushToUndoStack(
+          `Undo ${base} transformer`,
+          () => deleteDataContext(newContextName),
+          transform
         );
 
         if (order.includes("context1") && state["context1"] !== null) {

--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -6,6 +6,7 @@ import {
   notifyInteractiveFrameIsDirty,
   deleteDataContext,
   updateText,
+  deleteText,
 } from "../utils/codapPhone";
 import { useAttributes } from "../utils/hooks";
 import {
@@ -303,6 +304,9 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
 
         const textName = await createText(name, String(result));
 
+        // Add action to undo stack
+        pushToUndoStack(`Undo ${base} transformer`, () => deleteText(textName));
+
         // Workaround because the text doesn't show up after creation
         // See https://codap.concord.org/forums/topic/issue-creating-and-updating-text-views-through-data-interactive-api/#post-6483
         updateText(textName, String(result));
@@ -326,9 +330,12 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
       } else if (typeof result === "object") {
         // This is the case where the transformation returns a dataset
         const newContextName = await applyNewDataSet(result, name, description);
+
+        // Add action to undo stack
         pushToUndoStack(`Undo ${base} transformer`, () =>
           deleteDataContext(newContextName)
         );
+
         if (order.includes("context1") && state["context1"] !== null) {
           addUpdateListener(
             state["context1"],

--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -6,7 +6,6 @@ import {
   notifyInteractiveFrameIsDirty,
   deleteDataContext,
   updateText,
-  deleteText,
 } from "../utils/codapPhone";
 import { useAttributes } from "../utils/hooks";
 import {

--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -4,6 +4,7 @@ import {
   createText,
   getInteractiveFrame,
   notifyInteractiveFrameIsDirty,
+  deleteDataContext,
   updateText,
 } from "../utils/codapPhone";
 import { useAttributes } from "../utils/hooks";
@@ -37,6 +38,7 @@ import {
 import { InteractiveState } from "../utils/codapPhone/types";
 import Popover from "../ui-components/Popover";
 import InfoIcon from "@material-ui/icons/Info";
+import { pushToUndoStack } from "../utils/codapPhone/listeners";
 
 // These types represent the configuration required for different UI elements
 interface ComponentInit {
@@ -324,6 +326,9 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
       } else if (typeof result === "object") {
         // This is the case where the transformation returns a dataset
         const newContextName = await applyNewDataSet(result, name, description);
+        pushToUndoStack("Transformation applied", () =>
+          deleteDataContext(newContextName)
+        );
         if (order.includes("context1") && state["context1"] !== null) {
           addUpdateListener(
             state["context1"],

--- a/src/transformer-components/TransformerREPLView.tsx
+++ b/src/transformer-components/TransformerREPLView.tsx
@@ -68,7 +68,7 @@ function TransformerREPLView(): ReactElement {
   useEffect(() => {
     async function fetchSavedState() {
       const savedState = (await getInteractiveFrame()).savedState;
-      if (savedState.transformerREPL) {
+      if (savedState && savedState.transformerREPL) {
         setTransformType(savedState.transformerREPL.transformer);
       }
     }

--- a/src/transformers/partition.ts
+++ b/src/transformers/partition.ts
@@ -4,7 +4,10 @@ import {
   updateContextWithDataSet,
   deleteDataContext,
 } from "../utils/codapPhone";
-import { addContextUpdateListener } from "../utils/codapPhone/listeners";
+import {
+  addContextUpdateListener,
+  pushToUndoStack,
+} from "../utils/codapPhone/listeners";
 import { codapValueToString } from "./util";
 import {
   DDTransformerProps,
@@ -114,6 +117,11 @@ export const partitionOverride = async (
       valueToContext[partitioned.distinctValueAsStr] = newContextName;
       outputContexts.push(newContextName);
     }
+
+    // Register undo action for partition transformer
+    pushToUndoStack("Undo partition transformer", () =>
+      outputContexts.forEach((context) => deleteDataContext(context))
+    );
 
     // listen for updates to the input data context
     addContextUpdateListener(inputDataCtxt, outputContexts, async () => {

--- a/src/transformers/partition.ts
+++ b/src/transformers/partition.ts
@@ -119,8 +119,18 @@ export const partitionOverride = async (
     }
 
     // Register undo action for partition transformer
-    pushToUndoStack("Undo partition transformer", () =>
-      outputContexts.forEach((context) => deleteDataContext(context))
+    console.log("Pushing partition undo");
+    pushToUndoStack(
+      "Apply partition transformer",
+      () => outputContexts.forEach((context) => deleteDataContext(context)),
+      () =>
+        partitionOverride(
+          { setErrMsg } as DDTransformerProps,
+          {
+            context1: inputDataCtxt,
+            attribute1: attributeName,
+          } as DDTransformerState
+        )
     );
 
     // listen for updates to the input data context

--- a/src/ui-components/TransformerSaveButton.tsx
+++ b/src/ui-components/TransformerSaveButton.tsx
@@ -55,7 +55,7 @@ export default function TransformerSaveButton({
   useEffect(() => {
     async function fetchSavedState() {
       const savedState = (await getInteractiveFrame()).savedState;
-      if (savedState.savedTransformation) {
+      if (savedState && savedState.savedTransformation) {
         setCurrentName(savedState.savedTransformation.name);
         setDescription(savedState.savedTransformation.description);
       }

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -35,6 +35,7 @@ import {
   removeListenersWithDependency,
   callAllInteractiveStateRequestListeners,
   popFromUndoStackAndExecute,
+  popFromRedoStackAndExecute,
   undoStack,
 } from "./listeners";
 import {
@@ -144,6 +145,14 @@ function codapRequestHandler(
   ) {
     // if CODAP notifies us it's undo time, then fire an undo callback
     popFromUndoStackAndExecute();
+    return;
+  }
+
+  if (
+    command.resource === CodapInitiatedResource.UndoChangeNotice &&
+    command.values.operation === "redoAction"
+  ) {
+    popFromRedoStackAndExecute();
     return;
   }
 

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -34,8 +34,8 @@ import {
   removeContextUpdateListenersForContext,
   removeListenersWithDependency,
   callAllInteractiveStateRequestListeners,
-  undoStackLength,
   popFromUndoStackAndExecute,
+  undoStack,
 } from "./listeners";
 import {
   resourceFromContext,
@@ -154,8 +154,8 @@ function codapRequestHandler(
     // If CODAP says the undo stack has been cleared, but we still have undo actions remaining,
     // send bogus `notifyUndoableActionPerformed` requests so we get our place back in
     // CODAP's undo stack.
-    for (let i = 0; i < undoStackLength(); i++) {
-      notifyUndoableActionPerformed("");
+    for (const [message] of undoStack) {
+      notifyUndoableActionPerformed(message);
     }
   }
 

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -807,6 +807,24 @@ export async function updateText(name: string, content: string): Promise<void> {
   );
 }
 
+export async function deleteText(name: string): Promise<void> {
+  return new Promise<void>((resolve, reject) =>
+    phone.call(
+      {
+        action: CodapActions.Delete,
+        resource: resourceFromComponent(name),
+      },
+      (response) => {
+        if (response.success) {
+          resolve();
+        } else {
+          reject(new Error("Failed to delete text"));
+        }
+      }
+    )
+  );
+}
+
 async function ensureUniqueName(
   name: string,
   resourceType: CodapListResource

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -36,7 +36,6 @@ import {
   callAllInteractiveStateRequestListeners,
   popFromUndoStackAndExecute,
   popFromRedoStackAndExecute,
-  undoStack,
   clearUndoAndRedoStacks,
 } from "./listeners";
 import {

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -37,6 +37,7 @@ import {
   popFromUndoStackAndExecute,
   popFromRedoStackAndExecute,
   undoStack,
+  clearUndoAndRedoStacks,
 } from "./listeners";
 import {
   resourceFromContext,
@@ -160,12 +161,7 @@ function codapRequestHandler(
     command.resource === CodapInitiatedResource.UndoChangeNotice &&
     command.values.operation === "clearUndo"
   ) {
-    // If CODAP says the undo stack has been cleared, but we still have undo actions remaining,
-    // send bogus `notifyUndoableActionPerformed` requests so we get our place back in
-    // CODAP's undo stack.
-    for (const [message] of undoStack) {
-      notifyUndoableActionPerformed(message);
-    }
+    clearUndoAndRedoStacks();
   }
 
   // notification of which data context was deleted

--- a/src/utils/codapPhone/listeners.ts
+++ b/src/utils/codapPhone/listeners.ts
@@ -1,3 +1,4 @@
+import { notifyUndoableActionPerformed } from ".";
 import { InteractiveState } from "./types";
 
 // Listen for saved state requests.
@@ -30,6 +31,20 @@ export function callAllInteractiveStateRequestListeners(): InteractiveState {
     state = f(state);
   }
   return state;
+
+
+// The undo stack and related functions allow pushing and popping callbacks
+// that will be fired if CODAP notifies us that an undo request has been
+// initiated
+export const undoStack: Array<() => void> = [];
+
+export function pushToUndoStack(message: string, callback: () => void): void {
+  notifyUndoableActionPerformed(message);
+  newContextListeners.push(callback);
+}
+
+export function popFromUndoStack(): (() => void) | undefined {
+  return newContextListeners.pop();
 }
 
 // Listen for new or removed data contexts

--- a/src/utils/codapPhone/listeners.ts
+++ b/src/utils/codapPhone/listeners.ts
@@ -36,17 +36,23 @@ export function callAllInteractiveStateRequestListeners(): InteractiveState {
 // The undo stack and related functions allow pushing and popping callbacks
 // that will be fired if CODAP notifies us that an undo request has been
 // initiated
-export const undoStack: Array<[string, () => void]> = [];
+export const undoStack: Array<[string, () => void, () => void]> = [];
+export const redoStack: Array<[string, () => void, () => void]> = [];
 /**
  * Add an item to the undo stack. CODAP will be notified that an undoable action
  * has been performed and the callback will be saved in a stack. If CODAP tells
  * us its time to undo, the callback will be executed.
  * @param message the tooltip that CODAP will display if this undo action is next
  * @param callback the callback that will be fired if undo is pressed
+ * @param redoCallback the callback to add to the redo queue
  */
-export function pushToUndoStack(message: string, callback: () => void): void {
+export function pushToUndoStack(
+  message: string,
+  callback: () => void,
+  redoCallback: () => void
+): void {
   notifyUndoableActionPerformed(message);
-  undoStack.push([message, callback]);
+  undoStack.push([message, callback, redoCallback]);
 }
 
 /**
@@ -58,6 +64,24 @@ export function popFromUndoStackAndExecute(): boolean {
   if (popped) {
     // If there was a callback left, execute it
     popped[1]();
+    redoStack.push(popped);
+    return true;
+  } else {
+    // If no callback, return false
+    return false;
+  }
+}
+
+/**
+ *  Pops a callback form the redo stack and executes it
+ * @returns false if the redo stack is empty, true otherwise
+ */
+export function popFromRedoStackAndExecute(): boolean {
+  const popped = redoStack.pop();
+  if (popped) {
+    // If there was a callback left, execute it
+    popped[2]();
+    undoStack.push(popped);
     return true;
   } else {
     // If no callback, return false

--- a/src/utils/codapPhone/listeners.ts
+++ b/src/utils/codapPhone/listeners.ts
@@ -31,7 +31,7 @@ export function callAllInteractiveStateRequestListeners(): InteractiveState {
     state = f(state);
   }
   return state;
-
+}
 
 // The undo stack and related functions allow pushing and popping callbacks
 // that will be fired if CODAP notifies us that an undo request has been
@@ -40,11 +40,11 @@ export const undoStack: Array<() => void> = [];
 
 export function pushToUndoStack(message: string, callback: () => void): void {
   notifyUndoableActionPerformed(message);
-  newContextListeners.push(callback);
+  undoStack.push(callback);
 }
 
 export function popFromUndoStack(): (() => void) | undefined {
-  return newContextListeners.pop();
+  return undoStack.pop();
 }
 
 // Listen for new or removed data contexts

--- a/src/utils/codapPhone/listeners.ts
+++ b/src/utils/codapPhone/listeners.ts
@@ -36,8 +36,12 @@ export function callAllInteractiveStateRequestListeners(): InteractiveState {
 // The undo stack and related functions allow pushing and popping callbacks
 // that will be fired if CODAP notifies us that an undo request has been
 // initiated
-export const undoStack: Array<[string, () => void, () => void]> = [];
-export const redoStack: Array<[string, () => void, () => void]> = [];
+export let undoStack: Array<[string, () => void, () => void]> = [];
+export let redoStack: Array<[string, () => void, () => void]> = [];
+export const clearUndoAndRedoStacks = (): void => {
+  undoStack = [];
+  redoStack = [];
+};
 /**
  * Add an item to the undo stack. CODAP will be notified that an undoable action
  * has been performed and the callback will be saved in a stack. If CODAP tells

--- a/src/utils/codapPhone/listeners.ts
+++ b/src/utils/codapPhone/listeners.ts
@@ -36,7 +36,7 @@ export function callAllInteractiveStateRequestListeners(): InteractiveState {
 // The undo stack and related functions allow pushing and popping callbacks
 // that will be fired if CODAP notifies us that an undo request has been
 // initiated
-const undoStack: Array<[string, () => void]> = [];
+export const undoStack: Array<[string, () => void]> = [];
 /**
  * Add an item to the undo stack. CODAP will be notified that an undoable action
  * has been performed and the callback will be saved in a stack. If CODAP tells
@@ -63,13 +63,6 @@ export function popFromUndoStackAndExecute(): boolean {
     // If no callback, return false
     return false;
   }
-}
-
-/**
- * Get the length of the undo stack
- */
-export function undoStackLength(): number {
-  return undoStack.length;
 }
 
 // Listen for new or removed data contexts

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -8,6 +8,7 @@ export enum CodapResource {
   Collection = "collection",
   CollectionList = "collectionList",
   FormulaEngine = "formulaEngine",
+  UndoChangeNotice = "undoChangeNotice",
 }
 
 export enum CodapListResource {
@@ -121,6 +122,18 @@ export interface UpdateTextRequest {
   values: Partial<Text>;
 }
 
+export interface NotifyUndoChangeNoticeRequest {
+  action: CodapActions.Notify;
+  resource: CodapResource.UndoChangeNotice;
+  values:
+    | {
+        operation: "undoAction" | "redoAction" | "clearUndo" | "clearRedo";
+        canUndo: boolean;
+        canRedo: boolean;
+      }
+    | { operation: "undoableActionPerformed"; logMessage?: string };
+}
+
 export interface EvalExpressionRequest {
   action: CodapActions.Notify;
   resource: CodapResource.FormulaEngine;
@@ -232,6 +245,7 @@ export type CodapPhone = {
     r: GetFunctionInfoRequest,
     cb: (r: GetFunctionInfoResponse) => void
   ): void;
+  call(r: NotifyUndoChangeNoticeRequest, cb: (r: CodapResponse) => void): void;
   call(r: CodapRequest[], cb: (r: CodapResponse[]) => void): void;
 };
 
@@ -307,7 +321,7 @@ export type CodapInitiatedCommand =
       action: CodapActions.Notify;
       resource: CodapInitiatedResource.UndoChangeNotice;
       values: {
-        operation: string;
+        operation: "undoAction" | "redoAction" | "clearUndo" | "clearRedo";
         canUndo: boolean;
         canRedo: boolean;
       };


### PR DESCRIPTION
This PR adds the ability to use the CODAP undo button to delete tables that have just been created by a transformer application. At present, this is the only undoable functionality.

## Design decisions
If the user takes certain actions that are hard to undo/redo (like creating/deleting tables), CODAP clear it's undo/redo stack and start over (the undo/redo buttons will be grayed out). CODAP informs us of this so we can also clear the plugins internal undo/redo stack that we're tracking.

Since all our undo functionality involves deleting tables, the user will only ever be able to undo one transformer application before CODAP clears its undo functionality. This PR implements the following hack to get around that: if CODAP tells us to clear the undo stack but we still have undoable actions left, instead of clearing the undo stack we call `notifyUndoableActionPerformed()` once for every remaining action in the plugin's undo stack. This tells CODAP to put the plugin back in the undo stack and lets the user perform more "undo"s of transformer application.

However, this could result in undesirable behavior. Suppose we have the following stack of events:
```
<oldest event>
Transformers: Apply build column transformation to create table "A"
CODAP: rename attribute in "A"
CODAP: move attribute in "A"
CODAP: add case to "A"
CODAP: add case to "A"
Transformers: Apply copy transformation to "A"
<newest event>
```
With the current functionality, if the user presses undo once, the copy of "A" will be deleted. If they press undo again, "A" will be deleted. This might be shocking, since the user probably expects to undo adding the case to "A".

**I think this is a decision we have to make regarding the risk of having more powerful behavior at the of confusing edge cases. I'd be curious to hear your thoughts.**

## Troubles with redo
It looks like we won't be able to have redo without some hefty CODAP changes. Here's why:

Suppose we tell CODAP an undoable action has been performed when someone hits "apply transformer" to create a table. Then, if the user presses undo in CODAP, CODAP will inform us and we can delete the table. 

Ideally, the redo button should now be enabled, and if the user hits "redo" CODAP will inform us and we can re-create the deleted table. The issue is, CODAP treats deleting a table as an undo-clearing action. Since our undo functionality relies on deleting a table, the undo/redo stack is cleared and the user can't hit redo to recreate the table. This means even though our architecture _could_ support undo/redo of transformation application, the user won't be able to use them since CODAP keeps clearing the undo/redo stack.

## What else should be undoable
Are there any other plugin-related actions that should be undoable? We already get undo for free in an expression editor from codemirror.