### PR TITLE
use boundary name in value printing when possible

### DIFF
--- a/src/transformers/types.ts
+++ b/src/transformers/types.ts
@@ -17,6 +17,18 @@ export type CodapLanguageType =
   | "boundary";
 
 /**
+ * The properties of a CODAP boundary value that are necessary for
+ * extracting its name.
+ */
+export type Boundary = {
+  jsonBoundaryObject: {
+    properties: {
+      NAME: string;
+    };
+  };
+};
+
+/**
  * The format for output for most transformations contains three parts:
  *  1) dataset or numeric value (DataSet | number)
  *  2) output context name (string)

--- a/src/transformers/util.ts
+++ b/src/transformers/util.ts
@@ -1,7 +1,7 @@
 import { Collection, CodapAttribute } from "../utils/codapPhone/types";
 import { Env } from "../language/interpret";
 import { Value } from "../language/ast";
-import { CodapLanguageType, DataSet } from "./types";
+import { Boundary, CodapLanguageType, DataSet } from "./types";
 import { prettyPrintCase } from "../utils/prettyPrint";
 
 /**
@@ -215,7 +215,13 @@ export function codapValueToString(codapValue: unknown): string {
 
   // boundaries
   if (isBoundary(codapValue)) {
-    return "a boundary";
+    // Try to extract the name of the boundary, but not all have one.
+    const name = (codapValue as Boundary).jsonBoundaryObject.properties.NAME;
+    if (name !== undefined) {
+      return `a boundary (${name})`;
+    } else {
+      return "a boundary";
+    }
   }
 
   // boundary maps


### PR DESCRIPTION
This uses the `NAME` property that some boundary objects have to add further identifying info when printing a boundary, instead of just "a boundary". This is particularly useful in Partition dataset headers. Now it will print, for instance, "a boundary (Colorado)".