### PR TITLE
update inline docs to reflect/link to standalone docs

### DIFF
--- a/src/transformer-components/AboutInfo.tsx
+++ b/src/transformer-components/AboutInfo.tsx
@@ -21,7 +21,7 @@ function AboutInfo(): ReactElement {
 
           <p>
             The result of one transformer can be used as an input to another,
-            and in this way transformers can be chained together, resulting in a
+            and in this way transformers can be composed, resulting in a
             sequence of datasets, each a transformed version of the previous.
             This way of manipulating a dataset can be useful for making clear
             the specific steps that were used to process the data or change its
@@ -29,14 +29,20 @@ function AboutInfo(): ReactElement {
           </p>
 
           <p>
-            Any updates made to the input of a transformer will flow through and
-            affect its outputs. If you have a chain of transformed datasets, the
-            updates will flow through the chain.
+            Any updates made to the input dataset of a transformer will flow
+            through and affect its outputs. If you have a chain of transformed
+            datasets and you change the original dataset, the updates will flow
+            through the chain.
           </p>
 
           <p>
             You can also save a particular configuration of a transformer, and
-            reuse this custom transformer on several datasets.
+            reuse this custom transformer on several datasets. This allows you
+            to abstract over a particular computation you might want to perform
+            on your data (the way functions in Algebra are abstractions over
+            computations in arithmetic), and also enables tweaking and refining
+            your transformer using smaller test datasets, and then later
+            applying it to real-world data.{" "}
           </p>
 
           <h3>Getting Started</h3>
@@ -48,7 +54,8 @@ function AboutInfo(): ReactElement {
 
           <h3>Authors</h3>
           <p>
-            This plugin is brought to you by the{" "}
+            This plugin is brought to you by Paul Biberstein, Thomas Castleman,
+            and Jason Chen of the{" "}
             <a
               href="https://cs.brown.edu/research/plt/"
               target="_blank"
@@ -66,7 +73,7 @@ function AboutInfo(): ReactElement {
               target="_blank"
               rel="noreferrer"
             >
-              Bootstrap World
+              Bootstrap
             </a>
             .
           </p>

--- a/src/transformer-components/DataDrivenTransformer.tsx
+++ b/src/transformer-components/DataDrivenTransformer.tsx
@@ -34,9 +34,6 @@ import {
   removeInteractiveStateRequestListener,
 } from "../utils/codapPhone/listeners";
 import { InteractiveState } from "../utils/codapPhone/types";
-import Popover from "../ui-components/Popover";
-import InfoIcon from "@material-ui/icons/Info";
-import { IconButton } from "@material-ui/core";
 import { pushToUndoStack } from "../utils/codapPhone/listeners";
 import {
   TransformationOutputType,
@@ -45,6 +42,7 @@ import {
 } from "../utils/transformationDescription";
 import { displaySingleValue } from "../transformers/util";
 import { makeDatasetImmutable } from "../transformers/util";
+import TransformerInfo from "./TransformerInfo";
 
 // These types represent the configuration required for different UI elements
 interface ComponentInit {
@@ -224,6 +222,7 @@ export type DDTransformerProps = {
     summary: string;
     consumes: string;
     produces: string;
+    docLink: string;
   };
   activeTransformationsDispatch: SafeActiveTransformationsDispatch;
 };
@@ -376,44 +375,10 @@ const DataDrivenTransformer = (props: DDTransformerProps): ReactElement => {
     }
   };
 
-  /**
-   * Splits a string into several <p> tags, one for each line of text.
-   */
-  function splitIntoParagraphs(text: string): JSX.Element[] {
-    return text.split("\n").map((paragraph, i) => (
-      <>
-        <p key={i}>{paragraph}</p>
-      </>
-    ));
-  }
-
   return (
     <>
-      {/* Only render info icon if NOT a saved transformation. */}
-      {!saveData && (
-        <Popover
-          button={
-            <IconButton style={{ padding: "0" }} size="small">
-              <InfoIcon htmlColor="var(--blue-green)" fontSize="inherit" />
-            </IconButton>
-          }
-          buttonStyles={{ marginLeft: "5px", display: "inline" }}
-          tooltip={`More Info on ${base}`}
-          innerContent={
-            <>
-              <p>{splitIntoParagraphs(info.summary)}</p>
-              <p>
-                <b>Consumes: </b>
-                {splitIntoParagraphs(info.consumes)}
-              </p>
-              <p>
-                <b>Produces: </b>
-                {splitIntoParagraphs(info.produces)}
-              </p>
-            </>
-          }
-        />
-      )}
+      {/* Only render info if NOT a saved transformation. */}
+      {!saveData && <TransformerInfo {...info} transformerName={base} />}
 
       {order.map((component) => {
         if (component === "context1" || component === "context2") {

--- a/src/transformer-components/TransformerInfo.css
+++ b/src/transformer-components/TransformerInfo.css
@@ -1,0 +1,5 @@
+
+/* Space out the summary/consumes/produces/link sections */
+.transformer-info-section {
+  margin-bottom: 10px;
+}

--- a/src/transformer-components/TransformerInfo.tsx
+++ b/src/transformer-components/TransformerInfo.tsx
@@ -1,0 +1,72 @@
+import React, { ReactElement } from "react";
+import Popover from "../ui-components/Popover";
+import { IconButton } from "@material-ui/core";
+import InfoIcon from "@material-ui/icons/Info";
+import "./TransformerInfo.css";
+
+/**
+ * Splits a string into several <p> tags, one for each line of text.
+ */
+function splitIntoParagraphs(text: string): JSX.Element[] {
+  return text.split("\n").map((paragraph, i) => (
+    <>
+      <p key={i}>{paragraph}</p>
+    </>
+  ));
+}
+
+type TransformerInfoProps = {
+  transformerName: string;
+  summary: string;
+  consumes: string;
+  produces: string;
+  docLink: string;
+};
+
+/**
+ * TransformerInfo renders a popover element which contains documentation for
+ * a given transformer. This documentation is defined in transformerList.ts
+ * and consists of a summary, what the transformer consumes/produces, and a
+ * link to external standalone documentation.
+ */
+function TransformerInfo({
+  transformerName,
+  summary,
+  consumes,
+  produces,
+  docLink,
+}: TransformerInfoProps): ReactElement {
+  return (
+    <Popover
+      button={
+        <IconButton style={{ padding: "0" }} size="small">
+          <InfoIcon htmlColor="var(--blue-green)" fontSize="inherit" />
+        </IconButton>
+      }
+      buttonStyles={{ marginLeft: "5px", display: "inline" }}
+      tooltip={`More Info on ${transformerName}`}
+      innerContent={
+        <>
+          <div className="transformer-info-section">
+            {splitIntoParagraphs(summary)}
+          </div>
+          <div className="transformer-info-section">
+            <b>Consumes: </b>
+            {splitIntoParagraphs(consumes)}
+          </div>
+          <div className="transformer-info-section">
+            <b>Produces: </b>
+            {splitIntoParagraphs(produces)}
+          </div>
+          <div className="transformer-info-section">
+            <a href={docLink} target="_blank" rel="noreferrer">
+              More Info
+            </a>
+          </div>
+        </>
+      }
+    />
+  );
+}
+
+export default TransformerInfo;

--- a/src/transformer-components/transformerList.ts
+++ b/src/transformer-components/transformerList.ts
@@ -105,10 +105,22 @@ export type TransformerList = Record<
         summary: string;
         consumes: string;
         produces: string;
+        docLink: string;
       };
     };
   }
 >;
+
+/**
+ * Computes the link into the standalone documentation for a particular transformer
+ * given its heading ID in the Google doc.
+ *
+ * @param headingID The auto-generated heading ID from the Google doc
+ * @returns A link to the docs for this transformer
+ */
+function docLinkFromHeadingID(headingID: string): string {
+  return `https://docs.google.com/document/d/1NZA9gxtu6jD3M-5SQyx0tvV2N5qYKMgRm1XUwMnLgJU/edit#heading=${headingID}`;
+}
 
 const transformerList: TransformerList = {
   Partition: {
@@ -129,12 +141,14 @@ const transformerList: TransformerList = {
       },
       info: {
         summary:
-          "Splits a single dataset into multiple datasets based on the values of a given \
-        attribute. Each output dataset contains only cases that share the same distinct value \
-        of that attribute.",
+          "Creates multiple new datasets from an attribute of a single dataset. \
+          Each output dataset contains only cases that share the same distinct \
+          value of that attribute.",
         consumes:
-          "A dataset to split into multiple, and an attribute to determine how to split.",
-        produces: "One dataset per unique value of the indicated attribute.",
+          "A dataset containing an attribute with one or more unique values.",
+        produces:
+          "One new dataset per unique value of the indicated attribute.",
+        docLink: docLinkFromHeadingID("h.j1zfqypxsk9t"),
       },
     },
   },
@@ -149,10 +163,11 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: flatten },
       info: {
         summary:
-          "Takes a dataset with multiple collections and collapses \
-        it into a dataset with a single collection containing all of the attributes.",
+          "Takes a dataset with multiple collections and collapses it into a \
+          new dataset with a single collection containing all of the attributes.",
         consumes: "A dataset with many collections.",
         produces: "A dataset with a single collection.",
+        docLink: docLinkFromHeadingID("h.panq958nqlq5"),
       },
     },
   },
@@ -170,12 +185,13 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: groupBy },
       info: {
         summary:
-          "Produces a dataset that is grouped by combinations of \
-        the given attributes, by adding a new parent collection that contains \
-        copies of these attributes.",
+          "Produces a new dataset that is grouped by combinations of the given \
+          attributes, by adding a new parent collection that contains copies of \
+          these attributes.",
         consumes: "A dataset to group and a list of attributes to group by.",
         produces:
           "A copy of the input dataset whose cases are grouped by the given attributes.",
+        docLink: docLinkFromHeadingID("h.rdk3sh75yqxm"),
       },
     },
   },
