### PR TITLE
allow editing of saved transformers

### DIFF
--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -202,6 +202,7 @@ export type DDTransformerProps = {
   base: BaseTransformerName;
   init: DDTransformerInit;
   saveData?: DDTransformerState;
+  editable: boolean;
   info: {
     summary: string;
     consumes: string;
@@ -224,6 +225,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
     info,
     base,
     saveData,
+    editable,
     errorDisplay,
     setErrMsg,
   } = props;
@@ -406,7 +408,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
                   notifyStateIsDirty();
                   setState({ [component]: e.target.value });
                 }}
-                disabled={saveData !== undefined}
+                disabled={!editable}
               />
             </div>
           );
@@ -425,7 +427,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
                   notifyStateIsDirty();
                   setState({ [component]: s });
                 }}
-                disabled={saveData !== undefined}
+                disabled={!editable}
               />
             </div>
           );
@@ -448,7 +450,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
                   setState({ [component]: s });
                 }}
                 selected={state[component]}
-                disabled={saveData !== undefined}
+                disabled={!editable}
               />
             </div>
           );
@@ -459,7 +461,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
               <TextInput
                 value={state[component]}
                 onChange={(e) => setState({ [component]: e.target.value })}
-                disabled={saveData !== undefined}
+                disabled={!editable}
                 onBlur={notifyStateIsDirty}
               />
             </div>
@@ -477,7 +479,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
                 options={tmp.options}
                 value={state[component]}
                 defaultValue={tmp.defaultValue}
-                disabled={saveData !== undefined}
+                disabled={!editable}
               />
             </div>
           ) : (
@@ -504,7 +506,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
                   });
                 }}
                 inputTypeDisabled={
-                  init[component]?.inputTypeDisabled || saveData !== undefined
+                  init[component]?.inputTypeDisabled || !editable
                 }
                 outputTypes={tmp.outputTypes}
                 selectedOutputType={state[component].outputType}
@@ -518,7 +520,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
                   });
                 }}
                 outputTypeDisabled={
-                  init[component]?.outputTypeDisabled || saveData !== undefined
+                  init[component]?.outputTypeDisabled || !editable
                 }
               />
             </div>
@@ -537,7 +539,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
                     | "attributes1"
                     | "attributes2"
                 ].map((a) => a.name)}
-                disabled={saveData !== undefined}
+                disabled={!editable}
                 onBlur={notifyStateIsDirty}
               />
             </div>

--- a/src/transformer-components/SavedTransformerView.css
+++ b/src/transformer-components/SavedTransformerView.css
@@ -1,0 +1,12 @@
+
+.editing-indicator {
+    margin-bottom: 10px;
+    background-color: #ffffe6;
+    padding: 6px;
+    border: solid 1px #b3b300;
+    border-radius: 5px;
+}
+
+.editing-indicator * {
+    color: #b3b300;
+}

--- a/src/transformer-components/SavedTransformerView.css
+++ b/src/transformer-components/SavedTransformerView.css
@@ -10,3 +10,7 @@
 .editing-indicator * {
     color: #999900;
 }
+
+.divider {
+    margin-top: 10px;
+}

--- a/src/transformer-components/SavedTransformerView.css
+++ b/src/transformer-components/SavedTransformerView.css
@@ -3,10 +3,10 @@
     margin-bottom: 10px;
     background-color: #ffffe6;
     padding: 6px;
-    border: solid 1px #b3b300;
+    border: solid 1px #999900;
     border-radius: 5px;
 }
 
 .editing-indicator * {
-    color: #b3b300;
+    color: #999900;
 }

--- a/src/transformer-components/SavedTransformerView.tsx
+++ b/src/transformer-components/SavedTransformerView.tsx
@@ -15,6 +15,8 @@ import {
   addInteractiveStateRequestListener,
   removeInteractiveStateRequestListener,
 } from "../utils/codapPhone/listeners";
