### PR TITLE
Parameterize formula evaluater in transformers that use formulas

### DIFF
--- a/src/transformers/__tests__/data.ts
+++ b/src/transformers/__tests__/data.ts
@@ -30,6 +30,9 @@ function makeRecords(
   valueLists: unknown[][]
 ): Record<string, unknown>[] {
   return valueLists.map((valueList) => {
+    if (attributes.length !== valueList.length) {
+      throw new Error("attributes list not the same length as a value list");
+    }
     const map: Record<string, unknown> = {};
     valueList.forEach((value, i) => {
       map[attributes[i]] = value;
@@ -37,6 +40,85 @@ function makeRecords(
     return map;
   });
 }
+
+/**
+ *
+ * @param randomize whether or not to the randomize the data in the boundary
+ * object (if false the same boundary will be returned each time)
+ * @returns a boundary object
+ */
+function makeSimpleBoundary(randomize: boolean) {
+  /**
+   * Makes a latitude/longitude pair between -90 and 90
+   */
+  const makeLatLong = () => [
+    Math.random() * 180 - 90,
+    Math.random() * 180 - 90,
+  ];
+
+  return {
+    jsonBoundaryObject: {
+      type: "Feature",
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          randomize
+            ? [
+                makeLatLong(),
+                makeLatLong(),
+                makeLatLong(),
+                makeLatLong(),
+                makeLatLong(),
+              ]
+            : [
+                [-93.0322265625, 36.29741818650811],
+                [-88.65966796875, 36.29741818650811],
+                [-88.65966796875, 39.26628442213066],
+                [-93.0322265625, 39.26628442213066],
+                [-93.0322265625, 36.29741818650811],
+              ],
+        ],
+      },
+      properties: {
+        CENSUSAREA: 97093.141,
+        GEO_ID: "0400000US56",
+        LSAD: "",
+        NAME: "Colorado",
+        STATE: "56",
+        THUMB:
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABmJLR0QA/wD/AP+gvaeTAAABuUlEQVR4nO3dTUoDQRRF4VPPiApBFyA4dQsu1424GBWciiD4i+2gTYeIoGmVuoPzgRPtwIu3q1LVeUmDJEmSJEmSJM3QYDgHjmc89gDY/9tyNtwBbx8/d1s+toCjb4757/rnuF4AZ8Bp70oEwGExnoEKUcDQuwitFdB6F6FJq94VaJNTVpbBQMIUsOhdhNYK2OldhCatGENRCMPIMhhIGAMJYyBZnLLSGEgYAwljIGEMJIuX39MYSBgDyVIGksXXkDDNJocsjpAwjpAwjpA0dp2EMZAsO05ZWXxRD1MGksVVVhinrDBOWWFsJQ3TbLbOYiBhWgF7vavQxEDCtAJ2e1ehNVdZWdwYhrH7PYzXssL4OfU0jpAsdi6GaU5ZYQq46V2EJq2Ay95VaK2Ap95FaDK4Uw9jIGFc9mapAl57V6GJV3vDuFMPYyBhbJQL4/shYby4GGbwe3uzDLYBZWmOkDD2ZWWxDSiNq6wwbgzDeFOwME5ZYRbABXD1xd/ugZdPv9tnvCHjyurmj3OdsN2y+xF4+OGxS8aTbcHvVpK3Wx6/+p8sGfd4T8Az43P9jrOVJEmSJEmSpHneAYtbL3RNXcxYAAAAAElFTkSuQmCC",
+      },
+    },
+  };
+}
+
+/**
+ * Evaluates a formula using the JS eval function
+ * @param expr the expression to be evaluated
+ * @param records a list of key/value pairs. For each item in the list, the
+ * expression will be evaluated with all values in the record added to the
+ * environment.
+ * @returns a list of the result of evaluated expr once for each record in records
+ */
+export const jsEvalFormula = (
+  expr: string,
+  records: Record<string, unknown>[]
+): Promise<unknown[]> => {
+  const expressionOutputs: unknown[] = [];
+
+  for (const record of records) {
+    // Prepend to the beginning of the expression `let` statements that bind
+    // all values in `record`
+    const fullExpr = Object.entries(record)
+      .map(([key, value]) => `let ${key} = ${value}`)
+      .join(";\n")
+      .concat(`;\n${expr}`);
+
+    expressionOutputs.push(eval(fullExpr));
+  }
+
+  return Promise.resolve(expressionOutputs);
+};
 
 /**
  * Makes a clone of a dataset.
@@ -65,6 +147,40 @@ export const DATASET_A: DataSet = {
   ),
 };
 
+export const DATASET_A_SUPERSET: DataSet = {
+  collections: [
+    makeCollection("parent", ["A"]),
+    makeCollection("child", ["B", "C", "D"]),
+  ],
+  records: makeRecords(
+    ["A", "B", "C", "D"],
+    [
+      [3, true, 2000, "a"],
+      [8, true, 2003, "a"],
+      [10, false, 1998, "a"],
+      [4, true, 2010, "a"],
+      [10, false, 2014, "a"],
+    ]
+  ),
+};
+
+export const DATASET_A_SUBSET: DataSet = {
+  collections: [
+    makeCollection("parent", ["A"]),
+    makeCollection("child", ["B"]),
+  ],
+  records: makeRecords(
+    ["A", "B"],
+    [
+      [3, true],
+      [8, true],
+      [10, false],
+      [4, true],
+      [10, false],
+    ]
+  ),
+};
+
 export const DATASET_B: DataSet = {
   collections: [
     makeCollection("cases", ["Name", "Birth Year", "Current Year", "Grade"]),
@@ -78,6 +194,32 @@ export const DATASET_B: DataSet = {
       ["Eve", 2000, 2021, 93],
       ["Nick", 1998, 2021, 95],
       ["Paula", 1988, 2021, 81],
+    ]
+  ),
+};
+
+/**
+ * A dataset that attempts to exercise many CODAP features including:
+ *  boundaries,
+ *  strings (including punctuation and whitespace),
+ *  colors,
+ *  numbers,
+ *  booleans,
+ *  missing values
+ */
+export const FULLY_FEATURED_DATASET: DataSet = {
+  collections: [
+    makeCollection("Collection 1", ["Attribute 1", "Attribute 2"]),
+    makeCollection("Collection 2", ["Attribute 3", "Attribute 4"]),
+    makeCollection("Collection 3", ["Attribute 5"]),
+  ],
+  records: makeRecords(
+    ["Attribute 1", "Attribute 2", "Attribute 3", "Attribute 4", "Attribute 5"],
+    [
+      ["rgb(100,200,0)", -1, makeSimpleBoundary(false), "test 1", true],
+      ["  \n  ", -2, makeSimpleBoundary(false), "test 2", true],
+      [".;'[]-=<>", 3, makeSimpleBoundary(false), "test 3", false],
+      ["", "", "", "", ""],
     ]
   ),
 };

--- a/src/transformers/__tests__/data.ts
+++ b/src/transformers/__tests__/data.ts
@@ -93,14 +93,15 @@ function makeSimpleBoundary(randomize: boolean) {
 }
 
 /**
- * Evaluates a formula using the JS eval function
+ * Evaluates a formula using the JS eval function. Use this function for
+ * testing transformers like `buildColumn` that require evaluating expressions
  * @param expr the expression to be evaluated
  * @param records a list of key/value pairs. For each item in the list, the
  * expression will be evaluated with all values in the record added to the
  * environment.
  * @returns a list of the result of evaluated expr once for each record in records
  */
-export const jsEvalFormula = (
+export const jsEvalExpression = (
   expr: string,
   records: Record<string, unknown>[]
 ): Promise<unknown[]> => {

--- a/src/transformers/buildColumn.ts
+++ b/src/transformers/buildColumn.ts
@@ -1,6 +1,6 @@
 import { CodapLanguageType, DataSet, TransformationOutput } from "./types";
 import {
-  evalExpression,
+  codapEvalFormula,
   getContextAndDataSet,
 } from "../utils/codapPhone/index";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
@@ -60,7 +60,8 @@ export async function uncheckedBuildColumn(
   newAttributeName: string,
   collectionName: string,
   expression: string,
-  outputType: CodapLanguageType
+  outputType: CodapLanguageType,
+  evalFormula = codapEvalFormula
 ): Promise<DataSet> {
   // find collection to add attribute to
   const collections = dataset.collections.map(cloneCollection);
@@ -89,7 +90,7 @@ export async function uncheckedBuildColumn(
     description: `An attribute whose values were computed with the formula ${expression}`,
   });
 
-  const colValues = await evalExpression(expression, dataset.records);
+  const colValues = await evalFormula(expression, dataset.records);
 
   // Check for type errors (might throw error and abort transformer)
   reportTypeErrorsForRecords(dataset.records, colValues, outputType);

--- a/src/transformers/buildColumn.ts
+++ b/src/transformers/buildColumn.ts
@@ -1,6 +1,6 @@
 import { CodapLanguageType, DataSet, TransformationOutput } from "./types";
 import {
-  codapEvalFormula,
+  evalExpression,
   getContextAndDataSet,
 } from "../utils/codapPhone/index";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
@@ -61,7 +61,7 @@ export async function uncheckedBuildColumn(
   collectionName: string,
   expression: string,
   outputType: CodapLanguageType,
-  evalFormula = codapEvalFormula
+  evalFormula = evalExpression
 ): Promise<DataSet> {
   // find collection to add attribute to
   const collections = dataset.collections.map(cloneCollection);

--- a/src/transformers/filter.ts
+++ b/src/transformers/filter.ts
@@ -1,5 +1,5 @@
 import { DataSet, TransformationOutput } from "./types";
-import { evalExpression, getContextAndDataSet } from "../utils/codapPhone";
+import { codapEvalFormula, getContextAndDataSet } from "../utils/codapPhone";
 import { codapValueToString } from "./util";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { readableName } from "../transformer-components/util";
@@ -31,12 +31,13 @@ export async function filter({
 
 async function uncheckedFilter(
   dataset: DataSet,
-  predicate: string
+  predicate: string,
+  evalFormula = codapEvalFormula
 ): Promise<DataSet> {
   const filteredRecords: Record<string, unknown>[] = [];
 
   // evaluate predicate at each case in the dataset
-  const predValues = await evalExpression(predicate, dataset.records);
+  const predValues = await evalFormula(predicate, dataset.records);
 
   predValues.forEach((value, i) => {
     if (value !== true && value !== false) {

--- a/src/transformers/filter.ts
+++ b/src/transformers/filter.ts
@@ -1,5 +1,5 @@
 import { DataSet, TransformationOutput } from "./types";
-import { codapEvalFormula, getContextAndDataSet } from "../utils/codapPhone";
+import { evalExpression, getContextAndDataSet } from "../utils/codapPhone";
 import { codapValueToString } from "./util";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { readableName } from "../transformer-components/util";
@@ -32,7 +32,7 @@ export async function filter({
 async function uncheckedFilter(
   dataset: DataSet,
   predicate: string,
-  evalFormula = codapEvalFormula
+  evalFormula = evalExpression
 ): Promise<DataSet> {
   const filteredRecords: Record<string, unknown>[] = [];
 

--- a/src/transformers/fold.ts
+++ b/src/transformers/fold.ts
@@ -5,7 +5,7 @@ import {
   codapValueToString,
   allAttrNames,
 } from "./util";
-import { evalExpression, getContextAndDataSet } from "../utils/codapPhone";
+import { codapEvalFormula, getContextAndDataSet } from "../utils/codapPhone";
 import { uniqueName } from "../utils/names";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { parenthesizeName, readableName } from "../transformer-components/util";
@@ -164,11 +164,12 @@ async function uncheckedGenericFold(
   expression: string,
   resultColumnName: string,
   accumulatorName: string,
-  resultColumnDescription = ""
+  resultColumnDescription = "",
+  evalFormula = codapEvalFormula
 ): Promise<DataSet> {
   resultColumnName = uniqueName(resultColumnName, allAttrNames(dataset));
 
-  let acc = (await evalExpression(base, [{}]))[0];
+  let acc = (await evalFormula(base, [{}]))[0];
   const resultRecords = [];
 
   for (const row of dataset.records) {
@@ -180,7 +181,7 @@ async function uncheckedGenericFold(
     }
 
     environment[accumulatorName] = acc;
-    acc = (await evalExpression(expression, [environment]))[0];
+    acc = (await evalFormula(expression, [environment]))[0];
     resultRecords.push(insertInRow(row, resultColumnName, acc));
   }
 

--- a/src/transformers/fold.ts
+++ b/src/transformers/fold.ts
@@ -5,7 +5,7 @@ import {
   codapValueToString,
   allAttrNames,
 } from "./util";
-import { codapEvalFormula, getContextAndDataSet } from "../utils/codapPhone";
+import { evalExpression, getContextAndDataSet } from "../utils/codapPhone";
 import { uniqueName } from "../utils/names";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { parenthesizeName, readableName } from "../transformer-components/util";
@@ -165,7 +165,7 @@ async function uncheckedGenericFold(
   resultColumnName: string,
   accumulatorName: string,
   resultColumnDescription = "",
-  evalFormula = codapEvalFormula
+  evalFormula = evalExpression
 ): Promise<DataSet> {
   resultColumnName = uniqueName(resultColumnName, allAttrNames(dataset));
 

--- a/src/transformers/sort.ts
+++ b/src/transformers/sort.ts
@@ -1,5 +1,5 @@
 import { CodapLanguageType, DataSet, TransformationOutput } from "./types";
-import { evalExpression, getContextAndDataSet } from "../utils/codapPhone";
+import { codapEvalFormula, getContextAndDataSet } from "../utils/codapPhone";
 import { codapValueToString, reportTypeErrorsForRecords } from "./util";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { readableName } from "../transformer-components/util";
@@ -89,10 +89,11 @@ async function uncheckedSort(
   dataset: DataSet,
   keyExpr: string,
   outputType: CodapLanguageType,
-  sortDirection: SortDirection
+  sortDirection: SortDirection,
+  evalFormula = codapEvalFormula
 ): Promise<DataSet> {
   const records = dataset.records;
-  const keyValues = await evalExpression(keyExpr, records);
+  const keyValues = await evalFormula(keyExpr, records);
 
   // Check for type errors (might throw error and abort transformer)
   reportTypeErrorsForRecords(records, keyValues, outputType);

--- a/src/transformers/sort.ts
+++ b/src/transformers/sort.ts
@@ -1,5 +1,5 @@
 import { CodapLanguageType, DataSet, TransformationOutput } from "./types";
-import { codapEvalFormula, getContextAndDataSet } from "../utils/codapPhone";
+import { evalExpression, getContextAndDataSet } from "../utils/codapPhone";
 import { codapValueToString, reportTypeErrorsForRecords } from "./util";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { readableName } from "../transformer-components/util";
@@ -90,7 +90,7 @@ async function uncheckedSort(
   keyExpr: string,
   outputType: CodapLanguageType,
   sortDirection: SortDirection,
-  evalFormula = codapEvalFormula
+  evalFormula = evalExpression
 ): Promise<DataSet> {
   const records = dataset.records;
   const keyValues = await evalFormula(keyExpr, records);

--- a/src/transformers/transformColumn.ts
+++ b/src/transformers/transformColumn.ts
@@ -1,5 +1,5 @@
 import { CodapLanguageType, DataSet, TransformationOutput } from "./types";
-import { evalExpression, getContextAndDataSet } from "../utils/codapPhone";
+import { codapEvalFormula, getContextAndDataSet } from "../utils/codapPhone";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { readableName } from "../transformer-components/util";
 import {
@@ -51,10 +51,11 @@ async function uncheckedTransformColumn(
   dataset: DataSet,
   attributeName: string,
   expression: string,
-  outputType: CodapLanguageType
+  outputType: CodapLanguageType,
+  evalFormula = codapEvalFormula
 ): Promise<DataSet> {
   const records = dataset.records.map(shallowCopy);
-  const exprValues = await evalExpression(expression, records);
+  const exprValues = await evalFormula(expression, records);
 
   // Check for type errors (might throw error and abort transformer)
   reportTypeErrorsForRecords(records, exprValues, outputType);

--- a/src/transformers/transformColumn.ts
+++ b/src/transformers/transformColumn.ts
@@ -1,5 +1,5 @@
 import { CodapLanguageType, DataSet, TransformationOutput } from "./types";
-import { codapEvalFormula, getContextAndDataSet } from "../utils/codapPhone";
+import { evalExpression, getContextAndDataSet } from "../utils/codapPhone";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { readableName } from "../transformer-components/util";
 import {
@@ -52,7 +52,7 @@ async function uncheckedTransformColumn(
   attributeName: string,
   expression: string,
   outputType: CodapLanguageType,
-  evalFormula = codapEvalFormula
+  evalFormula = evalExpression
 ): Promise<DataSet> {
   const records = dataset.records.map(shallowCopy);
   const exprValues = await evalFormula(expression, records);

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -860,7 +860,7 @@ export async function createTableWithDataSet(
   return [newContext, newTable];
 }
 
-export function codapEvalFormula(
+export function evalExpression(
   expr: string,
   records: Record<string, unknown>[]
 ): Promise<unknown[]> {

--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -860,7 +860,7 @@ export async function createTableWithDataSet(
   return [newContext, newTable];
 }
 
-export function evalExpression(
+export function codapEvalFormula(
   expr: string,
   records: Record<string, unknown>[]
 ): Promise<unknown[]> {


### PR DESCRIPTION
This PR modifies all transformers that require evaluating a formula to accept a function as a parameter that implements that evaluation logic.

The existing CODAP phone `evalExpression` function is used as a default parameter, but the `transformers/__tests__/data.ts` file includes a `jsEvalFormula` function that can be passed instead to use the js `eval` function as a mock for the CODAP engine.

The tests that actually use this functionality aren't included here. I have them on a separate branch. However, I've also included some additional testing datasets and some changes to the existing test functions.