@@ -199,19 +215,20 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: pivotLonger },
       info: {
         summary:
-          "Pivots a dataset to make it longer and narrower. \
-        It does this by turning indicated attribute names into values under a \
-        single attribute, and putting the values formerly under those attributes \
-        under a new attribute. A single case in the input is thus split into \
-        multiple cases (making the dataset 'longer').",
+          "Pivots a dataset, making a new one that is longer and narrower. It \
+          does this by turning indicated attribute names into values under a \
+          single attribute, and putting the values formerly under those attributes \
+          under a new attribute. A single case in the input is thus split into \
+          multiple cases (making the dataset 'longer'). This is the inverse of \
+          Pivot Wider.",
         consumes:
-          "A dataset to pivot, a list of attributes that should become \
-        values, and names for both the attribute that will contain the former \
-        attribute names ('Names To') and the attribute that will contain the \
-        values that were under those attributes ('Values To').",
+          "A dataset to pivot, a list of attributes that should become values, \
+          and names for both the attribute that will contain the former attribute \
+          names ('Names To') and the attribute that will contain the values that \
+          were under those attributes ('Values To').",
         produces:
-          "A pivoted copy of the input, usually with more cases and \
-        less attributes.",
+          "A pivoted copy of the input, usually with more cases and fewer attributes.",
+        docLink: docLinkFromHeadingID("h.3ag94ew1tob2"),
       },
     },
   },