+import "../ui-components/TransformerSaveButton.css";
+import "./SavedTransformerView.css";
 
 /**
  * SavedTransformerView wraps a saved transformer in other important info
@@ -28,6 +30,7 @@ function SavedTransformerView({
   const [errMsg, setErrMsg] = useState<string | null>(null);
   const [editable, setEditable] = useState<boolean>(false);
   const [savedTransformer, setSavedTransformer] = useState(urlTransformer);
+  const [saveErr, setSaveErr] = useState<string | null>(null);
 
   // Load saved state from CODAP memory
   useEffect(() => {
@@ -68,13 +71,20 @@ function SavedTransformerView({
 
   return (
     <div className="transformer-view">
+      {editable && (
+        <div className="editing-indicator">
+          <p>You are editing this transformer...</p>
+        </div>
+      )}
       {editable ? (
         <TextInput
           value={savedTransformer.name}
-          onChange={(e) =>
-            setSavedTransformer({ ...savedTransformer, name: e.target.value })
-          }
+          onChange={(e) => {
+            setSavedTransformer({ ...savedTransformer, name: e.target.value });
+            setSaveErr(null);
+          }}
           placeholder={"Transformer Name"}
+          className="saved-transformer-name"
           onBlur={notifyStateIsDirty}
         />
       ) : (
@@ -86,13 +96,15 @@ function SavedTransformerView({
       {editable ? (
         <TextArea
           value={savedTransformer.description || ""}
-          onChange={(e) =>
+          onChange={(e) => {
             setSavedTransformer({
               ...savedTransformer,
               description: e.target.value,
-            })
-          }
+            });
+            setSaveErr(null);
+          }}
           placeholder="Purpose Statement"
+          className="purpose-statement"
           onBlur={notifyStateIsDirty}
         />
       ) : (
@@ -106,7 +118,15 @@ function SavedTransformerView({
       />
       <button
         id="edit-button"
-        onClick={() => setEditable(!editable)}
+        onClick={() => {
+          // if going to non-editable (saving) and name is blank
+          if (editable && savedTransformer.name.trim() === "") {
+            setSaveErr("Please choose a name for the transformer");
+            return;
+          }
+
+          setEditable(!editable);
+        }}
         title={
           editable
             ? "Save changes made to this transformer"
@@ -115,6 +135,7 @@ function SavedTransformerView({
       >
         {editable ? "Save" : "Edit"}
       </button>
+      <ErrorDisplay message={saveErr} />
     </div>
   );
 }

--- a/src/transformer-components/SavedTransformerView.tsx
+++ b/src/transformer-components/SavedTransformerView.tsx
@@ -15,6 +15,7 @@ function SavedTransformerView({
   transformer: SavedTransformer;
 }): ReactElement {
   const [errMsg, setErrMsg] = useState<string | null>(null);
+  const [editable, setEditable] = useState<boolean>(false);
 
   return (
     <div className="transformer-view">
@@ -27,7 +28,9 @@ function SavedTransformerView({
         setErrMsg={setErrMsg}
         errorDisplay={<ErrorDisplay message={errMsg} />}
         transformer={urlTransformer}
+        editable={editable}
       />
+      <button onClick={() => setEditable(!editable)}>Edit</button>
     </div>
   );
 }

--- a/src/transformer-components/SavedTransformerView.tsx
+++ b/src/transformer-components/SavedTransformerView.tsx
@@ -74,7 +74,7 @@ function SavedTransformerView({
     <div className="transformer-view">
       {editable && (
         <div className="editing-indicator">
-          <p>You are editing this transformer...</p>
+          <p>You are editing this transformer</p>
         </div>
       )}
       {editable ? (
@@ -95,19 +95,22 @@ function SavedTransformerView({
         </h2>
       )}
       {editable ? (
-        <TextArea
-          value={savedTransformer.description || ""}
-          onChange={(e) => {
-            setSavedTransformer({
-              ...savedTransformer,
-              description: e.target.value,
-            });
-            setSaveErr(null);
-          }}
-          placeholder="Purpose Statement"
-          className="purpose-statement"
-          onBlur={notifyStateIsDirty}
-        />
+        <>
+          <TextArea
+            value={savedTransformer.description || ""}
+            onChange={(e) => {
+              setSavedTransformer({
+                ...savedTransformer,
+                description: e.target.value,
+              });
+              setSaveErr(null);
+            }}
+            placeholder="Purpose Statement"
+            className="purpose-statement"
+            onBlur={notifyStateIsDirty}
+          />
+          <hr className="divider" />
+        </>
       ) : (
         savedTransformer.description && <p>{savedTransformer.description}</p>
       )}

--- a/src/transformer-components/SavedTransformerView.tsx
+++ b/src/transformer-components/SavedTransformerView.tsx
@@ -30,7 +30,17 @@ function SavedTransformerView({
         transformer={urlTransformer}
         editable={editable}
       />
-      <button onClick={() => setEditable(!editable)}>Edit</button>
+      <button
+        id="edit-button"
+        onClick={() => setEditable(!editable)}
+        title={
+          editable
+            ? "Save changes made to this transformer"
+            : "Make changes to this transformer"
+        }
+      >
+        {editable ? "Save" : "Edit"}
+      </button>
     </div>
   );
 }

--- a/src/transformer-components/SavedTransformerView.tsx
+++ b/src/transformer-components/SavedTransformerView.tsx
@@ -4,6 +4,17 @@ import "./TransformerViews.css";
 import ErrorDisplay from "../ui-components/Error";
 import { SavedTransformer } from "./types";
 import { TransformerRenderer } from "./TransformerRenderer";
+import { TextArea, TextInput } from "../ui-components";
+import {
+  getInteractiveFrame,
+  notifyInteractiveFrameIsDirty,
+} from "../utils/codapPhone";
+import { useEffect } from "react";
+import { InteractiveState } from "../utils/codapPhone/types";
+import {
+  addInteractiveStateRequestListener,
+  removeInteractiveStateRequestListener,
+} from "../utils/codapPhone/listeners";
 
 /**
  * SavedTransformerView wraps a saved transformer in other important info
@@ -16,18 +27,81 @@ function SavedTransformerView({
 }): ReactElement {
   const [errMsg, setErrMsg] = useState<string | null>(null);
   const [editable, setEditable] = useState<boolean>(false);
+  const [savedTransformer, setSavedTransformer] = useState(urlTransformer);
+
+  // Load saved state from CODAP memory
+  useEffect(() => {
+    async function fetchSavedState() {
+      const savedState = (await getInteractiveFrame()).savedState;
+      if (savedState && savedState.savedTransformation) {
+        setSavedTransformer({
+          ...savedTransformer,
+          name: savedState.savedTransformation.name,
+          description: savedState.savedTransformation.description,
+        });
+      }
+    }
+    fetchSavedState();
+  }, []);
+
+  // Register a listener to generate the plugin's state
+  useEffect(() => {
+    const callback = (
+      previousInteractiveState: InteractiveState
+    ): InteractiveState => {
+      return {
+        ...previousInteractiveState,
+        savedTransformation: {
+          name: savedTransformer.name,
+          description: savedTransformer.description || "",
+        },
+      };
+    };
+
+    addInteractiveStateRequestListener(callback);
+    return () => removeInteractiveStateRequestListener(callback);
+  }, [savedTransformer]);
+
+  function notifyStateIsDirty() {
+    notifyInteractiveFrameIsDirty();
+  }
 
   return (
     <div className="transformer-view">
-      <h2>
-        {urlTransformer.name}
-        <span id="transformerBase"> ({urlTransformer.content.base})</span>
-      </h2>
-      {urlTransformer.description && <p>{urlTransformer.description}</p>}
+      {editable ? (
+        <TextInput
+          value={savedTransformer.name}
+          onChange={(e) =>
+            setSavedTransformer({ ...savedTransformer, name: e.target.value })
+          }
+          placeholder={"Transformer Name"}
+          onBlur={notifyStateIsDirty}
+        />
+      ) : (
+        <h2>
+          {savedTransformer.name}
+          <span id="transformerBase"> ({savedTransformer.content.base})</span>
+        </h2>
+      )}
+      {editable ? (
+        <TextArea
+          value={savedTransformer.description || ""}
+          onChange={(e) =>
+            setSavedTransformer({
+              ...savedTransformer,
+              description: e.target.value,
+            })
+          }
+          placeholder="Purpose Statement"
+          onBlur={notifyStateIsDirty}
+        />
+      ) : (
+        savedTransformer.description && <p>{savedTransformer.description}</p>
+      )}
       <TransformerRenderer
         setErrMsg={setErrMsg}
         errorDisplay={<ErrorDisplay message={errMsg} />}
-        transformer={urlTransformer}
+        transformer={savedTransformer}
         editable={editable}
       />
       <button

--- a/src/transformer-components/SavedTransformerView.tsx
+++ b/src/transformer-components/SavedTransformerView.tsx
@@ -8,6 +8,7 @@ import { TextArea, TextInput } from "../ui-components";
 import {
   getInteractiveFrame,
   notifyInteractiveFrameIsDirty,
+  updateInteractiveFrame,
 } from "../utils/codapPhone";
 import { useEffect } from "react";
 import { InteractiveState } from "../utils/codapPhone/types";
@@ -123,6 +124,13 @@ function SavedTransformerView({
           if (editable && savedTransformer.name.trim() === "") {
             setSaveErr("Please choose a name for the transformer");
             return;
+          }
+
+          // if saving, update the interactive frame to use the new transformer name
+          if (editable) {
+            updateInteractiveFrame({
+              title: `Transformer: ${savedTransformer.name}`,
+            });
           }
 
           setEditable(!editable);

--- a/src/transformer-components/TransformerREPLView.tsx
+++ b/src/transformer-components/TransformerREPLView.tsx
@@ -125,6 +125,7 @@ function TransformerREPLView(): ReactElement {
         transformer={baseTransformers.find(
           ({ name }) => name === transformType
         )}
+        editable={true}
       />
     </div>
   );

--- a/src/transformer-components/TransformerRenderer.tsx
+++ b/src/transformer-components/TransformerRenderer.tsx
@@ -5,6 +5,7 @@ import transformerList from "./transformerList";
 
 interface TransformerRendererProps {
   transformer?: SavedTransformer;
+  editable: boolean;
   setErrMsg: (s: string | null) => void;
   errorDisplay: ReactElement;
 }
@@ -14,6 +15,7 @@ interface TransformerRendererProps {
  */
 export const TransformerRenderer = ({
   transformer,
+  editable,
   setErrMsg,
   errorDisplay,
 }: TransformerRendererProps): ReactElement => {
@@ -34,6 +36,7 @@ export const TransformerRenderer = ({
           info={transformerList[key].componentData.info}
           base={transformer.content.base}
           saveData={transformer.content.data}
+          editable={editable}
         />
       );
     }

--- a/src/transformer-components/TransformerViews.css
+++ b/src/transformer-components/TransformerViews.css
@@ -12,3 +12,7 @@
   color: gray;
   font-size: 0.7em;
 }
