### PR TITLE
fix partition naming bug and make partitioned values clearer

### DIFF
--- a/src/transformers/partition.ts
+++ b/src/transformers/partition.ts
@@ -51,9 +51,9 @@ export const partitionOverride = async (
     // return both the datasets and their names
     return partitioned.map((pd) => [
       pd,
-      `Partition of ${readableContext} by ${attributeName} = ${codapValueToString(
+      `${attributeName} = ${codapValueToString(
         pd.distinctValue
-      )}`,
+      )} in ${readableContext}`,
     ]);
   };
 
@@ -105,11 +105,18 @@ export const partitionOverride = async (
     let valueToContext: Record<string, string> = {};
     const outputContexts: string[] = [];
 
+    const { context: inputContext } = await getContextAndDataSet(inputDataCtxt);
+    const inputDataCtxtName = readableName(inputContext);
+
     for (const [partitioned, name] of transformed) {
       const newContextName = await applyNewDataSet(
         partitioned.dataset,
         name,
-        partitionDatasetDescription(partitioned, inputDataCtxt, attributeName)
+        partitionDatasetDescription(
+          partitioned,
+          inputDataCtxtName,
+          attributeName
+        )
       );
       valueToContext[partitioned.distinctValueAsStr] = newContextName;
       outputContexts.push(newContextName);
@@ -124,7 +131,7 @@ export const partitionOverride = async (
         if (
           !confirmLargeOutput(
             transformed.length,
-            `Updating the partition of ${inputDataCtxt} will lead to ${transformed.length} total output datasets`
+            `Updating the partition of ${inputDataCtxtName} will lead to ${transformed.length} total output datasets`
           )
         ) {
           return;
@@ -143,7 +150,7 @@ export const partitionOverride = async (
               name,
               partitionDatasetDescription(
                 partitioned,
-                inputDataCtxt,
+                inputDataCtxtName,
                 attributeName
               )
             );


### PR DESCRIPTION
This fixes a bug that was causing the data context name used in partitioned table titles/descriptions to be the actual name and not the title (unlike all the other transformers).

I've also modified the names of output tables in partition so that the values are nearer to the front of the name--however I didn't really find a non-awkward way to have the name start directly with the value. Let me know what you all think of this "{attribute} = {value} in {dataset}" naming convention.

![name-changes](https://user-images.githubusercontent.com/13399527/124622424-1b7ba900-de49-11eb-8600-4622231bc1f5.png)
