### PR TITLE
name changes for running aggregators

### DIFF
--- a/src/transformers/fold.ts
+++ b/src/transformers/fold.ts
@@ -39,9 +39,7 @@ function makeFoldWrapper(
 
     const { context, dataset } = await getContextAndDataSet(contextName);
     const resultAttributeName = uniqueName(
-      `${label} of ${parenthesizeName(inputAttributeName)} from ${readableName(
-        context
-      )}`,
+      `${label} of ${parenthesizeName(inputAttributeName)}`,
       allAttrNames(dataset)
     );
 
@@ -321,6 +319,7 @@ export async function differenceFrom({
       dataset,
       inputAttributeName,
       resultAttributeName,
+      `The difference of each case with the case above it (from the ${inputAttributeName} attribute in the ${ctxtName} dataset). ${startingValue} is subtracted from the first case.`,
       Number(startingValue)
     ),
     `DifferenceFrom(${ctxtName}, ...)`,
@@ -334,6 +333,7 @@ function uncheckedDifferenceFrom(
   dataset: DataSet,
   inputColumnName: string,
   resultColumnName: string,
+  resultColumnDescription: string,
   startingValue = 0
 ): DataSet {
   // Construct a fold that computes the difference of each case with
@@ -350,5 +350,10 @@ function uncheckedDifferenceFrom(
     }
   );
 
-  return differenceFromFold(dataset, inputColumnName, resultColumnName, "");
+  return differenceFromFold(
+    dataset,
+    inputColumnName,
+    resultColumnName,
+    resultColumnDescription
+  );
 }


### PR DESCRIPTION
This removes the dataset name from running aggregator names, as was brought up in #154. It also gives Difference From a more useful tooltip.