### PR TITLE
allow multiple values in mode

### DIFF
--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -43,6 +43,7 @@ import {
   SafeActiveTransformationsDispatch,
   ActionTypes as ActiveTransformationActionTypes,
 } from "../utils/transformationDescription";
+import { displaySingleValue } from "../transformers/util";
 
 // These types represent the configuration required for different UI elements
 interface ComponentInit {
@@ -328,7 +329,7 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
       // Determine whether the transformerFunction returns a textbox or a table
       if (typeof result === "number" || Array.isArray(result)) {
         // This is the case where the transformer returns a single value
-        const textName = await createText(name, String(result));
+        const textName = await createText(name, displaySingleValue(result));
 
         activeTransformationsDispatch({
           type: ActiveTransformationActionTypes.ADD,

--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -326,9 +326,8 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
       }
 
       // Determine whether the transformerFunction returns a textbox or a table
-      if (typeof result === "number") {
-        // This is the case where the transformer returns a number
-
+      if (typeof result === "number" || Array.isArray(result)) {
+        // This is the case where the transformer returns a single value
         const textName = await createText(name, String(result));
 
         activeTransformationsDispatch({

--- a/src/transformer-components/transformerList.ts
+++ b/src/transformer-components/transformerList.ts
@@ -678,11 +678,12 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: mode },
       info: {
         summary:
-          "Finds the mode value of a given numeric attribute in the given \
-          dataset. This is the value which occurs most often under the given attribute.",
-        consumes: "A dataset and an attribute within it to find the mode of.",
+          "Finds the mode value(s) of a given numeric attribute in the given \
+          dataset. These are the values which occur most often under the given attribute.",
+        consumes:
+          "A dataset and an attribute within it to find the mode(s) of.",
         produces:
-          "A single number which is the mode value of the given attribute.",
+          "A list of numbers which are the most frequently occuring in the given attribute.",
       },
     },
   },

--- a/src/transformers/mode.ts
+++ b/src/transformers/mode.ts
@@ -35,7 +35,7 @@ export async function mode({
  * @param dataset - The input DataSet
  * @param attribute - The column to find the mode of.
  */
-function uncheckedMode(dataset: DataSet, attribute: string): number {
+function uncheckedMode(dataset: DataSet, attribute: string): number[] {
   // Extract numeric values from the indicated attribute
   const values = extractAttributeAsNumeric(dataset, attribute);
 
@@ -52,20 +52,23 @@ function uncheckedMode(dataset: DataSet, attribute: string): number {
     valueToFrequency[value]++;
   }
 
-  // Find the value that occurs with maximum frequency. NOTE: The below cast
-  // is safe because values/valueToFrequency are guaranteed to be non-empty
-  // because we have already errored out if the dataset has no records.
-  const [mostFrequent] = Object.entries(valueToFrequency).reduce(
-    (maxes: [string, number] | undefined, elt) => {
-      if (maxes === undefined) {
-        return elt;
-      }
+  // Find the maximum frequency of any element in the value to frequency map.
+  // The below cast to number is safe because we already checked that values
+  // (and therefore valueToFrequency) is non-empty and therefore some max exists.
+  const maxFrequency = Object.entries(valueToFrequency).reduce(
+    (maxFrequency: number | undefined, elt) => {
       const [, frequency] = elt;
-      const [, maxFrequency] = maxes;
-      return frequency > maxFrequency ? elt : maxes;
+      if (maxFrequency === undefined) {
+        return frequency;
+      } else {
+        return frequency > maxFrequency ? frequency : maxFrequency;
+      }
     },
     undefined
-  ) as [string, number];
+  ) as number;
 
-  return Number(mostFrequent);
+  // Return all values which have the max frequency
+  return Object.keys(valueToFrequency)
+    .map((v) => Number(v))
+    .filter((v) => valueToFrequency[v] === maxFrequency);
 }

--- a/src/transformers/types.ts
+++ b/src/transformers/types.ts
@@ -30,16 +30,21 @@ export type Boundary = {
 };
 
 /**
+ * SingeValue represents the output of a single-value transformer (e.g. median).
+ */
+type SingleValue = number | number[];
+
+/**
  * The format for output for most transformations contains three parts:
  *  1) dataset or numeric value (DataSet | number)
  *  2) output context name (string)
  *  3) output context description] (string)
  */
 export type DataSetTransformationOutput = [DataSet, string, string];
-export type NumberTransformationOutput = [number, string, string];
+export type SingleValueTransformationOutput = [SingleValue, string, string];
 
 export type TransformationOutput =
   | DataSetTransformationOutput
-  | NumberTransformationOutput;
+  | SingleValueTransformationOutput;
 
 export type FullOverrideSaveState = PartitionSaveState;

--- a/src/transformers/types.ts
+++ b/src/transformers/types.ts
@@ -32,7 +32,7 @@ export type Boundary = {
 /**
  * SingeValue represents the output of a single-value transformer (e.g. median).
  */
-type SingleValue = number | number[];
+export type SingleValue = number | number[];
 
 /**
  * The format for output for most transformations contains three parts:

--- a/src/transformers/util.ts
+++ b/src/transformers/util.ts
@@ -1,7 +1,7 @@
 import { Collection, CodapAttribute } from "../utils/codapPhone/types";
 import { Env } from "../language/interpret";
 import { Value } from "../language/ast";
-import { Boundary, CodapLanguageType, DataSet } from "./types";
+import { Boundary, CodapLanguageType, DataSet, SingleValue } from "./types";
 import { prettyPrintCase } from "../utils/prettyPrint";
 
 /**
@@ -507,4 +507,20 @@ export function extractAttributeAsNumeric(
   }
 
   return numericValues;
+}
+
+/**
+ * Converts a SingleValue (the output of a single-value transformer)
+ * into a string.
+ *
+ * @param value The value to convert to a string.
+ */
+export function displaySingleValue(value: SingleValue): string {
+  if (typeof value === "number") {
+    // value is a single number
+    return String(value);
+  } else {
+    // value is a list of numbers
+    return `[${value.join(", ")}]`;
+  }
 }

--- a/src/utils/transformationDescription.ts
+++ b/src/utils/transformationDescription.ts
@@ -26,6 +26,7 @@ import {
 } from "./codapPhone/listeners";
 import { InteractiveState } from "./codapPhone/types";
 import { PartitionSaveState } from "../transformers/partition";
+import { displaySingleValue } from "../transformers/util";
 
 /**
  * useActiveTransformations
@@ -234,7 +235,7 @@ async function updateTextFromDatasetCreator(
   ) => Promise<SingleValueTransformationOutput>
 ): Promise<void> {
   const [result] = await transformFunc(state);
-  await updateText(outputName, String(result));
+  await updateText(outputName, displaySingleValue(result));
 }
 
 async function updateFromFullOverride(

--- a/src/utils/transformationDescription.ts
+++ b/src/utils/transformationDescription.ts
@@ -9,7 +9,7 @@ import {
 } from "../transformer-components/DataDrivenTransformer";
 import {
   DataSetTransformationOutput,
-  NumberTransformationOutput,
+  SingleValueTransformationOutput,
 } from "../transformers/types";
 import {
   updateContextWithDataSet,
@@ -206,7 +206,7 @@ async function updateFromDescription(
         description.output,
         transformFunc.func as (
           state: DDTransformerState
-        ) => Promise<NumberTransformationOutput>
+        ) => Promise<SingleValueTransformationOutput>
       );
     }
   } else if (transformFunc.kind === "fullOverride") {
@@ -231,7 +231,7 @@ async function updateTextFromDatasetCreator(
   outputName: string,
   transformFunc: (
     state: DDTransformerState
-  ) => Promise<NumberTransformationOutput>
+  ) => Promise<SingleValueTransformationOutput>
 ): Promise<void> {
   const [result] = await transformFunc(state);
   await updateText(outputName, String(result));


### PR DESCRIPTION
This adds support for a single-value transformer producing a list of numbers, and applies it to the Mode transformer, which now produces all the mode values of the given attribute.