@@ -233,17 +250,18 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: pivotWider },
       info: {
         summary:
-          "Pivots a dataset to make it shorter and wider. \
-        It does this by turning the values of an indicated attribute into \
-        attribute names, and using the values of another attribute as values \
-        for these new attributes.",
+          "Pivots a dataset, making a new one that is shorter and wider. It does \
+          this by turning the values of an indicated attribute into attribute \
+          names, and using the values of another attribute as values for these \
+          new attributes. This is the inverse of Pivot Longer.",
         consumes:
-          "A dataset to pivot, an attribute that contains values which \
-        should be turned into attribute names ('Names From'), and an attribute containing \
-        values which should be moved under the newly created attributes ('Values From').",
+          "A dataset to pivot, an attribute that contains values which should be \
+          turned into attribute names ('Names From'), and an attribute containing \
+          values which should be moved under the newly created attributes \
+          ('Values From').",
         produces:
-          "A pivoted copy of the input, usually with less cases and \
-        more attributes.",
+          "A pivoted copy of the input, usually with fewer cases and more attributes.",
+        docLink: docLinkFromHeadingID("h.g7bra3b61eoj"),
       },
     },
   },
@@ -267,22 +285,23 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: join },
       info: {
         summary:
-          "Combines two datasets into one, based on values \
-        that are shared between the datasets. The output is a copy of \
-        the base dataset, but the collection containing the base attribute also \
-        contains copies of the attributes from the collection containing the \
-        joining attribute in the joining dataset.\n\
-        The copied attributes hold values from the first case in the joining \
-        dataset whose value for the joining attribute matched the value of the \
-        base attribute (or are missing if there is no such case).",
+          "Combines two datasets into a new one, based on values that are shared \
+          between the datasets. The output is a copy of the base dataset, but the \
+          collection containing the base attribute also contains copies of the \
+          attributes from the collection containing the joining attribute in the \
+          joining dataset.\n\
+          The copied attributes hold values from the first case in the joining \
+          dataset whose value for the joining attribute matched the value of the \
+          base attribute (or are missing if there is no such case).",
         consumes:
           "Two datasets to join (one base and one joining), and an attribute \
-        from each whose shared values will determine which cases are joined to \
-        each other.",
+          from each whose shared values will determine which cases are joined to \
+          each other.",
         produces:
-          "A single dataset containing all collections/attributes from \
-        the base dataset, as well as some cases copied in from the joining dataset \
-        where the joining and base attributes matched.",
+          "A single, new dataset containing all collections/attributes from the \
+          base dataset, as well as some cases copied in from the joining dataset \
+          where the joining and base attributes matched.",
+        docLink: docLinkFromHeadingID("h.vdg3eipys2m2"),
       },
     },
   },