+
+#edit-button {
+  margin-top: 5px;
+}

--- a/src/ui-components/ExpressionEditor.tsx
+++ b/src/ui-components/ExpressionEditor.tsx
@@ -137,14 +137,13 @@ export default function ExpressionEditor({
             completeSingle: false,
             hint: codapFormulaHints,
           },
+          readOnly: disabled,
         }}
         onInputRead={(editor) => {
           editor.showHint();
         }}
         onBeforeChange={(editor, data, value) => {
-          if (!disabled) {
-            onChange(value);
-          }
+          onChange(value);
         }}
         onBlur={onBlur}
       />

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -74,18 +74,24 @@ const DEFAULT_PLUGIN_HEIGHT = 500;
 
 // Initialize
 export async function initPhone(title: string): Promise<void> {
+  return updateInteractiveFrame({
+    title,
+    dimensions: {
+      width: DEFAULT_PLUGIN_WIDTH,
+      height: DEFAULT_PLUGIN_HEIGHT,
+    },
+  });
+}
+
+export async function updateInteractiveFrame(
+  values: Partial<Omit<InteractiveFrame, "interactiveState">>
+): Promise<void> {
   return new Promise<void>((resolve, reject) =>
     phone.call(
       {
         action: CodapActions.Update,
         resource: CodapResource.InteractiveFrame,
-        values: {
-          title,
-          dimensions: {
-            width: DEFAULT_PLUGIN_WIDTH,
-            height: DEFAULT_PLUGIN_HEIGHT,
-          },
-        },
+        values,
       },
       (response) => {
         // NOTE: Ensure the response exists, since if this is run

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -72,19 +72,20 @@ const phone: CodapPhone = new IframePhoneRpcEndpoint(
 const DEFAULT_PLUGIN_WIDTH = 350;
 const DEFAULT_PLUGIN_HEIGHT = 500;
 
-// Initialize
+// Initialize the interactive frame with a given title.
 export async function initPhone(title: string): Promise<void> {
+  const hasState = (await getInteractiveFrame()).savedState !== undefined;
   // Only resize the plugin to default dimensions if this is it's
   // first time being initialized (no savedState)
-  const dimensions =
-    (await getInteractiveFrame()).savedState === undefined
-      ? {
-          width: DEFAULT_PLUGIN_WIDTH,
-          height: DEFAULT_PLUGIN_HEIGHT,
-        }
-      : undefined;
+  const dimensions = hasState
+    ? {
+        width: DEFAULT_PLUGIN_WIDTH,
+        height: DEFAULT_PLUGIN_HEIGHT,
+      }
+    : undefined;
   return updateInteractiveFrame({
-    title,
+    // Don't update the title if there is save data.
+    title: hasState ? undefined : title,
     dimensions,
   });
 }


### PR DESCRIPTION
This adds support for editing transformers that have already been saved. You are able to edit any of the inputs to the transformer, but not its name/purpose statement.

You can edit by clicking the Edit button (seen below), at which point disabled inputs will become enabled. The button toggles whether or not inputs are disabled.

![edit](https://user-images.githubusercontent.com/13399527/124313020-4b236c00-db3e-11eb-8900-cbaae5671a42.png)