### PR TITLE
recognize color values when formatting

### DIFF
--- a/src/transformers/util.ts
+++ b/src/transformers/util.ts
@@ -182,8 +182,7 @@ export function pluralSuffix<T>(word: string, describing: T[]): string {
 }
 
 /**
- * Converts a CODAP cell value into a user-friendly string
- * for printing in error messages.
+ * Converts a CODAP cell value into a user-friendly string.
  *
  * @param codapValue the value to convert to a string for printing
  * @returns string version of the value
@@ -207,6 +206,11 @@ export function codapValueToString(codapValue: unknown): string {
   // numeric values
   if (!isNaN(Number(codapValue))) {
     return String(codapValue);
+  }
+
+  // colors
+  if (isColor(codapValue)) {
+    return `the color ${codapValue}`;
   }
 
   // boundaries
@@ -243,6 +247,26 @@ export function isBoundaryMap(value: unknown): boolean {
 export function isBoundary(value: unknown): boolean {
   return (
     typeof value === "object" && value !== null && "jsonBoundaryObject" in value
+  );
+}
+
+/**
+ * Determines if a given CODAP value is a color.
+ */
+export function isColor(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const noWhitespace = value.replace(/\s+/g, "");
+
+  // Hex, rgb, and rgba are the allowed syntaxes for defining color values in CODAP.
+  // Source: https://github.com/concord-consortium/codap/wiki/CODAP-Data-
+  // Interactive-Plugin-API#data-types-and-typeless-data
+  return (
+    /#[0-9a-fA-F]{6}/.test(noWhitespace) ||
+    /rgb\(\d{1,3},\d{1,3},\d{1,3}\)/.test(noWhitespace) ||
+    /rgba\(\d{1,3},\d{1,3},\d{1,3},(0|1)?\.\d*\)/.test(noWhitespace)
   );
 }
 


### PR DESCRIPTION
This adds support for recognizing CODAP color values when we go to format colors for printing. For instance, this is used in the titles of partitioned datasets:

![partition](https://user-images.githubusercontent.com/13399527/124614839-ac02bb00-de42-11eb-94ea-a95a006d78fc.png)

It also comes up in error messages:

![color-error](https://user-images.githubusercontent.com/13399527/124614850-ae651500-de42-11eb-9a0d-379f2b761745.png)

I figure it's good to expose the underlying hex/rgb/rgba color values--in the event the user didn't create it themselves and doesn't understand it, they'll still see "color" and know it was a color, and in the event they did create it of their own accord, knowing the color values might provide critical info (I prefer this to just showing "a color").