@@ -303,15 +322,16 @@ const transformerList: TransformerList = {
       },
       info: {
         summary:
-          "Takes two datasets that share the same attributes \
-        and produces a dataset that has all of their cases.",
+          "Takes two datasets that share the same attributes and produces a new \
+          dataset that has all of their cases.",
         consumes:
-          "Two datasets (a base and a combining dataset) that have the \
-        same attribute names.",
+          "Two datasets (a base and a combining dataset) that have the same \
+          attribute names.",
         produces:
-          "A single dataset that has the structure (in terms of how many \
-        collections and how they are organized) of the base dataset, but with \
-        all the cases of both the base and combining datasets.",
+          "A single, new dataset that has the structure (in terms of how many \
+            collections and how they are organized) of the base dataset, but \
+            with all the cases of both the base and combining datasets.",
+        docLink: docLinkFromHeadingID("h.ssd5a8j00sm7"),
       },
     },
   },
@@ -329,15 +349,16 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: count },
       info: {
         summary:
-          "Summarizes the frequency of all combinations \
-        of values of the given attributes that appear at least once in the input dataset.",
+          "Summarizes the frequency of all combinations of values of the given \
+          attributes that appear at least once in the input dataset.",
         consumes:
-          "A dataset and a list of attributes whose possible combinations \
-        within that dataset you want to count.",
+          "A dataset and a list of attributes whose possible combinations within \
+          that dataset you want to count.",
         produces:
-          "A dataset containing all combinations of values of the given \
-        attributes from the input dataset, as well as a 'Count' attribute that \
-        contains the number of occurrences of each combination of values.",
+          "A new dataset containing all combinations of values of the given \
+          attributes from the input dataset, as well as a 'Count' attribute that \
+          contains the number of occurrences of each combination of values.",
+        docLink: docLinkFromHeadingID("h.nhpqpjtaibn5"),
       },
     },
   },
@@ -366,18 +387,21 @@ const transformerList: TransformerList = {
       },
       transformerFunction: { kind: "datasetCreator", func: compare },
       info: {
-        summary: "Provides methods for comparing data within a dataset.",
+        summary:
+          "Provides ways of comparing the data from two attributes in \
+        the same dataset.",
         consumes:
-          "A dataset to compare, two attributes from within the dataset, \
-        and an indication of what kind of comparison to perform.",
+          "Two attributes to compare, the dataset they come from, and an \
+          indication of what kind of comparison to perform.",
         produces:
           "Output differs depending on the type of comparison:\n\
-        A categorical comparison produces a dataset that is grouped by the \
-        two selected attributes, and identical cases from the input datasets \
-        are merged together.\n\
-        A numeric comparison produces a dataset with four attributes: the original \
-        two attributes, their numeric difference, and a color indicating whether \
-        the difference was negative, positive, or neutral.",
+          A categorical comparison produces a dataset that is grouped by the two \
+          selected attributes, and identical cases from the input datasets are \
+          merged together.\n\
+          A numeric comparison produces a dataset with four attributes: the \
+          original two attributes, their numeric difference, and a color \
+          indicating whether the difference was negative, positive, or neutral.",
+        docLink: docLinkFromHeadingID("h.2og7klit1lga"),
       },
     },
   },
@@ -395,14 +419,14 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: runningSum },
       info: {
         summary:
-          "Produces a new dataset with an attribute added \
-        that contains the running sum of the given attribute's values across \
-        the whole dataset.",
+          "Produces a new dataset with an attribute added that contains the \
+          running sum of the given attribute's values across the whole dataset.",
         consumes:
-          "A dataset to compute the sum over, and an attribute whose values \
-        are used in the sum.",
+          "A dataset to compute the sum over, and an attribute whose values are \
+          used in the sum.",
         produces:
           "A copy of the input dataset with a running sum attribute added.",
+        docLink: docLinkFromHeadingID("h.a4c7fxsbf33r"),
       },
     },
   },
@@ -420,14 +444,15 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: runningMean },
       info: {
         summary:
-          "Produces a new dataset with an attribute added \
-        that contains the running mean of the given attribute's values across \
-        the whole dataset.",
+          "Produces a new dataset with an attribute added that contains the \
+          running mean (average) of the given attribute's values across the \
+          whole dataset.",
         consumes:
           "A dataset to compute the mean over, and an attribute whose values \
-        are used in the mean.",
+          are used in the mean.",
         produces:
           "A copy of the input dataset with a running mean attribute added.",
+        docLink: docLinkFromHeadingID("h.iijekpj8y560"),
       },
     },
   },
