### PR TITLE
add median, mode, std deviation

### DIFF
--- a/src/transformer-components/transformerList.ts
+++ b/src/transformer-components/transformerList.ts
@@ -25,7 +25,7 @@ import {
   runningMin,
   runningSum,
 } from "../transformers/fold";
-import { dotProduct } from "../transformers/dotProduct";
+import { sumProduct } from "../transformers/sumProduct";
 import { mean } from "../transformers/mean";
 import { median } from "../transformers/median";
 import { mode } from "../transformers/mode";
@@ -81,7 +81,7 @@ export type BaseTransformerName =
   | "Median"
   | "Mode"
   | "Standard Deviation"
-  | "Dot Product"
+  | "Sum Product"
   | "Combine Cases"
   | "Reduce"
   | "Partition";
@@ -711,26 +711,26 @@ const transformerList: TransformerList = {
       },
     },
   },
-  "Dot Product": {
+  "Sum Product": {
     group: "Aggregators",
     componentData: {
       init: {
         context1: {
-          title: "Dataset to Take Dot Product of",
+          title: "Dataset to Take Sum Product of",
         },
         attributeSet1: {
-          title: "Attributes to Take Dot Product of",
+          title: "Attributes to Take Sum Product of",
         },
       },
-      transformerFunction: { kind: "datasetCreator", func: dotProduct },
+      transformerFunction: { kind: "datasetCreator", func: sumProduct },
       info: {
         summary:
-          "Calculates a dot product of the indicated attributes \
+          "Calculates a sum product of the indicated attributes \
         by multiplying the values of these attributes in each case and summing \
         these products across the entire dataset.",
         consumes:
           "A dataset and a list of attributes whose values are used \
-        in the dot product.",
+        in the sum product.",
         produces:
           "A single number which is the sum of products of the values \
         from the indicated attributes in the input dataset.",

--- a/src/transformer-components/transformerList.ts
+++ b/src/transformer-components/transformerList.ts
@@ -28,6 +28,7 @@ import {
 import { dotProduct } from "../transformers/dotProduct";
 import { mean } from "../transformers/mean";
 import { median } from "../transformers/median";
+import { mode } from "../transformers/mode";
 import { partitionOverride } from "../transformers/partition";
 import { transformColumn } from "../transformers/transformColumn";
 
@@ -78,6 +79,7 @@ export type BaseTransformerName =
   | "Dot Product"
   | "Mean"
   | "Median"
+  | "Mode"
   | "Combine Cases"
   | "Reduce"
   | "Partition";
@@ -655,8 +657,9 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: mean },
       info: {
         summary:
-          "Finds the mean value of a given numeric attribute \
-        in the given dataset.",
+          "Finds the mean value of a given numeric attribute in the given dataset. \
+          This is the sum of all values under the attribute, divided by the number \
+          of values.",
         consumes: "A dataset and an attribute within it to take the mean of.",
         produces:
           "A single number which is the mean value of the given attribute.",
@@ -678,11 +681,34 @@ const transformerList: TransformerList = {
       info: {
         summary:
           "Finds the median value of a given numeric attribute in the given \
-          dataset. For datasets with an even number of cases, the average of \
-          the two middle values is used.",
+          dataset. This is the middle value which separates the higher half from \
+          the lower half of the dataset (when sorted). For datasets with an even \
+          number of cases, the average of the two middle values is used.",
         consumes: "A dataset and an attribute within it to find the median of.",
         produces:
           "A single number which is the median value of the given attribute.",
+      },
+    },
+  },
+  Mode: {
+    group: "Aggregators",
+    componentData: {
+      init: {
+        context1: {
+          title: "Dataset to Compute Mode Over",
+        },
+        attribute1: {
+          title: "Attribute to Find Mode of",
+        },
+      },
+      transformerFunction: { kind: "datasetCreator", func: mode },
+      info: {
+        summary:
+          "Finds the mode value of a given numeric attribute in the given \
+          dataset. This is the value which occurs most often under the given attribute.",
+        consumes: "A dataset and an attribute within it to find the mode of.",
+        produces:
+          "A single number which is the mode value of the given attribute.",
       },
     },
   },

--- a/src/transformer-components/transformerList.ts
+++ b/src/transformer-components/transformerList.ts
@@ -29,6 +29,7 @@ import { dotProduct } from "../transformers/dotProduct";
 import { mean } from "../transformers/mean";
 import { median } from "../transformers/median";
 import { mode } from "../transformers/mode";
+import { standardDeviation } from "../transformers/standardDeviation";
 import { partitionOverride } from "../transformers/partition";
 import { transformColumn } from "../transformers/transformColumn";
 
@@ -76,10 +77,11 @@ export type BaseTransformerName =
   | "Copy"
   | "Copy Structure"
   | "Join"
-  | "Dot Product"
   | "Mean"
   | "Median"
   | "Mode"
+  | "Standard Deviation"
+  | "Dot Product"
   | "Combine Cases"
   | "Reduce"
   | "Partition";
@@ -617,32 +619,6 @@ const transformerList: TransformerList = {
       },
     },
   },
-  "Dot Product": {
-    group: "Aggregators",
-    componentData: {
-      init: {
-        context1: {
-          title: "Dataset to Take Dot Product of",
-        },
-        attributeSet1: {
-          title: "Attributes to Take Dot Product of",
-        },
-      },
-      transformerFunction: { kind: "datasetCreator", func: dotProduct },
-      info: {
-        summary:
-          "Calculates a dot product of the indicated attributes \
-        by multiplying the values of these attributes in each case and summing \
-        these products across the entire dataset.",
-        consumes:
-          "A dataset and a list of attributes whose values are used \
-        in the dot product.",
-        produces:
-          "A single number which is the sum of products of the values \
-        from the indicated attributes in the input dataset.",
-      },
-    },
-  },
   Mean: {
     group: "Aggregators",
     componentData: {
@@ -709,6 +685,55 @@ const transformerList: TransformerList = {
         consumes: "A dataset and an attribute within it to find the mode of.",
         produces:
           "A single number which is the mode value of the given attribute.",
+      },
+    },
+  },
+  "Standard Deviation": {
+    group: "Aggregators",
+    componentData: {
+      init: {
+        context1: {
+          title: "Dataset to Compute Standard Deviation Over",
+        },
+        attribute1: {
+          title: "Attribute to Find Standard Deviation of",
+        },
+      },
+      transformerFunction: { kind: "datasetCreator", func: standardDeviation },
+      info: {
+        summary:
+          "Finds the standard deviation of a given numeric attribute in the given \
+          dataset.",
+        consumes:
+          "A dataset and an attribute within it to find the standard deviation of.",
+        produces:
+          "A single number which is the standard deviation of the given attribute.",
+      },
+    },
+  },
+  "Dot Product": {
+    group: "Aggregators",
+    componentData: {
+      init: {
+        context1: {
+          title: "Dataset to Take Dot Product of",
+        },
+        attributeSet1: {
+          title: "Attributes to Take Dot Product of",
+        },
+      },
+      transformerFunction: { kind: "datasetCreator", func: dotProduct },
+      info: {
+        summary:
+          "Calculates a dot product of the indicated attributes \
+        by multiplying the values of these attributes in each case and summing \
+        these products across the entire dataset.",
+        consumes:
+          "A dataset and a list of attributes whose values are used \
+        in the dot product.",
+        produces:
+          "A single number which is the sum of products of the values \
+        from the indicated attributes in the input dataset.",
       },
     },
   },

--- a/src/transformer-components/transformerList.ts
+++ b/src/transformer-components/transformerList.ts
@@ -26,7 +26,8 @@ import {
   runningSum,
 } from "../transformers/fold";
 import { dotProduct } from "../transformers/dotProduct";
-import { average } from "../transformers/average";
+import { mean } from "../transformers/mean";
+import { median } from "../transformers/median";
 import { partitionOverride } from "../transformers/partition";
 import { transformColumn } from "../transformers/transformColumn";
 
@@ -75,7 +76,8 @@ export type BaseTransformerName =
   | "Copy Structure"
   | "Join"
   | "Dot Product"
-  | "Average"
+  | "Mean"
+  | "Median"
   | "Combine Cases"
   | "Reduce"
   | "Partition";
@@ -416,7 +418,7 @@ const transformerList: TransformerList = {
       info: {
         summary:
           "Produces a new dataset with an attribute added \
-        that contains the running mean (average) of the given attribute's values across \
+        that contains the running mean of the given attribute's values across \
         the whole dataset.",
         consumes:
           "A dataset to compute the mean over, and an attribute whose values \
@@ -639,26 +641,48 @@ const transformerList: TransformerList = {
       },
     },
   },
-  Average: {
+  Mean: {
     group: "Aggregators",
     componentData: {
       init: {
         context1: {
-          title: "Dataset to Take Average of",
+          title: "Dataset to Compute Mean Over",
         },
         attribute1: {
-          title: "Attribute to Average",
+          title: "Attribute to Find Mean of",
         },
       },
-      transformerFunction: { kind: "datasetCreator", func: average },
+      transformerFunction: { kind: "datasetCreator", func: mean },
       info: {
         summary:
-          "Takes the average value of a given numeric attribute \
+          "Finds the mean value of a given numeric attribute \
         in the given dataset.",
-        consumes:
-          "A dataset and an attribute within it to take the average of.",
+        consumes: "A dataset and an attribute within it to take the mean of.",
         produces:
-          "A single number which is the average value of the given attribute.",
+          "A single number which is the mean value of the given attribute.",
+      },
+    },
+  },
+  Median: {
+    group: "Aggregators",
+    componentData: {
+      init: {
+        context1: {
+          title: "Dataset to Compute Median Over",
+        },
+        attribute1: {
+          title: "Attribute to Find Median of",
+        },
+      },
+      transformerFunction: { kind: "datasetCreator", func: median },
+      info: {
+        summary:
+          "Finds the median value of a given numeric attribute in the given \
+          dataset. For datasets with an even number of cases, the average of \
+          the two middle values is used.",
+        consumes: "A dataset and an attribute within it to find the median of.",
+        produces:
+          "A single number which is the median value of the given attribute.",
       },
     },
   },

--- a/src/transformers/dotProduct.ts
+++ b/src/transformers/dotProduct.ts
@@ -63,33 +63,3 @@ function uncheckedDotProduct(dataset: DataSet, attributes: string[]): number {
     )
     .reduce((a, b) => a + b);
 }
-
-/**
- * Temporray solution. Until text gets fixed, use a single celled table for
- * scalar values
- */
-export function dotProductTable(
-  dataset: DataSet,
-  attributes: string[]
-): DataSet {
-  const records = [
-    {
-      "Dot Product": uncheckedDotProduct(dataset, attributes),
-    },
-  ];
-  const collections = [
-    {
-      name: "Cases",
-      attrs: [
-        {
-          name: "Dot Product",
-        },
-      ],
-      labels: {},
-    },
-  ];
-  return {
-    collections,
-    records,
-  };
-}

--- a/src/transformers/dotProduct.ts
+++ b/src/transformers/dotProduct.ts
@@ -50,7 +50,7 @@ function uncheckedDotProduct(dataset: DataSet, attributes: string[]): number {
         if (row[attribute] === undefined) {
           throw new Error(`Invalid attribute name: ${attribute}`);
         }
-        const value = Number(row[attribute]);
+        const value = parseFloat(String(row[attribute]));
         if (isNaN(value)) {
           throw new Error(
             `Expected number in attribute ${attribute}, instead got ${codapValueToString(

--- a/src/transformers/mean.ts
+++ b/src/transformers/mean.ts
@@ -36,13 +36,13 @@ export async function mean({
  * @param attribute - The column to find the mean of.
  */
 function uncheckedMean(dataset: DataSet, attribute: string): number {
-  if (dataset.records.length === 0) {
-    throw new Error(`Cannot take mean of dataset with no cases`);
-  }
-
   // Extract the numeric values from the indicated attribute.
   const values = extractAttributeAsNumeric(dataset, attribute);
 
+  if (values.length === 0) {
+    throw new Error(`Cannot find mean of no numeric values`);
+  }
+
   // Sum them and divide by the number of records.
-  return values.reduce((acc, value) => acc + value, 0) / dataset.records.length;
+  return values.reduce((acc, value) => acc + value, 0) / values.length;
 }

--- a/src/transformers/mean.ts
+++ b/src/transformers/mean.ts
@@ -5,9 +5,9 @@ import { DataSet, TransformationOutput } from "./types";
 import { codapValueToString } from "./util";
 
 /**
- * Takes the average of a given column.
+ * Takes the mean of a given column.
  */
-export async function average({
+export async function mean({
   context1: contextName,
   attribute1: attribute,
 }: DDTransformerState): Promise<TransformationOutput> {
@@ -16,26 +16,26 @@ export async function average({
   }
 
   if (attribute === null) {
-    throw new Error("Please choose an attribute to take the average of.");
+    throw new Error("Please choose an attribute to take the mean of.");
   }
 
   const { context, dataset } = await getContextAndDataSet(contextName);
   const ctxtName = readableName(context);
 
   return [
-    uncheckedAverage(dataset, attribute),
-    `Average of ${attribute} in ${ctxtName}`,
-    `The average value of the ${attribute} attribute in the ${ctxtName} dataset.`,
+    uncheckedMean(dataset, attribute),
+    `Mean of ${attribute} in ${ctxtName}`,
+    `The mean value of the ${attribute} attribute in the ${ctxtName} dataset.`,
   ];
 }
 
 /**
- * Takes the average of a given column.
+ * Takes the mean of a given column.
  *
  * @param dataset - The input DataSet
- * @param attribute - The column to take the dot product of.
+ * @param attribute - The column to find the mean of.
  */
-function uncheckedAverage(dataset: DataSet, attribute: string): number {
+function uncheckedMean(dataset: DataSet, attribute: string): number {
   const sum = dataset.records.reduce((acc, row) => {
     if (row[attribute] === undefined) {
       throw new Error(`Invalid attribute name: ${attribute}`);
@@ -49,31 +49,4 @@ function uncheckedAverage(dataset: DataSet, attribute: string): number {
     return acc + value;
   }, 0);
   return sum / dataset.records.length;
-}
-
-/**
- * Temporray solution. Until text gets fixed, use a single celled table for
- * scalar values
- */
-export function averageTable(dataset: DataSet, attribute: string): DataSet {
-  const records = [
-    {
-      Average: uncheckedAverage(dataset, attribute),
-    },
-  ];
-  const collections = [
-    {
-      name: "Cases",
-      attrs: [
-        {
-          name: "Average",
-        },
-      ],
-      labels: {},
-    },
-  ];
-  return {
-    collections,
-    records,
-  };
 }

--- a/src/transformers/mean.ts
+++ b/src/transformers/mean.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { extractNumericValues } from "./util";
+import { extractAttributeAsNumeric } from "./util";
 
 /**
  * Takes the mean of a given column.
@@ -41,7 +41,7 @@ function uncheckedMean(dataset: DataSet, attribute: string): number {
   }
 
   // Extract the numeric values from the indicated attribute.
-  const values = extractNumericValues(dataset, attribute);
+  const values = extractAttributeAsNumeric(dataset, attribute);
 
   // Sum them and divide by the number of records.
   return values.reduce((acc, value) => acc + value, 0) / dataset.records.length;

--- a/src/transformers/mean.ts
+++ b/src/transformers/mean.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { codapValueToString } from "./util";
+import { extractNumericValues } from "./util";
 
 /**
  * Takes the mean of a given column.
@@ -36,17 +36,13 @@ export async function mean({
  * @param attribute - The column to find the mean of.
  */
 function uncheckedMean(dataset: DataSet, attribute: string): number {
-  const sum = dataset.records.reduce((acc, row) => {
-    if (row[attribute] === undefined) {
-      throw new Error(`Invalid attribute name: ${attribute}`);
-    }
-    const value = Number(row[attribute]);
-    if (isNaN(value)) {
-      throw new Error(
-        `Expected number, instead got ${codapValueToString(row[attribute])}`
-      );
-    }
-    return acc + value;
-  }, 0);
-  return sum / dataset.records.length;
+  if (dataset.records.length === 0) {
+    throw new Error(`Cannot take mean of dataset with no cases`);
+  }
+
+  // Extract the numeric values from the indicated attribute.
+  const values = extractNumericValues(dataset, attribute);
+
+  // Sum them and divide by the number of records.
+  return values.reduce((acc, value) => acc + value, 0) / dataset.records.length;
 }

--- a/src/transformers/median.ts
+++ b/src/transformers/median.ts
@@ -36,12 +36,12 @@ export async function median({
  * @param attribute - The column to find the median of.
  */
 function uncheckedMedian(dataset: DataSet, attribute: string): number {
-  if (dataset.records.length === 0) {
-    throw new Error(`Cannot find median of dataset with no cases`);
-  }
-
   // Extract numeric values from the indicated attribute
   const values = extractAttributeAsNumeric(dataset, attribute);
+
+  if (values.length === 0) {
+    throw new Error(`Cannot find median of no numeric values`);
+  }
 
   // Sort the numeric values ascending
   values.sort((a, b) => a - b);

--- a/src/transformers/median.ts
+++ b/src/transformers/median.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { extractNumericValues } from "./util";
+import { extractAttributeAsNumeric } from "./util";
 
 /**
  * Finds the median of a given attribute's values.
@@ -41,7 +41,7 @@ function uncheckedMedian(dataset: DataSet, attribute: string): number {
   }
 
   // Extract numeric values from the indicated attribute
-  const values = extractNumericValues(dataset, attribute);
+  const values = extractAttributeAsNumeric(dataset, attribute);
 
   // Sort the numeric values ascending
   values.sort((a, b) => a - b);

--- a/src/transformers/median.ts
+++ b/src/transformers/median.ts
@@ -1,0 +1,70 @@
+import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
+import { readableName } from "../transformer-components/util";
+import { getContextAndDataSet } from "../utils/codapPhone";
+import { DataSet, TransformationOutput } from "./types";
+import { codapValueToString } from "./util";
+
+/**
+ * Finds the median of a given attribute's values.
+ */
+export async function median({
+  context1: contextName,
+  attribute1: attribute,
+}: DDTransformerState): Promise<TransformationOutput> {
+  if (contextName === null) {
+    throw new Error("Please choose a valid dataset to transform.");
+  }
+
+  if (attribute === null) {
+    throw new Error("Please choose an attribute to find the median of.");
+  }
+
+  const { context, dataset } = await getContextAndDataSet(contextName);
+  const ctxtName = readableName(context);
+
+  return [
+    uncheckedMedian(dataset, attribute),
+    `Median of ${attribute} in ${ctxtName}`,
+    `The median value of the ${attribute} attribute in the ${ctxtName} dataset.`,
+  ];
+}
+
+/**
+ * Finds the median of a given attribute's values.
+ *
+ * @param dataset - The input DataSet
+ * @param attribute - The column to find the median of.
+ */
+function uncheckedMedian(dataset: DataSet, attribute: string): number {
+  if (dataset.records.length === 0) {
+    throw new Error(`Cannot find median of dataset with no cases`);
+  }
+
+  // Extract numeric values from the indicated attribute
+  const values = dataset.records.map((record) => {
+    if (record[attribute] === undefined) {
+      throw new Error(`Invalid attribute name: ${attribute}`);
+    }
+    const numericValue = parseFloat(String(record[attribute]));
+    if (isNaN(numericValue)) {
+      throw new Error(
+        `Expected number, instead got ${codapValueToString(record[attribute])}`
+      );
+    }
+    return numericValue;
+  });
+
+  // Sort the numeric values ascending
+  values.sort((a, b) => a - b);
+
+  if (values.length % 2 === 0) {
+    const middleRight = values.length / 2;
+    const middleLeft = middleRight - 1;
+
+    // Median is average of middle elements
+    return (values[middleLeft] + values[middleRight]) / 2;
+  } else {
+    // Median is the middle element
+    return values[Math.floor(values.length / 2)];
+  }
+}

--- a/src/transformers/median.ts
+++ b/src/transformers/median.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { codapValueToString } from "./util";
+import { extractNumericValues } from "./util";
 
 /**
  * Finds the median of a given attribute's values.
@@ -41,18 +41,7 @@ function uncheckedMedian(dataset: DataSet, attribute: string): number {
   }
 
   // Extract numeric values from the indicated attribute
-  const values = dataset.records.map((record) => {
-    if (record[attribute] === undefined) {
-      throw new Error(`Invalid attribute name: ${attribute}`);
-    }
-    const numericValue = parseFloat(String(record[attribute]));
-    if (isNaN(numericValue)) {
-      throw new Error(
-        `Expected number, instead got ${codapValueToString(record[attribute])}`
-      );
-    }
-    return numericValue;
-  });
+  const values = extractNumericValues(dataset, attribute);
 
   // Sort the numeric values ascending
   values.sort((a, b) => a - b);

--- a/src/transformers/mode.ts
+++ b/src/transformers/mode.ts
@@ -36,12 +36,12 @@ export async function mode({
  * @param attribute - The column to find the mode of.
  */
 function uncheckedMode(dataset: DataSet, attribute: string): number {
-  if (dataset.records.length === 0) {
-    throw new Error(`Cannot find mode of dataset with no cases`);
-  }
-
   // Extract numeric values from the indicated attribute
   const values = extractAttributeAsNumeric(dataset, attribute);
+
+  if (values.length === 0) {
+    throw new Error(`Cannot find mode of no numeric values`);
+  }
 
   // Determine the frequency of each value
   const valueToFrequency: Record<number, number> = {};

--- a/src/transformers/mode.ts
+++ b/src/transformers/mode.ts
@@ -1,0 +1,71 @@
+import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
+import { readableName } from "../transformer-components/util";
+import { getContextAndDataSet } from "../utils/codapPhone";
+import { DataSet, TransformationOutput } from "./types";
+import { extractNumericValues } from "./util";
+
+/**
+ * Finds the mode of a given attribute's values.
+ */
+export async function mode({
+  context1: contextName,
+  attribute1: attribute,
+}: DDTransformerState): Promise<TransformationOutput> {
+  if (contextName === null) {
+    throw new Error("Please choose a valid dataset to transform.");
+  }
+
+  if (attribute === null) {
+    throw new Error("Please choose an attribute to find the mode of.");
+  }
+
+  const { context, dataset } = await getContextAndDataSet(contextName);
+  const ctxtName = readableName(context);
+
+  return [
+    uncheckedMode(dataset, attribute),
+    `Mode of ${attribute} in ${ctxtName}`,
+    `The mode value of the ${attribute} attribute in the ${ctxtName} dataset.`,
+  ];
+}
+
+/**
+ * Finds the mode of a given attribute's values.
+ *
+ * @param dataset - The input DataSet
+ * @param attribute - The column to find the mode of.
+ */
+function uncheckedMode(dataset: DataSet, attribute: string): number {
+  if (dataset.records.length === 0) {
+    throw new Error(`Cannot find mode of dataset with no cases`);
+  }
+
+  // Extract numeric values from the indicated attribute
+  const values = extractNumericValues(dataset, attribute);
+
+  // Determine the frequency of each value
+  const valueToFrequency: Record<number, number> = {};
+  for (const value of values) {
+    if (valueToFrequency[value] === undefined) {
+      valueToFrequency[value] = 0;
+    }
+    valueToFrequency[value]++;
+  }
+
+  // Find the value that occurs with maximum frequency. NOTE: The below cast
+  // is safe because values/valueToFrequency are guaranteed to be non-empty
+  // because we have already errored out if the dataset has no records.
+  const [mostFrequent] = Object.entries(valueToFrequency).reduce(
+    (maxes: [string, number] | undefined, elt) => {
+      if (maxes === undefined) {
+        return elt;
+      }
+      const [, frequency] = elt;
+      const [, maxFrequency] = maxes;
+      return frequency > maxFrequency ? elt : maxes;
+    },
+    undefined
+  ) as [string, number];
+
+  return Number(mostFrequent);
+}

--- a/src/transformers/mode.ts
+++ b/src/transformers/mode.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { extractNumericValues } from "./util";
+import { extractAttributeAsNumeric } from "./util";
 
 /**
  * Finds the mode of a given attribute's values.
@@ -41,7 +41,7 @@ function uncheckedMode(dataset: DataSet, attribute: string): number {
   }
 
   // Extract numeric values from the indicated attribute
-  const values = extractNumericValues(dataset, attribute);
+  const values = extractAttributeAsNumeric(dataset, attribute);
 
   // Determine the frequency of each value
   const valueToFrequency: Record<number, number> = {};

--- a/src/transformers/standardDeviation.ts
+++ b/src/transformers/standardDeviation.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { extractNumericValues } from "./util";
+import { extractAttributeAsNumeric } from "./util";
 
 /**
  * Finds the standard deviation of a given attribute's values.
@@ -56,7 +56,7 @@ function uncheckedStandardDeviation(
   }
 
   // Extract numeric values from the indicated attribute
-  const values = extractNumericValues(dataset, attribute);
+  const values = extractAttributeAsNumeric(dataset, attribute);
 
   const populationMean = mean(values);
   const squaredDeviations = values.map((v) => Math.pow(v - populationMean, 2));

--- a/src/transformers/standardDeviation.ts
+++ b/src/transformers/standardDeviation.ts
@@ -1,0 +1,67 @@
+import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
+import { readableName } from "../transformer-components/util";
+import { getContextAndDataSet } from "../utils/codapPhone";
+import { DataSet, TransformationOutput } from "./types";
+import { extractNumericValues } from "./util";
+
+/**
+ * Finds the standard deviation of a given attribute's values.
+ */
+export async function standardDeviation({
+  context1: contextName,
+  attribute1: attribute,
+}: DDTransformerState): Promise<TransformationOutput> {
+  if (contextName === null) {
+    throw new Error("Please choose a valid dataset to transform.");
+  }
+
+  if (attribute === null) {
+    throw new Error(
+      "Please choose an attribute to find the standard deviation of."
+    );
+  }
+
+  const { context, dataset } = await getContextAndDataSet(contextName);
+  const ctxtName = readableName(context);
+
+  return [
+    uncheckedStandardDeviation(dataset, attribute),
+    `Standard Deviation of ${attribute} in ${ctxtName}`,
+    `The standard deviation of the ${attribute} attribute in the ${ctxtName} dataset.`,
+  ];
+}
+
+/**
+ * Computes the mean value of a list of values.
+ *
+ * @param vs List of values to compute mean over
+ * @returns The mean value
+ */
+function mean(vs: number[]): number {
+  return vs.reduce((a, b) => a + b, 0) / vs.length;
+}
+
+/**
+ * Finds the standard deviation of a given attribute's values.
+ *
+ * @param dataset - The input DataSet
+ * @param attribute - The column to find the standard deviation of.
+ */
+function uncheckedStandardDeviation(
+  dataset: DataSet,
+  attribute: string
+): number {
+  if (dataset.records.length === 0) {
+    throw new Error(`Cannot find standard deviation of dataset with no cases`);
+  }
+
+  // Extract numeric values from the indicated attribute
+  const values = extractNumericValues(dataset, attribute);
+
+  const populationMean = mean(values);
+  const squaredDeviations = values.map((v) => Math.pow(v - populationMean, 2));
+  const variance = mean(squaredDeviations);
+  const stdDev = Math.sqrt(variance);
+
+  return stdDev;
+}

--- a/src/transformers/standardDeviation.ts
+++ b/src/transformers/standardDeviation.ts
@@ -51,12 +51,12 @@ function uncheckedStandardDeviation(
   dataset: DataSet,
   attribute: string
 ): number {
-  if (dataset.records.length === 0) {
-    throw new Error(`Cannot find standard deviation of dataset with no cases`);
-  }
-
   // Extract numeric values from the indicated attribute
   const values = extractAttributeAsNumeric(dataset, attribute);
+
+  if (values.length === 0) {
+    throw new Error(`Cannot find standard deviation of no numeric values`);
+  }
 
   const populationMean = mean(values);
   const squaredDeviations = values.map((v) => Math.pow(v - populationMean, 2));

--- a/src/transformers/sumProduct.ts
+++ b/src/transformers/sumProduct.ts
@@ -5,9 +5,9 @@ import { DataSet, TransformationOutput } from "./types";
 import { codapValueToString, listAsString, pluralSuffix } from "./util";
 
 /**
- * Takes the dot product of the given columns.
+ * Takes the sum product of the given columns.
  */
-export async function dotProduct({
+export async function sumProduct({
   context1: contextName,
   attributeSet1: attributes,
 }: DDTransformerState): Promise<TransformationOutput> {
@@ -17,7 +17,7 @@ export async function dotProduct({
 
   if (attributes.length === 0) {
     throw new Error(
-      "Please choose at least one attribute to take the dot product of."
+      "Please choose at least one attribute to take the sum product of."
     );
   }
 
@@ -26,22 +26,22 @@ export async function dotProduct({
   const attributeNames = listAsString(attributes);
 
   return [
-    await uncheckedDotProduct(dataset, attributes),
-    `Dot Product of ${ctxtName}`,
+    await uncheckedSumProduct(dataset, attributes),
+    `Sum Product of ${ctxtName}`,
     `The sum across all cases in ${ctxtName} of the product ` +
       `of the ${pluralSuffix("attribute", attributes)} ${attributeNames}.`,
   ];
 }
 
 /**
- * Takes the dot product of the given columns.
+ * Takes the sum product of the given columns.
  *
  * @param dataset - The input DataSet
- * @param attributes - The columns to take the dot product of.
+ * @param attributes - The columns to take the sum product of.
  */
-function uncheckedDotProduct(dataset: DataSet, attributes: string[]): number {
+function uncheckedSumProduct(dataset: DataSet, attributes: string[]): number {
   if (attributes.length === 0) {
-    throw new Error("Cannot take the dot product of zero columns.");
+    throw new Error("Cannot take the sum product of zero columns.");
   }
 
   return dataset.records
@@ -61,5 +61,5 @@ function uncheckedDotProduct(dataset: DataSet, attributes: string[]): number {
         return product * value;
       }, 1)
     )
-    .reduce((a, b) => a + b);
+    .reduce((a, b) => a + b, 0);
 }

--- a/src/transformers/sumProduct.ts
+++ b/src/transformers/sumProduct.ts
@@ -50,6 +50,10 @@ function uncheckedSumProduct(dataset: DataSet, attributes: string[]): number {
         if (row[attribute] === undefined) {
           throw new Error(`Invalid attribute name: ${attribute}`);
         }
+        // Missing values turn the whole row into NaN
+        if (row[attribute] === "") {
+          return NaN;
+        }
         const value = parseFloat(String(row[attribute]));
         if (isNaN(value)) {
           throw new Error(
@@ -61,5 +65,6 @@ function uncheckedSumProduct(dataset: DataSet, attributes: string[]): number {
         return product * value;
       }, 1)
     )
+    .filter((product) => !isNaN(product))
     .reduce((a, b) => a + b, 0);
 }

--- a/src/transformers/util.ts
+++ b/src/transformers/util.ts
@@ -473,3 +473,30 @@ export function shallowCopy<T>(x: T): T {
 }
 
 export const cloneAttribute = shallowCopy;
+
+/**
+ * Extracts a list of numbers from an attribute in a dataset that is expected
+ * to contain numeric values. Errors if the attribute is undefined for some
+ * records, or if the attribute's values parse to non-numeric.
+ *
+ * @param dataset The dataset to extract from.
+ * @param attribute The attribute containing numeric values.
+ * @returns A list of the attributes values parsed to numbers.
+ */
+export function extractNumericValues(
+  dataset: DataSet,
+  attribute: string
+): number[] {
+  return dataset.records.map((record) => {
+    if (record[attribute] === undefined) {
+      throw new Error(`Invalid attribute name: ${attribute}`);
+    }
+    const numericValue = parseFloat(String(record[attribute]));
+    if (isNaN(numericValue)) {
+      throw new Error(
+        `Expected number, instead got ${codapValueToString(record[attribute])}`
+      );
+    }
+    return numericValue;
+  });
+}

--- a/src/transformers/util.ts
+++ b/src/transformers/util.ts
@@ -487,16 +487,24 @@ export function extractAttributeAsNumeric(
   dataset: DataSet,
   attribute: string
 ): number[] {
-  return dataset.records.map((record) => {
+  const numericValues = [];
+
+  for (const record of dataset.records) {
     if (record[attribute] === undefined) {
       throw new Error(`Invalid attribute name: ${attribute}`);
     }
-    const numericValue = parseFloat(String(record[attribute]));
-    if (isNaN(numericValue)) {
+    // Ignore missing values
+    if (record[attribute] === "") {
+      continue;
+    }
+    const value = parseFloat(String(record[attribute]));
+    if (isNaN(value)) {
       throw new Error(
         `Expected number, instead got ${codapValueToString(record[attribute])}`
       );
     }
-    return numericValue;
-  });
+    numericValues.push(value);
+  }
+
+  return numericValues;
 }

--- a/src/transformers/util.ts
+++ b/src/transformers/util.ts
@@ -483,7 +483,7 @@ export const cloneAttribute = shallowCopy;
  * @param attribute The attribute containing numeric values.
  * @returns A list of the attributes values parsed to numbers.
  */
-export function extractNumericValues(
+export function extractAttributeAsNumeric(
   dataset: DataSet,
   attribute: string
 ): number[] {


### PR DESCRIPTION
This renames "Average" --> "Mean", and adds three new single-value transformers: Median, Mode, and Standard Deviation.

At the moment, all of these error on a dataset with no records, as well as if non-numeric values are given.

Please look over these and let me know if there are any edge cases you think aren't handled correctly.