### PR TITLE
Don't resize plugin to default dimensions when opening existing file

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,54 +4,57 @@ import { SavedTransformer } from "./transformer-components/types";
 import TransformerREPLView from "./transformer-components/TransformerREPLView";
 import { initPhone } from "./utils/codapPhone";
 import "./App.css";
+import { useEffect } from "react";
 
 export const App = (): ReactElement => {
   type ReadyStatus = "loading" | "ready" | "error";
   const [status, setStatus] = useState<ReadyStatus>("loading");
+  const [pluginContent, setPluginContent] = useState<ReactElement>(<></>);
 
-  const loadingMsg = <p className="loading">Connecting to CODAP...</p>;
-  const initErrorMsg = (
-    <p className="initError">
-      Could not connect to CODAP. Please make sure you are using Transformers
-      within CODAP.
-    </p>
-  );
+  // On first render, initialize the plugin and parse the URL to see
+  // if we need to render a saved transformation
+  useEffect(() => {
+    /**
+     * Initializes a new data interactive (plugin) with the given name,
+     * and turns off loading once it has succeeded, or indicates an
+     * error should be displayed if it fails.
+     */
+    const initWithPluginName = (name: string): void => {
+      initPhone(name)
+        .then(() => {
+          setStatus("ready");
+        })
+        .catch(() => {
+          setStatus("error");
+        });
+    };
 
-  /**
-   * Initializes a new data interactive (plugin) with the given name,
-   * and turns off loading once it has succeeded, or indicates an
-   * error should be displayed if it fails.
-   */
-  const initWithPluginName = (name: string): void => {
-    initPhone(name)
-      .then(() => {
-        setStatus("ready");
-      })
-      .catch(() => {
-        setStatus("error");
-      });
-  };
+    const parsedUrl = new URL(window.location.href);
+    const transformer = parsedUrl.searchParams.get("transform");
+    if (transformer === null) {
+      initWithPluginName("Transformers");
+      setPluginContent(<TransformerREPLView />);
+    } else {
+      const parsedTransformer: SavedTransformer = JSON.parse(
+        decodeURIComponent(transformer)
+      );
 
-  const parsedUrl = new URL(window.location.href);
-  const transformer = parsedUrl.searchParams.get("transform");
-  let pluginContent: JSX.Element;
-
-  if (transformer === null) {
-    initWithPluginName("Transformers");
-    pluginContent = <TransformerREPLView />;
-  } else {
-    const parsedTransformer: SavedTransformer = JSON.parse(
-      decodeURIComponent(transformer)
-    );
-
-    initWithPluginName(`Transformer: ${parsedTransformer.name}`);
-    pluginContent = <SavedTransformerView transformer={parsedTransformer} />;
-  }
+      initWithPluginName(`Transformer: ${parsedTransformer.name}`);
+      setPluginContent(
+        <SavedTransformerView transformer={parsedTransformer} />
+      );
+    }
+  }, []);
 
   if (status === "error") {
-    return initErrorMsg;
+    return (
+      <p className="initError">
+        Could not connect to CODAP. Please make sure you are using Transformers
+        within CODAP.
+      </p>
+    );
   } else if (status === "loading") {
-    return loadingMsg;
+    return <p className="loading">Connecting to CODAP...</p>;
   } else {
     return pluginContent;
   }

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -74,6 +74,16 @@ const DEFAULT_PLUGIN_HEIGHT = 320;
 
 // Initialize
 export async function initPhone(title: string): Promise<void> {
+  // Only resize the plugin to default dimensions if this is it's
+  // first time being initialized (no savedState)
+  const dimensions =
+    (await getInteractiveFrame()).savedState === undefined
+      ? {
+          width: DEFAULT_PLUGIN_WIDTH,
+          height: DEFAULT_PLUGIN_HEIGHT,
+        }
+      : undefined;
+
   return new Promise<void>((resolve, reject) =>
     phone.call(
       {
@@ -81,10 +91,7 @@ export async function initPhone(title: string): Promise<void> {
         resource: CodapResource.InteractiveFrame,
         values: {
           title,
-          dimensions: {
-            width: DEFAULT_PLUGIN_WIDTH,
-            height: DEFAULT_PLUGIN_HEIGHT,
-          },
+          dimensions,
         },
       },
       (response) => {
@@ -233,6 +240,7 @@ export function getInteractiveFrame(): Promise<InteractiveFrame> {
       },
       (response) => {
         if (response.success) {
+          console.log(response.values);
           resolve(response.values);
         } else {
           reject(new Error("Failed to get interactive frame."));


### PR DESCRIPTION
Fixes #110. When opening a new file with `Transformers`, it should still be resized to the default dimensions. However, if you open a CODAP file that contains `Transformers`, it will stay at its current size.

Also added a useEffect hook to stop initialization logic in `App` from being fired multiple times.