@@ -445,14 +470,14 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: runningMin },
       info: {
         summary:
-          "Produces a new dataset with an attribute added \
-        that contains the running minimum of the given attribute's values across \
-        the whole dataset.",
+          "Produces a new dataset with an attribute added that contains the \
+          running minimum of the given attribute's values across the whole dataset.",
         consumes:
           "A dataset to compute the minimum over, and an attribute whose values \
-        are used in the minimum.",
+          are used in the minimum.",
         produces:
           "A copy of the input dataset with a running minimum attribute added.",
+        docLink: docLinkFromHeadingID("h.xshg6r8pui6q"),
       },
     },
   },
@@ -470,14 +495,14 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: runningMax },
       info: {
         summary:
-          "Produces a new dataset with an attribute added \
-        that contains the running maximum of the given attribute's values across \
-        the whole dataset.",
+          "Produces a new dataset with an attribute added that contains the \
+          running maximum of the given attribute's values across the whole dataset.",
         consumes:
           "A dataset to compute the maximum over, and an attribute whose values \
-        are used in the maximum.",
+          are used in the maximum.",
         produces:
           "A copy of the input dataset with a running maximum attribute added.",
+        docLink: docLinkFromHeadingID("h.he4m8wbu4fly"),
       },
     },
   },
@@ -495,15 +520,15 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: difference },
       info: {
         summary:
-          "Produces a dataset with a new attribute containing \
-        the difference of each case's value of a given attribute with the case directly \
-        above it. The first case (which has no case above it) subtracts 0 from its \
-        value.",
+          "Produces a new dataset with a new attribute containing the difference \
+          of each case's value of a given attribute with the case directly above \
+          it. The first case (which has no case above it) subtracts 0 from its value.",
         consumes:
           "A dataset and an attribute whose values are used in the difference.",
         produces:
-          "A copy of the input dataset with a new attribute added that \
-        contains the differences.",
+          "A copy of the input dataset with a new attribute added that contains \
+          the differences.",
+        docLink: docLinkFromHeadingID("h.126pcwyw826a"),
       },
     },
   },
@@ -527,15 +552,16 @@ const transformerList: TransformerList = {
       },
       info: {
         summary:
-          "Identical to the Difference transformer, but allows you to \
-        choose the starting value that will be subtracted from the first case. \
-        See info for Difference for more information.",
+          "Identical to the Difference transformer, but allows you to choose the \
+          starting value that will be subtracted from the first case. See info \
+          for Difference for more information.",
         consumes:
-          "A dataset, an attribute to take the difference over, and a \
-        starting value that will be subtracted from the first case.",
+          "A dataset, an attribute to take the difference over, and a starting \
+          value that will be subtracted from the first case.",
         produces:
-          "A copy of the input dataset with a new attribute that contains \
-        the differences.",
+          "A copy of the input dataset with a new attribute that contains the \
+          differences.",
+        docLink: docLinkFromHeadingID("h.p0oj9jm9w1kb"),
       },
     },
   },
@@ -562,20 +588,21 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: genericFold },
       info: {
         summary:
-          "Produces a dataset with a new attribute that accumulates a \
-        value across all the cases in the input dataset. Given a starting value and a \
-        formula, Reduce uses the formula to calculate each value of the new \
-        attribute.\n\
-        The formula can reference a special 'accumulator' value, \
-        which holds the value that the formula evaluated to in the previous case.",
+          "Produces a new dataset with an attribute that accumulates a value \
+          across all the cases in the input dataset. Given a starting value and \
+          a formula, Reduce uses the formula to calculate each value of the new \
+          attribute.\n\
+          The formula can reference a special 'accumulator' value, which holds \
+          the value that the formula evaluated to in the previous case.",
         consumes:
           "A dataset to add the new attribute to, a name for the new attribute, \
-        a starting value for the accumulator, a name for the accumulator (so you can \
-        refer to it in the formula), and a formula for determining the values of \
-        the new attribute.",
+          a starting value for the accumulator, a name for the accumulator (so \
+            you can refer to it in the formula), and a formula for determining \
+            the values of the new attribute.",
         produces:
-          "A copy of the input dataset with a new attribute added whose \
-        values are determined by the given formula evaluated for each case.",
+          "A copy of the input dataset with a new attribute added whose values \
+          are determined by the given formula evaluated for each case.",
+        docLink: docLinkFromHeadingID("h.fug5ntifvvlp"),
       },
     },
   },
