### PR TITLE
Add importer button

### DIFF
--- a/src/transformer-components/TransformerREPLView.tsx
+++ b/src/transformer-components/TransformerREPLView.tsx
@@ -11,6 +11,7 @@ import { TransformerRenderer } from "./TransformerRenderer";
 import {
   getInteractiveFrame,
   notifyInteractiveFrameIsDirty,
+  createDataInteractive,
 } from "../utils/codapPhone";
 import {
   addInteractiveStateRequestListener,
@@ -121,9 +122,20 @@ function TransformerREPLView(): ReactElement {
     notifyInteractiveFrameIsDirty();
   }
 
+  function launchImporter() {
+    createDataInteractive(
+      "Google Sheets Importer",
+      "https://google-sheets-importer.netlify.app/"
+    );
+  }
+
   return (
     <div className="transformer-view">
       <AboutInfo />
+
+      <button onClick={launchImporter} style={{ marginBottom: "10px" }}>
+        Importer
+      </button>
 
       <h3>Transformer Type</h3>
 


### PR DESCRIPTION
Adds an "Importer" button that spawns the sheets importer.
![image](https://user-images.githubusercontent.com/11802391/126826256-b6ee8f2e-c522-42ad-92b0-dfaa8cd6e978.png)


On localhost CODAP the importer plugin doesn't work. I suspect it's because it's not hosted locally. Can we try and deploy this and see if this works? Then we can send the link.