### PR TITLE
add about info

### DIFF
--- a/src/transformer-components/AboutInfo.css
+++ b/src/transformer-components/AboutInfo.css
@@ -1,0 +1,5 @@
+
+/* space out paragraphs in the about info */
+#about-info p {
+  margin-bottom: 10px;
+}

--- a/src/transformer-components/AboutInfo.tsx
+++ b/src/transformer-components/AboutInfo.tsx
@@ -1,0 +1,79 @@
+import React, { ReactElement } from "react";
+import Popover from "../ui-components/Popover";
+import "./AboutInfo.css";
+
+function AboutInfo(): ReactElement {
+  return (
+    <Popover
+      button={<button style={{ fontSize: "11px" }}>About</button>}
+      buttonStyles={{ float: "right" }}
+      tooltip={`About the Transformers Plugin`}
+      innerContent={
+        <div id="about-info">
+          <h3>About</h3>
+          <p>
+            The Transformers plugin allows you to transform datasets to produce
+            new, distinct output datasets or values, instead of modifying the
+            original input dataset itself. This enables easy “what if”
+            exploration and comparison of datasets that may represent distinct
+            transformations performed on the same source dataset.
+          </p>
+
+          <p>
+            The result of one transformer can be used as an input to another,
+            and in this way transformers can be chained together, resulting in a
+            sequence of datasets, each a transformed version of the previous.
+            This way of manipulating a dataset can be useful for making clear
+            the specific steps that were used to process the data or change its
+            structure.
+          </p>
+
+          <p>
+            Any updates made to the input of a transformer will flow through and
+            affect its outputs. If you have a chain of transformed datasets, the
+            updates will flow through the chain.
+          </p>
+
+          <p>
+            You can also save a particular configuration of a transformer, and
+            reuse this custom transformer on several datasets.
+          </p>
+
+          <h3>Getting Started</h3>
+          <p>
+            To get started with the Transformers plugin, check out the various
+            transformers in the “Transformer Type” dropdown. To learn more about
+            a specific transformer, click the “i” icon next to the dropdown.
+          </p>
+
+          <h3>Authors</h3>
+          <p>
+            This plugin is brought to you by the{" "}
+            <a
+              href="https://cs.brown.edu/research/plt/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Brown University PLT
+            </a>{" "}
+            in collaboration with{" "}
+            <a href="https://concord.org/" target="_blank" rel="noreferrer">
+              The Concord Consortium
+            </a>{" "}
+            and{" "}
+            <a
+              href="https://bootstrapworld.org/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Bootstrap World
+            </a>
+            .
+          </p>
+        </div>
+      }
+    />
+  );
+}
+
+export default AboutInfo;

--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -37,6 +37,7 @@ import {
 import { InteractiveState } from "../utils/codapPhone/types";
 import Popover from "../ui-components/Popover";
 import InfoIcon from "@material-ui/icons/Info";
+import { IconButton } from "@material-ui/core";
 
 // These types represent the configuration required for different UI elements
 interface ComponentInit {
@@ -376,7 +377,12 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
       {/* Only render info icon if NOT a saved transformation. */}
       {!saveData && (
         <Popover
-          icon={<InfoIcon htmlColor="var(--blue-green)" fontSize="small" />}
+          button={
+            <IconButton style={{ padding: "0" }} size="small">
+              <InfoIcon htmlColor="var(--blue-green)" fontSize="inherit" />
+            </IconButton>
+          }
+          buttonStyles={{ marginLeft: "5px", display: "inline" }}
           tooltip={`More Info on ${base}`}
           innerContent={
             <>

--- a/src/transformer-components/TransformerREPLView.tsx
+++ b/src/transformer-components/TransformerREPLView.tsx
@@ -17,6 +17,7 @@ import {
   removeInteractiveStateRequestListener,
 } from "../utils/codapPhone/listeners";
 import { InteractiveState } from "../utils/codapPhone/types";
+import AboutInfo from "./AboutInfo";
 
 // These are the base transformer types represented as SavedTransformer
 // objects
@@ -74,6 +75,7 @@ function TransformerREPLView(): ReactElement {
     }
     fetchSavedState();
   }, []);
+
   // Register a listener to generate the plugins state
   useEffect(() => {
     const callback = (
@@ -94,12 +96,15 @@ function TransformerREPLView(): ReactElement {
     addInteractiveStateRequestListener(callback);
     return () => removeInteractiveStateRequestListener(callback);
   }, [transformType]);
+
   function notifyStateIsDirty() {
     notifyInteractiveFrameIsDirty();
   }
 
   return (
     <div className="transformer-view">
+      <AboutInfo />
+
       <h3>Transformer Type</h3>
 
       <select

--- a/src/ui-components/Popover.css
+++ b/src/ui-components/Popover.css
@@ -1,0 +1,9 @@
+
+/* wrapper around whatever icon/button is used to control the popover */
+.popover-button-container {
+  display: inline-block;
+}
+
+.popover-button-container:hover {
+  cursor: pointer;
+}

--- a/src/ui-components/Popover.tsx
+++ b/src/ui-components/Popover.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from "react";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import { Popover as MaterialUIPopover } from "@material-ui/core";
 import Typography from "@material-ui/core/Typography";
-import IconButton from "@material-ui/core/IconButton";
+import "./Popover.css";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -17,21 +17,22 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 type PopoverProps = {
-  icon: JSX.Element;
+  button: JSX.Element;
+  buttonStyles?: React.CSSProperties;
   tooltip: string;
   innerContent: JSX.Element;
 };
 
 export default function Popover({
-  icon,
+  button,
+  buttonStyles,
   tooltip,
   innerContent,
 }: PopoverProps): ReactElement {
   const classes = useStyles();
-  const [anchorEl, setAnchorEl] =
-    React.useState<HTMLButtonElement | null>(null);
+  const [anchorEl, setAnchorEl] = React.useState<HTMLDivElement | null>(null);
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
@@ -43,16 +44,16 @@ export default function Popover({
   const id = open ? "simple-popover" : undefined;
 
   return (
-    <div style={{ display: "inline", marginLeft: "5px" }}>
-      <IconButton
-        style={{ padding: "0" }}
-        size="small"
+    <>
+      <div
+        className="popover-button-container"
+        style={buttonStyles}
         aria-describedby={id}
         onClick={handleClick}
         title={tooltip}
       >
-        {icon}
-      </IconButton>
+        {button}
+      </div>
       <MaterialUIPopover
         id={id}
         open={open}
@@ -69,6 +70,6 @@ export default function Popover({
       >
         <Typography className={classes.typography}>{innerContent}</Typography>
       </MaterialUIPopover>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
This adds a popover for general info about the transformers plugin. The info itself is still being reviewed by sk + Emmanuel and should be considered a draft, but this PR is more for introducing the UI pieces that will house this about info eventually.

Let me know what you all think.