@@ -597,8 +624,8 @@ const transformerList: TransformerList = {
           This is the sum of all values under the attribute, divided by the number \
           of values.",
         consumes: "A dataset and an attribute within it to take the mean of.",
-        produces:
-          "A single number which is the mean value of the given attribute.",
+        produces: "A single number which is the mean of the given attribute.",
+        docLink: docLinkFromHeadingID("h.lmsg0diutyw"),
       },
     },
   },
@@ -617,12 +644,13 @@ const transformerList: TransformerList = {
       info: {
         summary:
           "Finds the median value of a given numeric attribute in the given \
-          dataset. This is the middle value which separates the higher half from \
-          the lower half of the dataset (when sorted). For datasets with an even \
-          number of cases, the average of the two middle values is used.",
+          dataset. This is the middle value which separates the higher half \
+          from the lower half of the dataset (when sorted). For datasets with \
+          an even number of cases, the average of the two middle values is used.",
         consumes: "A dataset and an attribute within it to find the median of.",
         produces:
           "A single number which is the median value of the given attribute.",
+        docLink: docLinkFromHeadingID("h.6awq4ztrr1w9"),
       },
     },
   },
@@ -646,6 +674,7 @@ const transformerList: TransformerList = {
           "A dataset and an attribute within it to find the mode(s) of.",
         produces:
           "A list of numbers which are the most frequently occuring in the given attribute.",
+        docLink: docLinkFromHeadingID("h.2u89jvtiita2"),
       },
     },
   },
@@ -663,12 +692,13 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: standardDeviation },
       info: {
         summary:
-          "Finds the population standard deviation of a given numeric attribute in the given \
-          dataset.",
+          "Finds the population standard deviation of a given numeric attribute \
+          in the given dataset.",
         consumes:
           "A dataset and an attribute within it to find the standard deviation of.",
         produces:
           "A single number which is the standard deviation of the given attribute.",
+        docLink: docLinkFromHeadingID("h.3lpola26n9jt"),
       },
     },
   },
@@ -686,15 +716,16 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: sumProduct },
       info: {
         summary:
-          "Calculates a sum product of the indicated attributes \
-        by multiplying the values of these attributes in each case and summing \
-        these products across the entire dataset.",
+          "Calculates a sum product of the indicated attributes by multiplying \
+          the values of these attributes in each case and summing these products \
+          across the entire dataset.",
         consumes:
-          "A dataset and a list of attributes whose values are used \
-        in the sum product.",
+          "A dataset and a list of attributes whose values are used in the sum \
+          product.",
         produces:
-          "A single number which is the sum of products of the values \
-        from the indicated attributes in the input dataset.",
+          "A single number which is the sum of products of the values from the \
+          indicated attributes in the input dataset.",
+        docLink: docLinkFromHeadingID("h.rw1dv7p08258"),
       },
     },
   },
@@ -709,10 +740,11 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: copy },
       info: {
         summary:
-          "Produces a copy of the given dataset, \
-        copying all of its collections, attributes, and cases.",
+          "Produces a copy of the given dataset, copying all of its collections, \
+          attributes, and cases.",
         consumes: "A dataset to create a copy of.",
         produces: "A copy of the input dataset.",
+        docLink: docLinkFromHeadingID("h.uq0pa7ojmqp4"),
       },
     },
   },
@@ -727,13 +759,14 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: copyStructure },
       info: {
         summary:
-          "Produces a duplicate of the structure of the \
-        given dataset, but without copying any of the cases. The output has the \
-        same collections and attributes as the input, but is empty.",
+          "Produces a duplicate of the structure of the given dataset, but \
+          without copying any of the cases. The output has the same collections \
+          and attributes as the input, but is empty.",
         consumes: "A dataset to copy the structure of.",
         produces:
           "A dataset with the same collection and attribute structure as \
         the input, but no cases.",
+        docLink: docLinkFromHeadingID("h.wuazcel945t6"),
       },
     },
   },
@@ -752,10 +785,11 @@ const transformerList: TransformerList = {
       },
       info: {
         summary:
-          "Produces an editable copy of the given dataset \
-        that does not update when the original dataset is changed.",
+          "Produces an editable copy of the given dataset that does not update \
+          when the original dataset is changed.",
         consumes: "A dataset to copy.",
         produces: "An editable copy of the input dataset.",
+        docLink: docLinkFromHeadingID("h.k8luwltbuvbd"),
       },
     },
   },
