### PR TITLE
Break words when wrapping error messages

### DIFF
--- a/src/ui-components/Error.css
+++ b/src/ui-components/Error.css
@@ -5,6 +5,7 @@
     padding: 6px;
     border: solid 1px red;
     border-radius: 5px;
+    overflow-wrap: break-word;
 }
 
 .Error * {


### PR DESCRIPTION
Fixes #167.

#### Before
![image](https://user-images.githubusercontent.com/11802391/127013108-43de9b0f-79d2-46a0-85a0-99326f955227.png)
#### After
![image](https://user-images.githubusercontent.com/11802391/127013157-08d31fd2-d5c1-4291-bae3-28105fb0fc2a.png)
