### PR TITLE
use function application syntax in dataset titles

### DIFF
--- a/src/transformer-components/util.ts
+++ b/src/transformer-components/util.ts
@@ -25,15 +25,13 @@ export async function applyNewDataSet(
 }
 
 /**
- * Returns the context's title, if any, or falls back to its name. Also
- * adds parentheses around the name if it determines the name
- * is not a single word.
+ * Returns the context's title, if any, or falls back to its name.
  *
  * @param context the data context to produce a readable name for
  * @returns readable name of the context
  */
 export function readableName(context: DataContext): string {
-  return parenthesizeName(context.title ? context.title : context.name);
+  return context.title ? context.title : context.name;
 }
 
 /**

--- a/src/transformers/buildColumn.ts
+++ b/src/transformers/buildColumn.ts
@@ -45,7 +45,7 @@ export async function buildColumn({
       expression,
       outputType
     ),
-    `Build Column of ${ctxtName}`,
+    `BuildColumn(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with a new attribute (${attributeName}) added to ` +
       `the ${collectionName} collection, whose value is determined by the formula \`${expression}\`.`,
   ];

--- a/src/transformers/combineCases.ts
+++ b/src/transformers/combineCases.ts
@@ -33,7 +33,7 @@ export async function combineCases({
 
   return [
     await uncheckedCombineCases(dataset1, dataset2),
-    `Combined Cases of ${ctxtName1} and ${ctxtName2}`,
+    `CombinedCases(${ctxtName1}, ${ctxtName2})`,
     `A copy of ${ctxtName1}, containing all of the cases from both ${ctxtName1} and ${ctxtName2}.`,
   ];
 }

--- a/src/transformers/compare.ts
+++ b/src/transformers/compare.ts
@@ -52,13 +52,13 @@ export async function compare({
         inputAttribute1,
         inputAttribute2
       ),
-      `Compare of ${contextName}`,
+      `Compare(${contextName}, ...)`,
       `A categorical comparison of the attributes ${inputAttribute1} and ${inputAttribute2} (from ${contextName})`,
     ];
   } else {
     return [
       await uncheckedNumericCompare(dataset, inputAttribute1, inputAttribute2),
-      `Compare of ${contextName}`,
+      `Compare(${contextName}, ...)`,
       `A numeric comparison of the attributes ${inputAttribute1} and ${inputAttribute2} (from ${contextName})`,
     ];
   }

--- a/src/transformers/copy.ts
+++ b/src/transformers/copy.ts
@@ -18,7 +18,7 @@ export async function copy({
 
   return [
     await uncheckedCopy(dataset),
-    `Copy of ${ctxtName}`,
+    `Copy(${ctxtName})`,
     `A copy of the ${ctxtName} dataset.`,
   ];
 }

--- a/src/transformers/copyStructure.ts
+++ b/src/transformers/copyStructure.ts
@@ -19,7 +19,7 @@ export async function copyStructure({
 
   return [
     await uncheckedCopyStructure(dataset),
-    `Structure Copy of ${ctxtName}`,
+    `CopyStructure(${ctxtName})`,
     `A copy of the collections and attributes of the ${ctxtName} dataset, but with no cases.`,
   ];
 }

--- a/src/transformers/count.ts
+++ b/src/transformers/count.ts
@@ -36,7 +36,7 @@ export async function count({
 
   return [
     await uncheckedCount(dataset, attributes),
-    `Count of ${attributeNames} in ${ctxtName}`,
+    `Count(${ctxtName}, ...)`,
     `A summary of the frequency of all tuples of the ${pluralSuffix(
       "attribute",
       attributes

--- a/src/transformers/filter.ts
+++ b/src/transformers/filter.ts
@@ -24,7 +24,7 @@ export async function filter({
 
   return [
     await uncheckedFilter(dataset, predicate),
-    `Filter of ${ctxtName}`,
+    `Filter(${ctxtName}, ...)`,
     `A copy of ${ctxtName} that only includes the cases for which the predicate \`${predicate}\` is true.`,
   ];
 }

--- a/src/transformers/flatten.ts
+++ b/src/transformers/flatten.ts
@@ -20,7 +20,7 @@ export async function flatten({
 
   return [
     await uncheckedFlatten(dataset),
-    `Flatten of ${ctxtName}`,
+    `Flatten(${ctxtName})`,
     `A copy of ${ctxtName} in which all collections have been flattened into one collection.`,
   ];
 }

--- a/src/transformers/fold.ts
+++ b/src/transformers/fold.ts
@@ -61,7 +61,7 @@ function makeFoldWrapper(
         resultAttributeName,
         attributeDescription
       ),
-      `${label} of ${ctxtName}`,
+      `${label.replace(/\s+/, "")}(${ctxtName}, ...)`,
       datasetDescription,
     ];
   };
@@ -151,7 +151,7 @@ export async function genericFold({
       accumulatorName,
       resultDescription
     ),
-    `Reduce of ${ctxtName}`,
+    `Reduce(${ctxtName}, ...)`,
     `A reduce of the ${ctxtName} dataset, with an attribute ${resultColumnName} ` +
       `whose values are determined by the formula \`${expression}\`. ` +
       `The accumulator is named ${accumulatorName} and its initial value is \`${base}\`.`,
@@ -323,7 +323,7 @@ export async function differenceFrom({
       resultAttributeName,
       Number(startingValue)
     ),
-    `Difference From of ${ctxtName}`,
+    `DifferenceFrom(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with a new column whose values are the difference between ` +
       `the value of ${inputAttributeName} in the current case and the value of ${inputAttributeName} ` +
       `in the case above. The first case subtracts ${startingValue} from itself.`,

--- a/src/transformers/groupBy.ts
+++ b/src/transformers/groupBy.ts
@@ -52,7 +52,7 @@ export async function groupBy({
 
   return [
     await uncheckedGroupBy(dataset, attrNames, parentName),
-    `Group By of ${ctxtName}`,
+    `GroupBy(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with a new parent collection added ` +
       `which contains a copy of the ${pluralSuffix(
         "attribute",

--- a/src/transformers/join.ts
+++ b/src/transformers/join.ts
@@ -44,7 +44,7 @@ export async function join({
 
   return [
     await uncheckedJoin(dataset1, inputAttribute1, dataset2, inputAttribute2),
-    `Join of ${ctxtName1} and ${ctxtName2}`,
+    `Join(${ctxtName1}, ${ctxtName2}, ...)`,
     `A copy of ${ctxtName1}, with all the attributes/values from the collection ` +
       `containing ${inputAttribute2} in ${ctxtName2} added into the collection ` +
       `containing ${inputAttribute1} in ${ctxtName1}.`,

--- a/src/transformers/mean.ts
+++ b/src/transformers/mean.ts
@@ -24,7 +24,7 @@ export async function mean({
 
   return [
     uncheckedMean(dataset, attribute),
-    `Mean of ${attribute} in ${ctxtName}`,
+    `Mean(${ctxtName}, ${attribute})`,
     `The mean value of the ${attribute} attribute in the ${ctxtName} dataset.`,
   ];
 }

--- a/src/transformers/median.ts
+++ b/src/transformers/median.ts
@@ -24,7 +24,7 @@ export async function median({
 
   return [
     uncheckedMedian(dataset, attribute),
-    `Median of ${attribute} in ${ctxtName}`,
+    `Median(${ctxtName}, ${attribute})`,
     `The median value of the ${attribute} attribute in the ${ctxtName} dataset.`,
   ];
 }

--- a/src/transformers/mode.ts
+++ b/src/transformers/mode.ts
@@ -24,7 +24,7 @@ export async function mode({
 
   return [
     uncheckedMode(dataset, attribute),
-    `Mode of ${attribute} in ${ctxtName}`,
+    `Mode(${ctxtName}, ${attribute})`,
     `The mode value of the ${attribute} attribute in the ${ctxtName} dataset.`,
   ];
 }

--- a/src/transformers/partition.ts
+++ b/src/transformers/partition.ts
@@ -70,9 +70,9 @@ async function doTransform(
   // return both the datasets and their names
   return partitioned.map((pd) => [
     pd,
-    `${attributeName} = ${codapValueToString(
+    `Partition(${attributeName} = ${codapValueToString(
       pd.distinctValue
-    )} in ${readableContext}`,
+    )}, ${readableContext})`,
   ]);
 }
 

--- a/src/transformers/pivot.ts
+++ b/src/transformers/pivot.ts
@@ -45,7 +45,7 @@ export async function pivotLonger({
 
   return [
     await uncheckedPivotLonger(dataset, attributes, namesTo, valuesTo),
-    `Pivot Longer of ${ctxtName}`,
+    `PivotLonger(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with the ${pluralSuffix(
       "attribute",
       attributes
@@ -165,7 +165,7 @@ export async function pivotWider({
   const ctxtName = readableName(context);
   return [
     await uncheckedPivotWider(dataset, namesFrom, valuesFrom),
-    `Pivot Wider of ${ctxtName}`,
+    `PivotWider(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with the values in attribute ${namesFrom} converted ` +
       `into new attributes, which get their values from the attribute ${valuesFrom}.`,
   ];

--- a/src/transformers/selectAttributes.ts
+++ b/src/transformers/selectAttributes.ts
@@ -32,7 +32,7 @@ export async function selectAttributes({
 
   return [
     await uncheckedSelectAttributes(dataset, attributes, allBut),
-    `Select Attributes of ${ctxtName}`,
+    `SelectAttributes(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with ${
       allBut ? "all but" : "only"
     } the ${pluralSuffix("attribute", attributes)} ${attributeNames} included.`,

--- a/src/transformers/sort.ts
+++ b/src/transformers/sort.ts
@@ -80,7 +80,7 @@ export async function sort({
   const ctxtName = readableName(context);
   return [
     await uncheckedSort(dataset, expression, outputType, sortDirection),
-    `Sort ${sortDirection} of ${ctxtName}`,
+    `Sort(${ctxtName}, ...)`,
     `A copy of ${ctxtName}, sorted by the value of the key formula: \`${expression}\`.`,
   ];
 }

--- a/src/transformers/standardDeviation.ts
+++ b/src/transformers/standardDeviation.ts
@@ -26,7 +26,7 @@ export async function standardDeviation({
 
   return [
     uncheckedStandardDeviation(dataset, attribute),
-    `Standard Deviation of ${attribute} in ${ctxtName}`,
+    `StandardDeviation(${ctxtName}, ${attribute})`,
     `The standard deviation of the ${attribute} attribute in the ${ctxtName} dataset.`,
   ];
 }

--- a/src/transformers/sumProduct.ts
+++ b/src/transformers/sumProduct.ts
@@ -27,7 +27,7 @@ export async function sumProduct({
 
   return [
     await uncheckedSumProduct(dataset, attributes),
-    `Sum Product of ${ctxtName}`,
+    `SumProduct(${ctxtName}, [${attributes.join(", ")}])`,
     `The sum across all cases in ${ctxtName} of the product ` +
       `of the ${pluralSuffix("attribute", attributes)} ${attributeNames}.`,
   ];

--- a/src/transformers/transformColumn.ts
+++ b/src/transformers/transformColumn.ts
@@ -41,7 +41,7 @@ export async function transformColumn({
       expression,
       outputType
     ),
-    `Transform Column of ${ctxtName}`,
+    `TransformColumn(${ctxtName}, ...)`,
     `A copy of ${ctxtName}, with the ${attributeName} attribute's values ` +
       `determined by the formula \`${expression}\`.`,
   ];


### PR DESCRIPTION
This switches to dataset titles of the form:

- `Transformer(Dataset)` for transformers whose only parameter is a dataset (or 2)
- `Transformer(Dataset, ...)` for transformers which have other parameters (attributes, formulas, etc). The `...` indicates "more parameters went into this transformer, but you should check the description to read about them"
- something else for special cases.

Special cases include Partition, which creates multiple datasets and therefore seems to need something that differentiates its output datasets by their titles. Also, the single value transformers incorporate the attribute(s) they are computed over, because there is no "description" attached to text components.

Example:

![Screenshot from 2021-07-19 11-45-24](https://user-images.githubusercontent.com/13399527/126188370-4e10b820-afa3-4038-a5c2-9b107f835fd0.png)