@@ -778,14 +812,13 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: filter },
       info: {
         summary:
-          "Takes a dataset and produces a copy of it that contains \
-        only the cases for which the given formula evaluates to true.",
+          "Takes a dataset and produces a copy of it that contains only the \
+          cases for which the given formula evaluates to true.",
         consumes:
-          "A dataset to filter and a formula that evaluates to either true \
-        or false.",
+          "A dataset to filter and a formula that evaluates to either true or false.",
         produces:
-          "A copy of the input dataset that only has the cases for which \
-        the formula was true.",
+          "A copy of the input dataset that only has the cases for which the formula was true.",
+        docLink: docLinkFromHeadingID("h.ycy2d7rjztiu"),
       },
     },
   },
@@ -810,17 +843,16 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: transformColumn },
       info: {
         summary:
-          "Takes an input dataset and produces a copy \
-        of it with the values of one of its attributes transformed by a given \
-        formula. Make sure to indicate what type of value you expect the formula \
-        to evaluate to.",
+          "Takes an input dataset and produces a copy of it with the values of \
+          one of its attributes transformed by a given formula. Make sure to \
+          indicate what type of value you expect the formula to evaluate to.",
         consumes:
-          "A dataset, an attribute to transform, a formula that will \
-        determine the new values of the given attribute, and the type that the \
-        formula should evaluate to.",
+          "A dataset, an attribute to transform, a formula that will determine \
+          the new values of the given attribute, and the type that the formula \
+          should evaluate to.",
         produces:
-          "A copy of the input dataset with transformed values for the \
-        given attribute.",
+          "A copy of the input dataset with transformed values for the given attribute.",
+        docLink: docLinkFromHeadingID("h.dksm7abmovmg"),
       },
     },
   },
@@ -848,17 +880,18 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: buildColumn },
       info: {
         summary:
-          "Takes an input dataset and adds a new attribute \
-        to one of the collections, whose values are determined by a formula. \
-        Make sure to indicate what type of values you expect the formula to evaluate to.",
+          "Makes a new copy of a  dataset, and adds a new attribute to one of the \
+          collections, whose values are determined by a formula. Make sure to \
+          indicate what type of values you expect the formula to evaluate to.",
         consumes:
-          "A dataset, a name for the new attribute, an existing collection \
-        to add the attribute to, a formula for the attribute's values, and \
-        an indication of the type of value the formula will evaluate to.",
+          "A dataset, a name for the new attribute, an existing collection to \
+          add the attribute to, a formula for the attribute's values, and an \
+          indication of the type of value the formula will evaluate to.",
         produces:
-          "A copy of the input dataset, with the new attribute added to \
-        the indicated collection. The values of the new attribute are determined \
-        by evaluating the formula at each case.",
+          "A copy of the input dataset, with the new attribute added to the \
+          indicated collection. The values of the new attribute are determined \
+          by evaluating the formula at each case.",
+        docLink: docLinkFromHeadingID("h.dnpc70npaxkh"),
       },
     },
   },
@@ -893,16 +926,17 @@ const transformerList: TransformerList = {
       },
       info: {
         summary:
-          "Chooses particular attributes from \
-        a dataset and leaves out others. You can choose a list of attributes that \
-        will be the only ones to appear in the output ('select only') or choose a \
-        list that should NOT appear in the output ('select all but').",
+          "Chooses particular attributes from a dataset and leaves out others. \
+          You can choose a list of attributes that will be the only ones to appear \
+          in the output ('select only') or choose a list that should NOT appear \
+          in the output ('select all but').",
         consumes:
-          "A dataset, an indication of how to use the given attribute list \
-        (the 'mode'), and a list of attributes.",
+          "A dataset, an indication of how to use the given attribute list (the \
+            'mode'), and a list of attributes.",
         produces:
           "A copy of the input dataset that contains either only the listed \
-        attributes, or all but the listed attributes.",
+          attributes, or all but the listed attributes.",
+        docLink: docLinkFromHeadingID("h.runninikk5n5"),
       },
     },
   },
@@ -932,15 +966,15 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: sort },
       info: {
         summary:
-          "Takes a dataset and orders it, using the value of a formula \
-        to determine how cases should appear in order.",
+          "Takes a dataset and orders it, using the value of a formula to \
+          determine how cases should appear in order.",
         consumes:
-          "A dataset to sort, a formula ('key expression'), an indication of \
-        the type the formula evaluates to, and a sort direction (ascending or \
-          descending).",
+          "A dataset to sort, a formula ('key expression'), an indication of the \
+          type the formula evaluates to, and a sort direction (ascending or descending).",
         produces:
-          "A copy of the input dataset, with cases sorted by the value \
-        of the key expression.",
+          "A copy of the input dataset, with cases sorted by the value of the \
+          key expression.",
+        docLink: docLinkFromHeadingID("h.9swamcujp916"),
       },
     },
   },

