### PR TITLE
Show `[fixed]` labels on table with deleted inputs

### DIFF
--- a/src/utils/codapPhone/index.ts
+++ b/src/utils/codapPhone/index.ts
@@ -27,6 +27,9 @@ import {
   CodapAttribute,
   GetInteractiveStateResponse,
   InteractiveFrame,
+  CodapComponent,
+  GetComponentResponse,
+  ComponentListResponse,
 } from "./types";
 import {
   callUpdateListenersForContext,
@@ -303,6 +306,85 @@ export function notifyInteractiveFrameIsDirty(): Promise<void> {
           reject(
             new Error("Failed to notify interactive frame that state is dirty.")
           );
+        }
+      }
+    )
+  );
+}
+
+export function getAllComponents(): Promise<ComponentListResponse["values"]> {
+  return new Promise((resolve, reject) =>
+    phone.call(
+      {
+        action: CodapActions.Get,
+        resource: CodapListResource.ComponentList,
+      },
+      (response: ComponentListResponse) => {
+        if (Array.isArray(response.values)) {
+          resolve(response.values);
+        } else {
+          reject(new Error("Failed to get components."));
+        }
+      }
+    )
+  );
+}
+
+export function getComponent(component: string): Promise<CodapComponent> {
+  return new Promise<CodapComponent>((resolve, reject) =>
+    phone.call(
+      {
+        action: CodapActions.Get,
+        resource: resourceFromComponent(component),
+      },
+      (response: GetComponentResponse) => {
+        if (response.success) {
+          resolve(response.values);
+        } else {
+          reject(new Error("Failed to get component."));
+        }
+      }
+    )
+  );
+}
+
+export function updateComponent(
+  component: string,
+  values: Partial<CaseTable>
+): Promise<void> {
+  return new Promise((resolve, reject) =>
+    phone.call(
+      {
+        action: CodapActions.Update,
+        resource: resourceFromComponent(component),
+        values: values,
+      },
+      (response) => {
+        if (response.success) {
+          resolve();
+        } else {
+          reject(new Error("Failed to update component."));
+        }
+      }
+    )
+  );
+}
+export function updateDataContext(
+  context: string,
+  values: Partial<DataContext>
+): Promise<void> {
+  return new Promise((resolve, reject) =>
+    phone.call(
+      {
+        action: CodapActions.Update,
+        resource: resourceFromContext(context),
+        values: values,
+      },
+      (response) => {
+        if (response.success) {
+          resolve();
+        } else {
+          reject(new Error("Failed to update context."));
         }
       }
     )

--- a/src/utils/codapPhone/types.ts
+++ b/src/utils/codapPhone/types.ts
@@ -81,6 +81,11 @@ export type GetListRequest = {
   resource: CodapListResource;
 };
 
+export type GetComponentListRequest = {
+  action: CodapActions.Get;
+  resource: CodapListResource.ComponentList;
+};
+
 export type CreateContextRequest = {
   action: CodapActions.Create;
   resource: CodapResource.DataContext;
@@ -120,6 +125,17 @@ export interface UpdateTextRequest {
   action: CodapActions.Update;
   resource: string;
   values: Partial<Text>;
+}
+
+export interface UpdateComponentRequest {
+  action: CodapActions.Update;
+  resource: string;
+  values: Partial<CodapComponent>;
+}
+export interface UpdateContextRequest {
+  action: CodapActions.Update;
+  resource: string;
+  values: Partial<DataContext>;
 }
 
 export interface NotifyUndoChangeNoticeRequest {
@@ -170,6 +186,10 @@ interface ListResponse extends CodapResponse {
   values: CodapIdentifyingInfo[];
 }
 
+export interface ComponentListResponse extends CodapResponse {
+  values: (CodapIdentifyingInfo & { type: CodapComponentType })[];
+}
+
 interface GetDataResponse extends CodapResponse {
   values: {
     values: Record<string, unknown>;
@@ -188,6 +208,10 @@ export interface GetCaseResponse extends CodapResponse {
   values: {
     case: ReturnedCase;
   };
+}
+
+export interface GetComponentResponse extends CodapResponse {
+  values: CodapComponent;
 }
 
 export interface GetContextResponse extends CodapResponse {
@@ -228,11 +252,16 @@ export type CodapPhone = {
   ): void;
   call(r: GetContextListRequest, cb: (r: ListResponse) => void): void;
   call(r: GetListRequest, cb: (r: ListResponse) => void): void;
+  call(
+    r: GetComponentListRequest,
+    cb: (r: ComponentListResponse) => void
+  ): void;
   call(r: GetRequest, cb: (r: GetDataResponse) => void): void;
   call(r: GetRequest, cb: (r: GetContextResponse) => void): void;
   call(r: GetRequest, cb: (r: GetDataListResponse) => void): void;
   call(r: GetRequest, cb: (r: GetCasesResponse) => void): void;
   call(r: GetRequest, cb: (r: GetCaseResponse) => void): void;
+  call(r: GetRequest, cb: (r: GetComponentResponse) => void): void;
   call(r: CreateContextRequest, cb: (r: CreateContextResponse) => void): void;
   call(r: CreateDataItemsRequest, cb: (r: CodapResponse) => void): void;
   call(r: CreateCollectionsRequest, cb: (r: ListResponse) => void): void;
@@ -240,6 +269,8 @@ export type CodapPhone = {
   call(r: CreateTableRequest, cb: (r: TableResponse) => void): void;
   call(r: CreateTextRequest, cb: (r: CodapResponse) => void): void;
   call(r: UpdateTextRequest, cb: (r: CodapResponse) => void): void;
+  call(r: UpdateComponentRequest, cb: (r: CodapResponse) => void): void;
+  call(r: UpdateContextRequest, cb: (r: CodapResponse) => void): void;
   call(r: EvalExpressionRequest, cb: (r: EvalExpressionResponse) => void): void;
   call(
     r: GetFunctionInfoRequest,

--- a/src/utils/transformationDescription.ts
+++ b/src/utils/transformationDescription.ts
@@ -18,7 +18,6 @@ import {
   updateText,
   notifyInteractiveFrameIsDirty,
   updateDataContext,
-  getDataContext,
   getComponent,
   updateComponent,
 } from "./codapPhone";
@@ -140,6 +139,8 @@ export function useActiveTransformations(
                 },
               });
             }
+          } else if (transformation.transformer === "Editable Copy") {
+            // If the transformer was editable copy then we don't have to do anything
           } else {
             if (transformation.outputType === TransformationOutputType.TEXT) {
               // If this is an SV transformer than update the output text component title

--- a/src/utils/transformationDescription.ts
+++ b/src/utils/transformationDescription.ts
@@ -17,6 +17,8 @@ import {
   notifyInteractiveFrameIsDirty,
   updateDataContext,
   getDataContext,
+  getComponent,
+  updateComponent,
 } from "./codapPhone";
 import {
   addInteractiveStateRequestListener,
@@ -124,11 +126,22 @@ export function useActiveTransformations(
         // Rename transformations with newly missing inputs to add a [fixed] suffix
         for (const transformation of transformationsWithNewlyMissingInputs) {
           if ("output" in transformation) {
-            console.log("transformation", transformation);
-            const outputData = await getDataContext(transformation.output);
-            await updateDataContext(transformation.output, {
-              title: `${outputData.title} [fixed]`,
-            });
+            if (transformation.outputType === TransformationOutputType.TEXT) {
+              const outputData = await getComponent(transformation.output);
+              await updateComponent(transformation.output, {
+                title: `${outputData.title} [fixed]`,
+              });
+            } else if (
+              transformation.outputType === TransformationOutputType.CONTEXT
+            ) {
+              const outputData = await getDataContext(transformation.output);
+              await updateDataContext(transformation.output, {
+                title: `${outputData.title} [fixed]`,
+                metadata: {
+                  description: `${outputData.metadata?.description}\n\n An input to the transformer that created this dataset has been deleted so this dataset will no longer update.`,
+                },
+              });
+            }
           }
         }
         // Remove transformations with newly missing inputs

--- a/src/utils/transformationDescription.ts
+++ b/src/utils/transformationDescription.ts
@@ -28,6 +28,7 @@ import {
   removeContextUpdateHook,
   addContextDeletedHook,
   removeContextDeletedHook,
+  callAllContextListeners,
 } from "./codapPhone/listeners";
 import { makeDatasetImmutable } from "../transformers/util";
 import { InteractiveState } from "./codapPhone/types";
@@ -162,6 +163,8 @@ export function useActiveTransformations(
             }
           }
         }
+        callAllContextListeners();
+
         // Remove transformations with newly missing inputs
         cloned[input] = cloned[input].filter(
           (description) =>

--- a/src/utils/transformationDescription.ts
+++ b/src/utils/transformationDescription.ts
@@ -15,6 +15,8 @@ import {
   updateContextWithDataSet,
   updateText,
   notifyInteractiveFrameIsDirty,
+  updateDataContext,
+  getDataContext,
 } from "./codapPhone";
 import {
   addInteractiveStateRequestListener,
@@ -104,6 +106,20 @@ export function useActiveTransformations(
     async function callback(deletedContext: string) {
       const cloned = { ...activeTransformations };
       for (const input of Object.keys(cloned)) {
+        const transformations = activeTransformations[input].filter(
+          (description) =>
+            description.inputs.includes(deletedContext) ||
+            description.extraDependencies.includes(deletedContext)
+        );
+        for (const transformation of transformations) {
+          if ("output" in transformation) {
+            console.log("transformation", transformation);
+            const outputData = await getDataContext(transformation.output);
+            await updateDataContext(transformation.output, {
+              title: `${outputData.title} [fixed]`,
+            });
+          }
+        }
         cloned[input] = cloned[input].filter(
           (description) =>
             !(


### PR DESCRIPTION
This PR adds to the context deletion listener to make sure that when a table is deleted all it's output tables get the string `[fixed]` appended to their title.

Notably, this title change does not flow through to further tables, so you can get the following scenario.
![image](https://user-images.githubusercontent.com/40366824/126647928-50112ee3-c3da-4622-8752-0371e9eb2a20.png)
How do we think this case should be handled? Should we propagate the `[fixed]` notification to further tables, so we get `Copy(Copy(People)) [fixed]`, or should we propagate the new table name so we get `Copy(Copy(People) [fixed])`?