### PR TITLE
validate attributes in a uniform way

### DIFF
--- a/src/transformers/count.ts
+++ b/src/transformers/count.ts
@@ -1,6 +1,6 @@
 import { DataSet, TransformationOutput } from "./types";
 import { CodapAttribute, Collection } from "../utils/codapPhone/types";
-import { listAsString, eraseFormulas, shallowCopy, pluralSuffix } from "./util";
+import { listAsString, eraseFormulas, shallowCopy, pluralSuffix, validateAttribute } from "./util";
 import { uniqueName } from "../utils/names";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { getContextAndDataSet } from "../utils/codapPhone";
@@ -47,13 +47,7 @@ export async function count({
 function uncheckedCount(dataset: DataSet, attributes: string[]): DataSet {
   // validate attribute names
   for (const attrName of attributes) {
-    if (
-      dataset.collections.find((coll) =>
-        coll.attrs?.find((attr) => attr.name === attrName)
-      ) === undefined
-    ) {
-      throw new Error(`Invalid attribute name: ${attrName}`);
-    }
+    validateAttribute(dataset.collections, attrName);
   }
 
   let countedAttrs: CodapAttribute[] = [];
@@ -93,7 +87,7 @@ function uncheckedCount(dataset: DataSet, attributes: string[]): DataSet {
     const copy: Record<string, unknown> = {};
     for (const attrName of attributes) {
       if (record[attrName] === undefined) {
-        throw new Error(`Invalid attribute name: ${attrName}`);
+        throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute name: ${attrName}`);
       }
 
       copy[attrName] = record[attrName];

--- a/src/transformers/count.ts
+++ b/src/transformers/count.ts
@@ -1,6 +1,12 @@
 import { DataSet, TransformationOutput } from "./types";
 import { CodapAttribute, Collection } from "../utils/codapPhone/types";
-import { listAsString, eraseFormulas, shallowCopy, pluralSuffix, validateAttribute } from "./util";
+import {
+  listAsString,
+  eraseFormulas,
+  shallowCopy,
+  pluralSuffix,
+  validateAttribute,
+} from "./util";
 import { uniqueName } from "../utils/names";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
 import { getContextAndDataSet } from "../utils/codapPhone";
@@ -86,10 +92,6 @@ function uncheckedCount(dataset: DataSet, attributes: string[]): DataSet {
   const tuples = dataset.records.map((record) => {
     const copy: Record<string, unknown> = {};
     for (const attrName of attributes) {
-      if (record[attrName] === undefined) {
-        throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute name: ${attrName}`);
-      }
-
       copy[attrName] = record[attrName];
     }
     return copy;

--- a/src/transformers/fold.ts
+++ b/src/transformers/fold.ts
@@ -4,6 +4,7 @@ import {
   insertInRow,
   codapValueToString,
   allAttrNames,
+  validateAttribute,
 } from "./util";
 import { evalExpression, getContextAndDataSet } from "../utils/codapPhone";
 import { uniqueName } from "../utils/names";
@@ -78,12 +79,14 @@ function makeNumFold<T>(
     resultColumnName: string,
     resultColumnDescription: string
   ): DataSet => {
+    validateAttribute(dataset.collections, inputColumnName);
+
     resultColumnName = uniqueName(resultColumnName, allAttrNames(dataset));
     let acc = base;
 
     const resultRecords = dataset.records.map((row) => {
       if (row[inputColumnName] === undefined) {
-        throw new Error(`Invalid attribute name: ${inputColumnName}`);
+        throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute name: ${inputColumnName}`);
       }
 
       const numValue = Number(row[inputColumnName]);
@@ -336,6 +339,8 @@ function uncheckedDifferenceFrom(
   resultColumnName: string,
   startingValue = 0
 ): DataSet {
+  validateAttribute(dataset.collections, inputColumnName);
+
   // Construct a fold that computes the difference of each case with
   // the case above, but uses the given startingValue to begin
   const differenceFromFold = makeNumFold<{ numAbove: number | null }>(

--- a/src/transformers/fold.ts
+++ b/src/transformers/fold.ts
@@ -85,10 +85,6 @@ function makeNumFold<T>(
     let acc = base;
 
     const resultRecords = dataset.records.map((row) => {
-      if (row[inputColumnName] === undefined) {
-        throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute name: ${inputColumnName}`);
-      }
-
       const numValue = Number(row[inputColumnName]);
       if (!isNaN(numValue)) {
         const [newAcc, result] = f(acc, numValue);

--- a/src/transformers/groupBy.ts
+++ b/src/transformers/groupBy.ts
@@ -11,6 +11,7 @@ import {
   pluralSuffix,
   allCollectionNames,
   allAttrNames,
+  validateAttribute,
 } from "./util";
 import { uniqueName } from "../utils/names";
 
@@ -73,6 +74,10 @@ function uncheckedGroupBy(
   attrNames: string[],
   newParentName: string
 ): DataSet {
+  for (const attr of attrNames) {
+    validateAttribute(dataset.collections, attr);
+  }
+
   const groupedAttrs: CodapAttribute[] = [];
   let collections = dataset.collections.map(cloneCollection);
   const allAttributes = allAttrNames(dataset);

--- a/src/transformers/join.ts
+++ b/src/transformers/join.ts
@@ -69,15 +69,21 @@ function uncheckedJoin(
   joiningAttr: string
 ): DataSet {
   // find collection containing joining attribute in joining dataset
-  const [joiningCollection] = validateAttribute(joiningDataset.collections, joiningAttr, 
-    `Invalid joining attribute: ${joiningAttr}`);
+  const [joiningCollection] = validateAttribute(
+    joiningDataset.collections,
+    joiningAttr,
+    `Invalid joining attribute: ${joiningAttr}`
+  );
 
   const addedAttrs = joiningCollection.attrs?.map(cloneAttribute) || [];
   const addedAttrOriginalNames = addedAttrs.map((attr) => attr.name);
 
   const collections = baseDataset.collections.map(cloneCollection);
-  const [baseCollection] = validateAttribute(collections, baseAttr, 
-    `Invalid base attribute: ${baseAttr}`);
+  const [baseCollection] = validateAttribute(
+    collections,
+    baseAttr,
+    `Invalid base attribute: ${baseAttr}`
+  );
 
   // list of attributes whose names cannot be duplicated by the added attrs
   const namesToAvoid = allAttrNames(baseDataset);

--- a/src/transformers/join.ts
+++ b/src/transformers/join.ts
@@ -1,4 +1,3 @@
-import { Collection } from "../utils/codapPhone/types";
 import { DataSet, TransformationOutput } from "./types";
 import { uniqueName } from "../utils/names";
 import { DDTransformerState } from "../transformer-components/DataDrivenTransformer";
@@ -9,6 +8,7 @@ import {
   cloneCollection,
   cloneAttribute,
   allAttrNames,
+  validateAttribute,
 } from "./util";
 
 /**
@@ -69,25 +69,15 @@ function uncheckedJoin(
   joiningAttr: string
 ): DataSet {
   // find collection containing joining attribute in joining dataset
-  const joiningCollection = findCollectionWithAttr(
-    joiningDataset.collections,
-    joiningAttr
-  );
-  if (
-    joiningCollection === undefined ||
-    joiningCollection.attrs === undefined
-  ) {
-    throw new Error(`Invalid joining attribute: ${joiningAttr}`);
-  }
+  const [joiningCollection] = validateAttribute(joiningDataset.collections, joiningAttr, 
+    `Invalid joining attribute: ${joiningAttr}`);
 
-  const addedAttrs = joiningCollection.attrs.map(cloneAttribute);
+  const addedAttrs = joiningCollection.attrs?.map(cloneAttribute) || [];
   const addedAttrOriginalNames = addedAttrs.map((attr) => attr.name);
 
   const collections = baseDataset.collections.map(cloneCollection);
-  const baseCollection = findCollectionWithAttr(collections, baseAttr);
-  if (baseCollection === undefined || baseCollection.attrs === undefined) {
-    throw new Error(`Invalid base attribute: ${baseAttr}`);
-  }
+  const [baseCollection] = validateAttribute(collections, baseAttr, 
+    `Invalid base attribute: ${baseAttr}`);
 
   // list of attributes whose names cannot be duplicated by the added attrs
   const namesToAvoid = allAttrNames(baseDataset);
@@ -103,7 +93,7 @@ function uncheckedJoin(
   }
 
   // add the attrs from the joining collection into the collection being joined into
-  baseCollection.attrs = baseCollection.attrs.concat(addedAttrs);
+  baseCollection.attrs = (baseCollection.attrs || []).concat(addedAttrs);
 
   // start with a copy of the base dataset's records
   const records = baseDataset.records.map(shallowCopy);
@@ -128,17 +118,4 @@ function uncheckedJoin(
     collections,
     records,
   };
-}
-
-/**
- * Finds a collection which contains an attribute of the given name,
- * or undefined if no such collection exists.
- */
-function findCollectionWithAttr(
-  collections: Collection[],
-  attribute: string
-): Collection | undefined {
-  return collections.find((coll) =>
-    coll.attrs?.find((attr) => attr.name === attribute)
-  );
 }

--- a/src/transformers/mean.ts
+++ b/src/transformers/mean.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { extractAttributeAsNumeric } from "./util";
+import { extractAttributeAsNumeric, validateAttribute } from "./util";
 
 /**
  * Takes the mean of a given column.
@@ -36,6 +36,8 @@ export async function mean({
  * @param attribute - The column to find the mean of.
  */
 function uncheckedMean(dataset: DataSet, attribute: string): number {
+  validateAttribute(dataset.collections, attribute);
+
   // Extract the numeric values from the indicated attribute.
   const values = extractAttributeAsNumeric(dataset, attribute);
 

--- a/src/transformers/median.ts
+++ b/src/transformers/median.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { extractAttributeAsNumeric } from "./util";
+import { extractAttributeAsNumeric, validateAttribute } from "./util";
 
 /**
  * Finds the median of a given attribute's values.
@@ -36,6 +36,8 @@ export async function median({
  * @param attribute - The column to find the median of.
  */
 function uncheckedMedian(dataset: DataSet, attribute: string): number {
+  validateAttribute(dataset.collections, attribute);
+
   // Extract numeric values from the indicated attribute
   const values = extractAttributeAsNumeric(dataset, attribute);
 

--- a/src/transformers/mode.ts
+++ b/src/transformers/mode.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { extractAttributeAsNumeric } from "./util";
+import { extractAttributeAsNumeric, validateAttribute } from "./util";
 
 /**
  * Finds the mode of a given attribute's values.
@@ -36,6 +36,8 @@ export async function mode({
  * @param attribute - The column to find the mode of.
  */
 function uncheckedMode(dataset: DataSet, attribute: string): number {
+  validateAttribute(dataset.collections, attribute);
+  
   // Extract numeric values from the indicated attribute
   const values = extractAttributeAsNumeric(dataset, attribute);
 

--- a/src/transformers/mode.ts
+++ b/src/transformers/mode.ts
@@ -37,7 +37,7 @@ export async function mode({
  */
 function uncheckedMode(dataset: DataSet, attribute: string): number {
   validateAttribute(dataset.collections, attribute);
-  
+
   // Extract numeric values from the indicated attribute
   const values = extractAttributeAsNumeric(dataset, attribute);
 

--- a/src/transformers/partition.ts
+++ b/src/transformers/partition.ts
@@ -231,12 +231,9 @@ export function partition(
 
   const records = dataset.records;
   for (const record of records) {
-    if (record[attribute] === undefined) {
-      throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute: ${attribute}`);
-    }
-
-    // convert CODAP value to string to use as a key
-    const valueAsStr = JSON.stringify(record[attribute]);
+    // Convert CODAP value to string to use as a key.
+    // NOTE: If record[attribute] is undefined (missing), this will use "" instead.
+    const valueAsStr = JSON.stringify(record[attribute] || "");
 
     // initialize this category if needed
     if (partitioned[valueAsStr] === undefined) {

--- a/src/transformers/partition.ts
+++ b/src/transformers/partition.ts
@@ -8,7 +8,7 @@ import {
   addContextUpdateListener,
   pushToUndoStack,
 } from "../utils/codapPhone/listeners";
-import { codapValueToString } from "./util";
+import { codapValueToString, validateAttribute } from "./util";
 import {
   DDTransformerProps,
   DDTransformerState,
@@ -224,13 +224,15 @@ export function partition(
   dataset: DataSet,
   attribute: string
 ): PartitionDataset[] {
+  validateAttribute(dataset.collections, attribute);
+
   // map from distinct values of an attribute to all records sharing that value
   const partitioned: Record<string, [unknown, Record<string, unknown>[]]> = {};
 
   const records = dataset.records;
   for (const record of records) {
     if (record[attribute] === undefined) {
-      throw new Error(`Invalid attribute: ${attribute}`);
+      throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute: ${attribute}`);
     }
 
     // convert CODAP value to string to use as a key

--- a/src/transformers/pivot.ts
+++ b/src/transformers/pivot.ts
@@ -207,11 +207,6 @@ function uncheckedPivotWider(
   const newAttrs = Array.from(
     new Set(
       dataset.records.map((rec, i) => {
-        if (rec[namesFrom] === undefined) {
-          throw new Error(
-            `TODO: MAYBE NO ERROR? Invalid attribute to retrieve names from: ${namesFrom}`
-          );
-        }
         if (typeof rec[namesFrom] === "object") {
           throw new Error(
             `Cannot use ${codapValueToString(
@@ -222,14 +217,18 @@ function uncheckedPivotWider(
           );
         }
 
-        return String(rec[namesFrom]);
+        // NOTE: If rec[namesFrom] is undefined (missing), this returns ""
+        return String(rec[namesFrom] || "");
       })
     )
   );
 
   // find attribute to take values from
-  const [, valuesFromAttr] = validateAttribute([collection], valuesFrom,
-    `Invalid attribute to retrieve values from: ${valuesFrom}`);
+  const [, valuesFromAttr] = validateAttribute(
+    [collection],
+    valuesFrom,
+    `Invalid attribute to retrieve values from: ${valuesFrom}`
+  );
 
   // remove namesFrom/valuesFrom attributes from collection
   collection.attrs =

--- a/src/transformers/pivot.ts
+++ b/src/transformers/pivot.ts
@@ -9,6 +9,7 @@ import {
   listAsString,
   pluralSuffix,
   plural,
+  validateAttribute,
 } from "./util";
 
 /**
@@ -77,6 +78,10 @@ function uncheckedPivotLonger(
   namesTo: string,
   valuesTo: string
 ): DataSet {
+  for (const attr of toPivot) {
+    validateAttribute(dataset.collections, attr);
+  }
+
   // TODO: is this a necessary requirement?
   if (dataset.collections.length !== 1) {
     throw new Error(
@@ -186,6 +191,9 @@ function uncheckedPivotWider(
   namesFrom: string,
   valuesFrom: string
 ): DataSet {
+  validateAttribute(dataset.collections, namesFrom);
+  validateAttribute(dataset.collections, valuesFrom);
+
   // TODO: is this a necessary requirement?
   if (dataset.collections.length !== 1) {
     throw new Error(
@@ -201,7 +209,7 @@ function uncheckedPivotWider(
       dataset.records.map((rec, i) => {
         if (rec[namesFrom] === undefined) {
           throw new Error(
-            `Invalid attribute to retrieve names from: ${namesFrom}`
+            `TODO: MAYBE NO ERROR? Invalid attribute to retrieve names from: ${namesFrom}`
           );
         }
         if (typeof rec[namesFrom] === "object") {
@@ -220,12 +228,8 @@ function uncheckedPivotWider(
   );
 
   // find attribute to take values from
-  const valuesFromAttr = collection.attrs?.find(
-    (attr) => attr.name === valuesFrom
-  );
-  if (valuesFromAttr === undefined) {
-    throw new Error(`Invalid attribute to retrieve values from: ${valuesFrom}`);
-  }
+  const [, valuesFromAttr] = validateAttribute([collection], valuesFrom,
+    `Invalid attribute to retrieve values from: ${valuesFrom}`);
 
   // remove namesFrom/valuesFrom attributes from collection
   collection.attrs =

--- a/src/transformers/selectAttributes.ts
+++ b/src/transformers/selectAttributes.ts
@@ -8,6 +8,7 @@ import {
   cloneCollection,
   pluralSuffix,
   listAsString,
+  validateAttribute,
 } from "./util";
 
 /**
@@ -54,6 +55,10 @@ function uncheckedSelectAttributes(
   attributes: string[],
   allBut: boolean
 ): DataSet {
+  for (const attr of attributes) {
+    validateAttribute(dataset.collections, attr);
+  }
+
   // determine which attributes are being selected
   const selectedAttrs = attrsToSelect(dataset, attributes, allBut);
 
@@ -70,7 +75,7 @@ function uncheckedSelectAttributes(
     for (const attrName of selectedAttrs) {
       // attribute does not appear on record, error
       if (record[attrName] === undefined) {
-        throw new Error(`Invalid attribute name: ${attrName}`);
+        throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute name: ${attrName}`);
       }
 
       copy[attrName] = record[attrName];

--- a/src/transformers/selectAttributes.ts
+++ b/src/transformers/selectAttributes.ts
@@ -73,11 +73,6 @@ function uncheckedSelectAttributes(
   for (const record of dataset.records) {
     const copy: Record<string, unknown> = {};
     for (const attrName of selectedAttrs) {
-      // attribute does not appear on record, error
-      if (record[attrName] === undefined) {
-        throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute name: ${attrName}`);
-      }
-
       copy[attrName] = record[attrName];
     }
     records.push(copy);

--- a/src/transformers/standardDeviation.ts
+++ b/src/transformers/standardDeviation.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { extractAttributeAsNumeric } from "./util";
+import { extractAttributeAsNumeric, validateAttribute } from "./util";
 
 /**
  * Finds the standard deviation of a given attribute's values.
@@ -51,6 +51,8 @@ function uncheckedStandardDeviation(
   dataset: DataSet,
   attribute: string
 ): number {
+  validateAttribute(dataset.collections, attribute);
+
   // Extract numeric values from the indicated attribute
   const values = extractAttributeAsNumeric(dataset, attribute);
 

--- a/src/transformers/sumProduct.ts
+++ b/src/transformers/sumProduct.ts
@@ -2,7 +2,7 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { codapValueToString, listAsString, pluralSuffix } from "./util";
+import { codapValueToString, listAsString, pluralSuffix, validateAttribute } from "./util";
 
 /**
  * Takes the sum product of the given columns.
@@ -44,11 +44,15 @@ function uncheckedSumProduct(dataset: DataSet, attributes: string[]): number {
     throw new Error("Cannot take the sum product of zero columns.");
   }
 
+  for (const attr of attributes) {
+    validateAttribute(dataset.collections, attr);
+  }
+
   return dataset.records
     .map((row) =>
       attributes.reduce((product, attribute) => {
         if (row[attribute] === undefined) {
-          throw new Error(`Invalid attribute name: ${attribute}`);
+          throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute name: ${attribute}`);
         }
         // Missing values turn the whole row into NaN
         if (row[attribute] === "") {

--- a/src/transformers/sumProduct.ts
+++ b/src/transformers/sumProduct.ts
@@ -2,7 +2,13 @@ import { DDTransformerState } from "../transformer-components/DataDrivenTransfor
 import { readableName } from "../transformer-components/util";
 import { getContextAndDataSet } from "../utils/codapPhone";
 import { DataSet, TransformationOutput } from "./types";
-import { codapValueToString, listAsString, pluralSuffix, validateAttribute } from "./util";
+import {
+  codapValueToString,
+  isMissing,
+  listAsString,
+  pluralSuffix,
+  validateAttribute,
+} from "./util";
 
 /**
  * Takes the sum product of the given columns.
@@ -51,11 +57,8 @@ function uncheckedSumProduct(dataset: DataSet, attributes: string[]): number {
   return dataset.records
     .map((row) =>
       attributes.reduce((product, attribute) => {
-        if (row[attribute] === undefined) {
-          throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute name: ${attribute}`);
-        }
         // Missing values turn the whole row into NaN
-        if (row[attribute] === "") {
+        if (isMissing(row[attribute])) {
           return NaN;
         }
         const value = parseFloat(String(row[attribute]));

--- a/src/transformers/transformColumn.ts
+++ b/src/transformers/transformColumn.ts
@@ -6,6 +6,7 @@ import {
   reportTypeErrorsForRecords,
   cloneCollection,
   shallowCopy,
+  validateAttribute,
 } from "./util";
 
 /**
@@ -53,6 +54,9 @@ async function uncheckedTransformColumn(
   expression: string,
   outputType: CodapLanguageType
 ): Promise<DataSet> {
+  validateAttribute(dataset.collections, attributeName,
+    `Invalid attribute to transform: ${attributeName}`);
+
   const records = dataset.records.map(shallowCopy);
   const exprValues = await evalExpression(expression, records);
 
@@ -63,7 +67,7 @@ async function uncheckedTransformColumn(
     const record = records[i];
 
     if (record[attributeName] === undefined) {
-      throw new Error(`Invalid attribute to transform: ${attributeName}`);
+      throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute to transform: ${attributeName}`);
     }
 
     record[attributeName] = value;

--- a/src/transformers/transformColumn.ts
+++ b/src/transformers/transformColumn.ts
@@ -54,8 +54,11 @@ async function uncheckedTransformColumn(
   expression: string,
   outputType: CodapLanguageType
 ): Promise<DataSet> {
-  validateAttribute(dataset.collections, attributeName,
-    `Invalid attribute to transform: ${attributeName}`);
+  validateAttribute(
+    dataset.collections,
+    attributeName,
+    `Invalid attribute to transform: ${attributeName}`
+  );
 
   const records = dataset.records.map(shallowCopy);
   const exprValues = await evalExpression(expression, records);
@@ -64,13 +67,7 @@ async function uncheckedTransformColumn(
   reportTypeErrorsForRecords(records, exprValues, outputType);
 
   exprValues.forEach((value, i) => {
-    const record = records[i];
-
-    if (record[attributeName] === undefined) {
-      throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute to transform: ${attributeName}`);
-    }
-
-    record[attributeName] = value;
+    records[i][attributeName] = value;
   });
 
   const collections = dataset.collections.map(cloneCollection);

--- a/src/transformers/util.ts
+++ b/src/transformers/util.ts
@@ -491,7 +491,7 @@ export function extractAttributeAsNumeric(
 
   for (const record of dataset.records) {
     if (record[attribute] === undefined) {
-      throw new Error(`Invalid attribute name: ${attribute}`);
+      throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute name: ${attribute}`);
     }
     // Ignore missing values
     if (record[attribute] === "") {
@@ -507,4 +507,25 @@ export function extractAttributeAsNumeric(
   }
 
   return numericValues;
+}
+
+/**
+ * Verifies that a given attribute (by name) exists in the given dataset. If
+ * the attribute is found, returns the collection it is in and the attribute 
+ * data. Otherwise, throws an error.
+ * 
+ * @param collections Collections within which to search for attribute. 
+ * @param attributeName The name of the attribute to look for.
+ * @param errorMsg A custom error message, to override the default.
+ */
+export function validateAttribute(collections: Collection[], attributeName: string, errorMsg?: string): [Collection, CodapAttribute] {
+  for (const coll of collections) {
+    const attr = coll.attrs?.find((attr) => attr.name === attributeName);
+
+    if (attr) {
+      return [coll, attr];
+    }
+  }
+
+  throw new Error(errorMsg || `Invalid attribute name: ${attributeName}`);
 }

--- a/src/transformers/util.ts
+++ b/src/transformers/util.ts
@@ -189,7 +189,7 @@ export function pluralSuffix<T>(word: string, describing: T[]): string {
  */
 export function codapValueToString(codapValue: unknown): string {
   // missing values
-  if (codapValue === "") {
+  if (isMissing(codapValue)) {
     return "a missing value";
   }
 
@@ -274,6 +274,17 @@ export function isColor(value: unknown): boolean {
     /rgb\(\d{1,3},\d{1,3},\d{1,3}\)/.test(noWhitespace) ||
     /rgba\(\d{1,3},\d{1,3},\d{1,3},(0|1)?\.\d*\)/.test(noWhitespace)
   );
+}
+
+/**
+ * Determines if the value represents a missing value in CODAP. These can
+ * manifest as either empty string "" or undefined.
+ *
+ * @param value The value to check for missing-ness
+ * @returns Whether or not the value is a missing value
+ */
+export function isMissing(value: unknown): boolean {
+  return value === "" || value === undefined;
 }
 
 export function reportTypeErrorsForRecords(
@@ -476,8 +487,9 @@ export const cloneAttribute = shallowCopy;
 
 /**
  * Extracts a list of numbers from an attribute in a dataset that is expected
- * to contain numeric values. Errors if the attribute is undefined for some
- * records, or if the attribute's values parse to non-numeric.
+ * to contain numeric values. Errors if the attribute's values parse to
+ * non-numeric. NOTE: This does not validate the given attribute--if the
+ * attribute isn't defined for any cases, this will return an empty list.
  *
  * @param dataset The dataset to extract from.
  * @param attribute The attribute containing numeric values.
@@ -490,11 +502,8 @@ export function extractAttributeAsNumeric(
   const numericValues = [];
 
   for (const record of dataset.records) {
-    if (record[attribute] === undefined) {
-      throw new Error(`TODO: MAYBE NO ERROR? Invalid attribute name: ${attribute}`);
-    }
     // Ignore missing values
-    if (record[attribute] === "") {
+    if (isMissing(record[attribute])) {
       continue;
     }
     const value = parseFloat(String(record[attribute]));
@@ -511,14 +520,18 @@ export function extractAttributeAsNumeric(
 
 /**
  * Verifies that a given attribute (by name) exists in the given dataset. If
- * the attribute is found, returns the collection it is in and the attribute 
+ * the attribute is found, returns the collection it is in and the attribute
  * data. Otherwise, throws an error.
- * 
- * @param collections Collections within which to search for attribute. 
+ *
+ * @param collections Collections within which to search for attribute.
  * @param attributeName The name of the attribute to look for.
  * @param errorMsg A custom error message, to override the default.
  */
-export function validateAttribute(collections: Collection[], attributeName: string, errorMsg?: string): [Collection, CodapAttribute] {
+export function validateAttribute(
+  collections: Collection[],
+  attributeName: string,
+  errorMsg?: string
+): [Collection, CodapAttribute] {
   for (const coll of collections) {
     const attr = coll.attrs?.find((attr) => attr.name === attributeName);
 


### PR DESCRIPTION
This adds a mechanism for ensuring that when a transformer takes a dataset and an attribute(s) from that dataset, we can check that the attribute exists within the dataset (by searching collections).

Previously, "Invalid attribute" errors were mostly being detected when we were processing a row and found that the given attribute was `undefined` for that row. We later discovered that rows can be `undefined` for an attribute that is indeed part of the dataset (see #144 and #148). Relying on row processing to detect these errors was brittle because 1) if there are no rows, attribute errors wouldn't be detected, and 2) the above situation, in which an attribute is actually valid but `undefined` in rows.

This checks attributes separately from handling of undefined values in rows. This PR also moves to treating `row[attr] === undefined` as a _missing value_, instead of an error--this is because when this happens, it appears exactly as a missing value does to the user.