--- a/src/transformer-components/transformerList.ts
+++ b/src/transformer-components/transformerList.ts
@@ -52,8 +52,8 @@ export type TransformerGroup =
   | "Combining Transformers"
   | "Summarizing Transformers"
   | "Running Aggregators"
-  | "Copy Transformers"
   | "Aggregators"
+  | "Copy Transformers"
   | "Others";
 
 /**
@@ -579,67 +579,6 @@ const transformerList: TransformerList = {
       },
     },
   },
-  Copy: {
-    group: "Copy Transformers",
-    componentData: {
-      init: {
-        context1: {
-          title: "Dataset to Copy",
-        },
-      },
-      transformerFunction: { kind: "datasetCreator", func: copy },
-      info: {
-        summary:
-          "Produces a copy of the given dataset, \
-        copying all of its collections, attributes, and cases.",
-        consumes: "A dataset to create a copy of.",
-        produces: "A copy of the input dataset.",
-      },
-    },
-  },
-  "Copy Structure": {
-    group: "Copy Transformers",
-    componentData: {
-      init: {
-        context1: {
-          title: "Dataset to Copy",
-        },
-      },
-      transformerFunction: { kind: "datasetCreator", func: copyStructure },
-      info: {
-        summary:
-          "Produces a duplicate of the structure of the \
-        given dataset, but without copying any of the cases. The output has the \
-        same collections and attributes as the input, but is empty.",
-        consumes: "A dataset to copy the structure of.",
-        produces:
-          "A dataset with the same collection and attribute structure as \
-        the input, but no cases.",
-      },
-    },
-  },
-  "Editable Copy": {
-    group: "Copy Transformers",
-    componentData: {
-      init: {
-        context1: {
-          title: "Dataset to Clone",
-        },
-      },
-      transformerFunction: {
-        kind: "fullOverride",
-        createFunc: editableCopyOverride,
-        updateFunc: async () => ({}),
-      },
-      info: {
-        summary:
-          "Produces an editable copy of the given dataset \
-        that does not update when the original dataset is changed.",
-        consumes: "A dataset to copy.",
-        produces: "An editable copy of the input dataset.",
-      },
-    },
-  },
   Mean: {
     group: "Aggregators",
     componentData: {
@@ -756,6 +695,67 @@ const transformerList: TransformerList = {
         produces:
           "A single number which is the sum of products of the values \
         from the indicated attributes in the input dataset.",
+      },
+    },
+  },
+  Copy: {
+    group: "Copy Transformers",
+    componentData: {
+      init: {
+        context1: {
+          title: "Dataset to Copy",
+        },
+      },
+      transformerFunction: { kind: "datasetCreator", func: copy },
+      info: {
+        summary:
+          "Produces a copy of the given dataset, \
+        copying all of its collections, attributes, and cases.",
+        consumes: "A dataset to create a copy of.",
+        produces: "A copy of the input dataset.",
+      },
+    },
+  },
+  "Copy Structure": {
+    group: "Copy Transformers",
+    componentData: {
+      init: {
+        context1: {
+          title: "Dataset to Copy",
+        },
+      },
+      transformerFunction: { kind: "datasetCreator", func: copyStructure },
+      info: {
+        summary:
+          "Produces a duplicate of the structure of the \
+        given dataset, but without copying any of the cases. The output has the \
+        same collections and attributes as the input, but is empty.",
+        consumes: "A dataset to copy the structure of.",
+        produces:
+          "A dataset with the same collection and attribute structure as \
+        the input, but no cases.",
+      },
+    },
+  },
+  "Editable Copy": {
+    group: "Copy Transformers",
+    componentData: {
+      init: {
+        context1: {
+          title: "Dataset to Clone",
+        },
+      },
+      transformerFunction: {
+        kind: "fullOverride",
+        createFunc: editableCopyOverride,
+        updateFunc: async () => ({}),
+      },
+      info: {
+        summary:
+          "Produces an editable copy of the given dataset \
+        that does not update when the original dataset is changed.",
+        consumes: "A dataset to copy.",
+        produces: "An editable copy of the input dataset.",
       },
     },
   },


### PR DESCRIPTION
This updates the inline docs in the popovers to be consistent with the documentation found [here](https://docs.google.com/document/d/1NZA9gxtu6jD3M-5SQyx0tvV2N5qYKMgRm1XUwMnLgJU/edit#heading=h.1wp8of2gw3s4) (which was reviewed by Emmanuel & co). 

There is also now a "More Info" link which takes you to the particular part of that documentation which details the transformer you are looking at. In particular, the draw of standalone docs is that they allow for more space so there are examples with images.